### PR TITLE
[QMS-5] App crashes on using the "Change Start Point" filter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+V1.XX.X
+[QMS-5] App crashes on using the "Change Start Point" filter
+
+
+
+------------------------------------------------------------------------
+---------Restart issue numbering because of migration to GitHub---------
+------------------------------------------------------------------------
 V 1.13.2
 [Issue #446] Advanced Filtering System
 [Issue #491] Skip saving of geo search

--- a/src/qmapshack/gis/trk/filter/filter.cpp
+++ b/src/qmapshack/gis/trk/filter/filter.cpp
@@ -537,6 +537,11 @@ void CGisItemTrk::filterSubPt2Pt()
 
 void CGisItemTrk::filterChangeStartPoint(qint32 idxNewStartPoint, const QString &wptName)
 {
+    if((idxNewStartPoint == 0) || (idxNewStartPoint >= cntVisiblePoints))
+    {
+        return;
+    }
+
     QVector<CTrackData::trkpt_t> pts;
     for(CTrackData::trkpt_t& pt : trk)
     {
@@ -567,12 +572,10 @@ void CGisItemTrk::filterChangeStartPoint(qint32 idxNewStartPoint, const QString 
         pts[i].time = pts[i].time.addSecs(deltaStart);    // Adjust new Start to End
     }
 
-    for (i = 0; i < idxNewStartPoint; ++i) // Reorder points
-    {
-        pts.insert(pts.size(), pts.takeAt(0));
-    }
+    const QVector<CTrackData::trkpt_t>& part1 = pts.mid(0, idxNewStartPoint);
+    const QVector<CTrackData::trkpt_t>& part2 = pts.mid(idxNewStartPoint,-1);
 
-    trk.readFrom(pts);
+    trk.readFrom(part2 + part1);
 
     deriveSecondaryData();
 


### PR DESCRIPTION
Fixes Issue #5 

Reordering seems not to work on OS X. Fixed it by splitting the track
into two parts and combining these parts in reverse order.