### PR TITLE
[QMS-12] Unify versions of all QMapShack tools

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V1.XX.X
 [QMS-5] App crashes on using the "Change Start Point" filter
-
+[QMS-12] Unify versions of all QMapShack tools
 
 
 ------------------------------------------------------------------------
@@ -146,7 +146,7 @@ V 1.11.0
 Add: QMapTool and friends as sub-project
 Add: Reverse route
 Add: BRoute binding to local address instead of all interfaces
-Add: Use track timestamp as arival time for waypoints attached to track 
+Add: Use track timestamp as arival time for waypoints attached to track
 Add: Optional overview generation to vrt builder
 Add: Add left button long press action to open menu on canvas
 Add: Framework to process and display realtime data
@@ -224,7 +224,7 @@ Add: Links to quickstart help
 Add: Russian translation
 Add: TCX file read and write support
 Add: Different cut modes for track cut function
-Add: Option for optimized build for local system architecture 
+Add: Option for optimized build for local system architecture
 Add: Support for BRouter (online/offline)
 Add: Enhance reprojection between projections like merc/utm/lcc
 [Issue #152] Garmin maps: Alter scale to detail level table
@@ -248,7 +248,7 @@ V 1.7.2
 * Add: Ctrl+W to close tabs that are not a map view
 * Add: Plot: X&Y zoom and drag graph by left mouse button
 * Add: Implement filter `Convert SubPoint to Point`
-* Add: Database: Export database to folders and GPX files 
+* Add: Database: Export database to folders and GPX files
 * Fix: Trk/Prj: Fixed missing update when changing roadbook mode. Disable copy with waypoints when no waypoints attached.
 * Fix: Prj: Fix update of project summary when changing the sorting mode
 * Fix: Trk: Fix nodata values for elevations applied by filter
@@ -296,7 +296,7 @@ V 1.6.3
 * [Issue #147] Fix bug preventing list formats to be removed
 * [Issue #148] Text editor: format of pasted text
 * [Issue #149] Properly initialize cachePath for systems without QMS configuration (new installations)
- 
+
 V 1.6.2
 * Add support kFreeBSD ports, treat like Linux.
 * Add support for GNU/Hurd, treat like Linux.
@@ -358,10 +358,10 @@ V 1.6.0
 * Add: User info to item history
 * Add: (Trk) Setup for line width and arrows
 * Add: (Trk) line coloring: local, global, automatic setup of limits
-* Add: (Trk) plot limits: local, global, automatic setup of limits 
+* Add: (Trk) plot limits: local, global, automatic setup of limits
 * Add: (Trk) colorize track by activity
 * Add: Adventures to Garmin devices. Projects are stored as adventure.
-* Add: "Archive" folder for Garmin devices. 
+* Add: "Archive" folder for Garmin devices.
 * Add: Show/hide action for projects on devices.
 * Add: Support GEMF raster maps
 * Add: Make custom waypoint symbols path configurable
@@ -472,7 +472,7 @@ V 1.3.0
 * Trk/Wpt: Make track/waypoint correlation an option if it takes too long.
 * Workspace: Add warning when loading a project twice
 * Speed up project file loading
-* Trk: Allow combining tracks for tracks on devices. 
+* Trk: Allow combining tracks for tracks on devices.
 * Trk: Allow pre-selection of several tracks for combining tracks
 * Many GUI fixes and code cleanup.
 
@@ -571,7 +571,7 @@ V 0.9.1
 V 0.9.0
 * Fix sign of area calculation
 * Mark item with user focus in item unclutter screen
-* Add support for multiple databases 
+* Add support for multiple databases
 * Add converter for QLandkarte GT to QMapShack database
 
 V 0.8.2
@@ -583,7 +583,7 @@ V 0.8.2
 
 V 0.8.1
 * Handle "no data" values in DEM files
-* Garmin maps: read copyright information 
+* Garmin maps: read copyright information
 * Save/Restore workspace on exit/start
 
 V 0.8.0

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -10,18 +10,10 @@ set(CMAKE_AUTOMOC ON)
 
 
 ###############################################################################################
-# Setup application name and version tags
+# Setup application name and defines
 ###############################################################################################
 
 STRING(TOLOWER ${PROJECT_NAME} APPLICATION_NAME)
-
-add_definitions(
-    -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
-    -DVER_MINOR=${PROJECT_VERSION_MINOR}
-    -DVER_STEP=${PROJECT_VERSION_PATCH}
-    -DVER_TWEAK=${VERSION_SUFFIX}
-    -DAPPLICATION_NAME=${PROJECT_NAME}
-)
 
 # and other funny defines -> maybe config.h is a better place for that
 add_definitions(-DROUTINO_XML_PATH=${ROUTINO_XML_PATH})
@@ -882,6 +874,14 @@ endif(APPLE)
 # Build the executable and define necessary libraries.
 ###############################################################################################
 add_executable(${APPLICATION_NAME} WIN32 ${MAININP})
+
+target_compile_definitions(${APPLICATION_NAME} PUBLIC
+    -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
+    -DVER_MINOR=${PROJECT_VERSION_MINOR}
+    -DVER_STEP=${PROJECT_VERSION_PATCH}
+    -DVER_TWEAK=${VERSION_SUFFIX}
+    -DAPPLICATION_NAME=${PROJECT_NAME}
+)
 
 if(Qt5DBus_FOUND)
     set(DBUS_LIB Qt5::DBus)

--- a/src/qmaptool/CMakeLists.txt
+++ b/src/qmaptool/CMakeLists.txt
@@ -9,21 +9,10 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
 ###############################################################################################
-# Setup application name and version tags
+# Setup application name
 ###############################################################################################
 
 set(APPLICATION_NAME qmaptool)
-set(QMAPTOOL_VERSION_MAJOR 1)
-set(QMAPTOOL_VERSION_MINOR 1)
-set(QMAPTOOL_VERSION_PATCH 1)
-
-add_definitions(
-    -DVER_MAJOR=${QMAPTOOL_VERSION_MAJOR}
-    -DVER_MINOR=${QMAPTOOL_VERSION_MINOR}
-    -DVER_STEP=${QMAPTOOL_VERSION_PATCH}
-    -DVER_TWEAK=${VERSION_SUFFIX}
-    -DAPPLICATION_NAME=${APPLICATION_NAME}
-)
 
 ###############################################################################################
 # All source files needed to compile
@@ -242,6 +231,14 @@ endif(APPLE)
 # Build the executable and define necessary libraries.
 ###############################################################################################
 add_executable(${APPLICATION_NAME} WIN32 ${MAININP})
+
+target_compile_definitions(${APPLICATION_NAME} PUBLIC
+    -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
+    -DVER_MINOR=${PROJECT_VERSION_MINOR}
+    -DVER_STEP=${PROJECT_VERSION_PATCH}
+    -DVER_TWEAK=${VERSION_SUFFIX}
+    -DAPPLICATION_NAME=${APPLICATION_NAME}
+)
 
 target_link_libraries(${APPLICATION_NAME}
     Qt5::Widgets

--- a/src/qmt_map2jnx/CMakeLists.txt
+++ b/src/qmt_map2jnx/CMakeLists.txt
@@ -1,17 +1,6 @@
 
 
 set(APPLICATION_NAME qmt_map2jnx)
-set(MAP2JNX_VERSION_MAJOR 1)
-set(MAP2JNX_VERSION_MINOR 0)
-set(MAP2JNX_VERSION_PATCH 0)
-
-add_definitions(
-    -DVER_MAJOR=${MAP2JNX_VERSION_MAJOR}
-    -DVER_MINOR=${MAP2JNX_VERSION_MINOR}
-    -DVER_STEP=${MAP2JNX_VERSION_PATCH}
-    -DVER_TWEAK=${VERSION_SUFFIX}
-    -DAPPLICATION_NAME=${APPLICATION_NAME}
-)
 
 
 #if you don't want the full compiler output, remove the following line
@@ -41,6 +30,14 @@ endif(WIN32)
 
 #list all source files here
 ADD_EXECUTABLE( ${APPLICATION_NAME} ${SRCS} ${HDRS})
+
+target_compile_definitions(${APPLICATION_NAME} PUBLIC
+    -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
+    -DVER_MINOR=${PROJECT_VERSION_MINOR}
+    -DVER_STEP=${PROJECT_VERSION_PATCH}
+    -DVER_TWEAK=${VERSION_SUFFIX}
+    -DAPPLICATION_NAME=${APPLICATION_NAME}
+)
 
 #add definitions, compiler switches, etc.
 IF(UNIX)

--- a/src/qmt_rgb2pct/CMakeLists.txt
+++ b/src/qmt_rgb2pct/CMakeLists.txt
@@ -9,21 +9,10 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
 ###############################################################################################
-# Setup application name and version tags
+# Setup application name
 ###############################################################################################
 
 set(APPLICATION_NAME qmt_rgb2pct)
-set(RGB2PCT_VERSION_MAJOR 1)
-set(RGB2PCT_VERSION_MINOR 0)
-set(RGB2PCT_VERSION_PATCH 0)
-
-add_definitions(
-    -DVER_MAJOR=${RGB2PCT_VERSION_MAJOR}
-    -DVER_MINOR=${RGB2PCT_VERSION_MINOR}
-    -DVER_STEP=${RGB2PCT_VERSION_PATCH}
-    -DVER_TWEAK=${VERSION_SUFFIX}
-    -DAPPLICATION_NAME=${APPLICATION_NAME}
-)
 
 ###############################################################################################
 # All source files needed to compile
@@ -91,6 +80,14 @@ endif(APPLE)
 # Build the executable and define necessary libraries.
 ###############################################################################################
 add_executable(${APPLICATION_NAME} WIN32 ${MAININP})
+
+target_compile_definitions(${APPLICATION_NAME} PUBLIC
+    -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
+    -DVER_MINOR=${PROJECT_VERSION_MINOR}
+    -DVER_STEP=${PROJECT_VERSION_PATCH}
+    -DVER_TWEAK=${VERSION_SUFFIX}
+    -DAPPLICATION_NAME=${APPLICATION_NAME}
+)
 
 target_link_libraries(${APPLICATION_NAME}
     Qt5::Core


### PR DESCRIPTION
Use PROJECT_VERSION_* for QMapShack and all other tools

What is the linked issue for this pull request (start with a `#`): #12 

Describe roughly what you have done:

Instead of defining the version number for each sub-project the PROJECT_VERSION_* defines are used for all sub-projects. As a result each application (QMapShack, QMapTool, qmt_map2jnx, qmt_rgb2pct) report the same version number.

What steps have to be done to perform a simple smoke test:

Open `About` menu or use the `--version` command line parameter

Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

Is every user facing string in a tr() macro?

- [ ] yes

Is the change user facing?

- [x] yes,
- [ ] no

If there are user facing changes did you add the ticket number and title into the changelog?

- [x] yes
