### PR TITLE
[QMS-13] Add support for Garmin Edge 500

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CMakeLists.txt.user

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 V1.XX.X
 [QMS-5] App crashes on using the "Change Start Point" filter
 [QMS-12] Unify versions of all QMapShack tools
-
+[QMS-13] Add support for Garmin Edge 500
 
 ------------------------------------------------------------------------
 ---------Restart issue numbering because of migration to GitHub---------

--- a/src/qmapshack/device/CDeviceGarmin.cpp
+++ b/src/qmapshack/device/CDeviceGarmin.cpp
@@ -21,6 +21,7 @@
 #include "gis/CGisListWks.h"
 #include "gis/fit/CFitProject.h"
 #include "gis/gpx/CGpxProject.h"
+#include "gis/tcx/CTcxProject.h"
 #include "gis/wpt/CGisItemWpt.h"
 
 
@@ -54,9 +55,9 @@ CDeviceGarmin::CDeviceGarmin(const QString &path, const QString &key, const QStr
     const QDomElement& xmlDevice    = dom.documentElement();
     const QDomNode& xmlModel        = xmlDevice.namedItem("Model");
 
-    id              = xmlDevice.namedItem("Id").toElement().text();
-    description     = xmlModel.namedItem("Description").toElement().text();
-    partno          = xmlModel.namedItem("PartNumber").toElement().text();
+    id              = xmlDevice.namedItem("Id").toElement().text().trimmed();
+    description     = xmlModel.namedItem("Description").toElement().text().trimmed();
+    partno          = xmlModel.namedItem("PartNumber").toElement().text().trimmed();
 
     setText(CGisListWks::eColumnName, QString("%1 (%2)").arg(description).arg(model));
     setToolTip(CGisListWks::eColumnName, QString("%1 (%2, %3)").arg(description).arg(partno).arg(model));
@@ -73,35 +74,40 @@ CDeviceGarmin::CDeviceGarmin(const QString &path, const QString &key, const QStr
         const QDomNode& xmlLocation = xmlFile.namedItem("Location");
         const QDomNode& xmlPath     = xmlLocation.namedItem("Path");
 
-        QString name = xmlName.toElement().text();
+        QString name = xmlName.toElement().text().trimmed();
+
         if(name == "GPSData")
         {
-            pathGpx = xmlPath.toElement().text();
+            pathGpx = xmlPath.toElement().text().trimmed();
         }
         else if(name == "GeotaggedPhotos")
         {
-            pathPictures = xmlPath.toElement().text();
+            pathPictures = xmlPath.toElement().text().trimmed();
         }
         else if(name == "GeocachePhotos")
         {
-            pathSpoilers = xmlPath.toElement().text();
+            pathSpoilers = xmlPath.toElement().text().trimmed();
         }
         else if(name == "FIT_TYPE_4")
         {
-            pathActivities = xmlPath.toElement().text();
+            pathActivities = xmlPath.toElement().text().trimmed();
         }
         else if(name == "FIT_TYPE_6")
         {
             // courses
-            pathCourses = xmlPath.toElement().text();
+            pathCourses = xmlPath.toElement().text().trimmed();
         }
         else if(name == "FIT_TYPE_8")
         {
-            pathLocations = xmlPath.toElement().text();
+            pathLocations = xmlPath.toElement().text().trimmed();
         }
         else if(name == "Adventures")
         {
-            pathAdventures = xmlPath.toElement().text();
+            pathAdventures = xmlPath.toElement().text().trimmed();
+        }
+        else if(name == "FitnessCourses")
+        {
+            pathTcx = xmlPath.toElement().text().trimmed();
         }
     }
 
@@ -112,6 +118,7 @@ CDeviceGarmin::CDeviceGarmin(const QString &path, const QString &key, const QStr
     qDebug() << dir.absoluteFilePath(pathCourses);
     qDebug() << dir.absoluteFilePath(pathLocations);
     qDebug() << dir.absoluteFilePath(pathAdventures);
+    qDebug() << dir.absoluteFilePath(pathTcx);
 
 
     if(!dir.exists(pathGpx))
@@ -130,10 +137,13 @@ CDeviceGarmin::CDeviceGarmin(const QString &path, const QString &key, const QStr
     {
         dir.mkpath(pathAdventures);
     }
+    if(!pathTcx.isEmpty() && !dir.exists(pathTcx))
+    {
+        dir.mkpath(pathTcx);
+    }
 
-
-    this->createProjectsFromFiles(pathGpx, "gpx");
-    this->createProjectsFromFiles(pathGpx + "/Current", "gpx");
+    createProjectsFromFiles(pathGpx, "gpx");
+    createProjectsFromFiles(pathGpx + "/Current", "gpx");
 
     QDir dirArchive(dir.absoluteFilePath(pathGpx + "/Archive"));
     if(dirArchive.exists() && (dirArchive.entryList(QStringList("*.gpx")).count() != 0))
@@ -141,9 +151,13 @@ CDeviceGarmin::CDeviceGarmin(const QString &path, const QString &key, const QStr
         archive = new CDeviceGarminArchive(dir.absoluteFilePath(pathGpx + "/Archive"), this);
     }
 
-    this->createProjectsFromFiles(pathActivities, "fit");
-    this->createProjectsFromFiles(pathCourses, "fit");
-    this->createProjectsFromFiles(pathLocations, "fit");
+    createProjectsFromFiles(pathActivities, "fit");
+    createProjectsFromFiles(pathCourses, "fit");
+    createProjectsFromFiles(pathLocations, "fit");
+    if(!pathTcx.isEmpty())
+    {
+        createProjectsFromFiles(pathTcx, "tcx");
+    }
 }
 
 void CDeviceGarmin::createProjectsFromFiles(QString subdirecoty, QString fileEnding)
@@ -162,6 +176,10 @@ void CDeviceGarmin::createProjectsFromFiles(QString subdirecoty, QString fileEnd
         if (fileEnding == "gpx")
         {
             project = new CGpxProject(filename, this);
+        }
+        if (fileEnding == "tcx")
+        {
+            project = new CTcxProject(filename, this);
         }
 
         if(!project->isValid())

--- a/src/qmapshack/device/CDeviceGarmin.h
+++ b/src/qmapshack/device/CDeviceGarmin.h
@@ -50,6 +50,7 @@ private:
     QString pathCourses       = "Garmin/Courses";
     QString pathLocations     = "Garmin/Locations";
     QString pathAdventures; // no default
+    QString pathTcx;        // no default
 
     int cntImages = 0;
 

--- a/src/qmapshack/device/CDeviceGarmin.h
+++ b/src/qmapshack/device/CDeviceGarmin.h
@@ -39,6 +39,12 @@ public:
 private:
     void createProjectsFromFiles(QString subdirecoty, QString fileEnding);
     void createAdventureFromProject(IGisProject * project, const QString &gpxFilename);
+    void insertCopyOfProjectAsGpx(IGisProject * project);
+    void insertCopyOfProjectAsTcx(IGisProject * project);
+
+    void reorderProjects(IGisProject * project);
+    QString createFileName(IGisProject * project, const QString& path, const QString &suffix);
+    QString simplifiedName(IGisProject * project);
 
     QString id;
     QString partno;

--- a/src/qmapshack/device/IDevice.cpp
+++ b/src/qmapshack/device/IDevice.cpp
@@ -309,12 +309,15 @@ void IDevice::updateProject(IGisProject * project)
 
 bool IDevice::testForExternalProject(const QString& filename)
 {
+    mount();
+
     if(QDir(filename).exists() || QFile::exists(filename))
     {
         QString msg = tr("There is another project with the same name. If you press 'ok' it will be removed and replaced.");
         int res = QMessageBox::warning(CMainWindow::getBestWidgetForParent(), getName(), msg, QMessageBox::Ok|QMessageBox::Abort, QMessageBox::Ok);
         if(res != QMessageBox::Ok)
         {
+            umount();
             return true;
         }
 
@@ -332,14 +335,15 @@ bool IDevice::testForExternalProject(const QString& filename)
         const int N = childCount();
         for(int n = 0; n < N; n++)
         {
-            QTreeWidgetItem * item = child(n);
-            if(item->text(CGisListWks::eColumnName) == fi.fileName())
+            QTreeWidgetItem * item = child(n);            
+            if(item->text(CGisListWks::eColumnName) == fi.baseName())
             {
                 delete item;
                 break;
             }
         }
     }
+    umount();
     return false;
 }
 

--- a/src/qmapshack/gis/tcx/CTcxProject.cpp
+++ b/src/qmapshack/gis/tcx/CTcxProject.cpp
@@ -31,13 +31,23 @@
 CTcxProject::CTcxProject(const QString &filename, CGisListWks * parent)
     : IGisProject(eTypeTcx, filename, parent)
 {
+    setup();
+}
+
+CTcxProject::CTcxProject(const QString &filename, IDevice * parent)
+    : IGisProject(eTypeGpx, filename, parent)
+{
+    setup();
+}
+
+void CTcxProject::setup()
+{
     setIcon(CGisListWks::eColumnIcon, QIcon("://icons/32x32/TcxProject.png"));
     blockUpdateItems(true);
     loadTcx(filename);
     blockUpdateItems(false);
     setupName(QFileInfo(filename).completeBaseName().replace("_", " "));
 }
-
 
 void CTcxProject::loadTcx(const QString& filename)
 {

--- a/src/qmapshack/gis/tcx/CTcxProject.h
+++ b/src/qmapshack/gis/tcx/CTcxProject.h
@@ -27,6 +27,7 @@ class CTcxProject : public IGisProject
     Q_DECLARE_TR_FUNCTIONS(CTcxProject)
 public:
     CTcxProject(const QString &filename, CGisListWks * parent);
+    CTcxProject(const QString &filename, IDevice * parent);
     virtual ~CTcxProject() = default;
 
     const QString getFileDialogFilter() const override
@@ -49,6 +50,7 @@ public:
     static void loadTcx(const QString &filename, CTcxProject *project);
 
 private:
+    void setup();
     void loadTcx(const QString& filename);
     void loadActivity(const QDomNode& activityRootNode);
     void loadCourse(const QDomNode& courseRootNode);

--- a/src/qmapshack/gis/tcx/CTcxProject.h
+++ b/src/qmapshack/gis/tcx/CTcxProject.h
@@ -28,6 +28,7 @@ class CTcxProject : public IGisProject
 public:
     CTcxProject(const QString &filename, CGisListWks * parent);
     CTcxProject(const QString &filename, IDevice * parent);
+    CTcxProject(const QString &filename, const IGisProject * project, IDevice * parent);
     virtual ~CTcxProject() = default;
 
     const QString getFileDialogFilter() const override


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** #13 

**Describe roughly what you have done:**
  
* Add trimmed() to all text readout as there can be leading and trailing spaces
* Decode section `FitnessCourses` and store path as TCX target path
* Read projects from TCX target path
* Detect Edge 5xx and save data as TCX
* Fix testForExternalProject() by mounting the device

**What steps have to be done to perform a simple smoke test:**

* Attach a device or a USB stick with the correct GarminDevice.xml 
* TCX files on the device should be listed
* Send a project to the device -> should be listed
* Restart QMS -> project is listed on the device
* Send project again -> project on the device is replaced.

Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

Is every user facing string in a tr() macro?

- [x] yes

Is the change user facing?

- [x] yes,
- [ ] no

If there are user facing changes did you add the ticket number and title into the changelog?

- [x] yes
