### PR TITLE
[QMS-26] Add controll classes for mount/umount and cursor override

### DIFF
--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -350,7 +350,7 @@ void CCanvas::buildHelpText()
     labelHelp->ensureCursorVisible();
 }
 
-void CCanvas::setOverrideCursor(const QCursor &cursor, const QString&)
+void CCanvas::setOverrideCursor(const QCursor &cursor, const QString& src)
 {
 //    qDebug() << "setOverrideCursor" << src;
     QApplication::setOverrideCursor(cursor);

--- a/src/qmapshack/canvas/CCanvas.h
+++ b/src/qmapshack/canvas/CCanvas.h
@@ -60,7 +60,7 @@ public:
     CCanvas(QWidget * parent, const QString& name);
     virtual ~CCanvas();
 
-    static void setOverrideCursor(const QCursor &cursor, const QString&);
+    static void setOverrideCursor(const QCursor &cursor, const QString&src);
     static void restoreOverrideCursor(const QString &src);
     static void changeOverrideCursor(const QCursor& cursor, const QString &src);
 
@@ -292,6 +292,25 @@ private:
 
     QTextBrowser * labelHelp = nullptr;
 };
+
+class CCanvasCursorLock
+{
+public:
+    CCanvasCursorLock(const QCursor &cursor, const QString& src)
+        : src(src)
+    {
+        CCanvas::setOverrideCursor(cursor, src);
+    }
+
+    ~CCanvasCursorLock()
+    {
+        CCanvas::restoreOverrideCursor(src);
+    }
+
+private:
+    const QString src;
+};
+
 
 Q_DECLARE_METATYPE(CCanvas*)
 

--- a/src/qmapshack/device/CDeviceGarmin.cpp
+++ b/src/qmapshack/device/CDeviceGarmin.cpp
@@ -256,15 +256,14 @@ void CDeviceGarmin::insertCopyOfProjectAsTcx(IGisProject * project)
         return;
     }
 
+
+    if(!tcx->save())
     {
-        CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
-        if(!tcx->save())
-        {
-            delete tcx;
-            CCanvas::restoreOverrideCursor("~CSelectProjectDialog");
-            return;
-        }
+        delete tcx;
+        CCanvas::restoreOverrideCursor("~CSelectProjectDialog");
+        return;
     }
+
 
     // move new project to top of any sub-folder/sub-device item
     reorderProjects(tcx);

--- a/src/qmapshack/device/CDeviceGarmin.cpp
+++ b/src/qmapshack/device/CDeviceGarmin.cpp
@@ -256,14 +256,15 @@ void CDeviceGarmin::insertCopyOfProjectAsTcx(IGisProject * project)
         return;
     }
 
-    CCanvas::setOverrideCursor(Qt::ArrowCursor, "CDeviceGarmin");
-    if(!tcx->save())
     {
-        delete tcx;
-        CCanvas::restoreOverrideCursor("~CSelectProjectDialog");
-        return;
+        CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
+        if(!tcx->save())
+        {
+            delete tcx;
+            CCanvas::restoreOverrideCursor("~CSelectProjectDialog");
+            return;
+        }
     }
-    CCanvas::restoreOverrideCursor("~CSelectProjectDialog");
 
     // move new project to top of any sub-folder/sub-device item
     reorderProjects(tcx);

--- a/src/qmapshack/device/CDeviceGarminArchive.cpp
+++ b/src/qmapshack/device/CDeviceGarminArchive.cpp
@@ -44,7 +44,7 @@ void CDeviceGarminArchive::slotExpanded(QTreeWidgetItem * item)
 
     QMutexLocker lock(&IGisItem::mutexItems);
     CDeviceMountLock mountLock(*this);
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CDeviceGarminArchive::slotExpanded()");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     qDebug() << "reading files from device: " << dir.path();
     QStringList entries = dir.entryList(QStringList("*.gpx"));
     for(const QString &entry : entries)
@@ -56,6 +56,5 @@ void CDeviceGarminArchive::slotExpanded(QTreeWidgetItem * item)
             delete project;
         }
     }
-    CCanvas::restoreOverrideCursor("CDeviceGarminArchive::slotExpanded()");
 }
 

--- a/src/qmapshack/device/CDeviceGarminArchive.cpp
+++ b/src/qmapshack/device/CDeviceGarminArchive.cpp
@@ -43,8 +43,8 @@ void CDeviceGarminArchive::slotExpanded(QTreeWidgetItem * item)
     setText(CGisListWks::eColumnName, tr("Archive - loaded"));
 
     QMutexLocker lock(&IGisItem::mutexItems);
+    CDeviceMountLock mountLock(*this);
     CCanvas::setOverrideCursor(Qt::WaitCursor, "CDeviceGarminArchive::slotExpanded()");
-    mount();
     qDebug() << "reading files from device: " << dir.path();
     QStringList entries = dir.entryList(QStringList("*.gpx"));
     for(const QString &entry : entries)
@@ -56,7 +56,6 @@ void CDeviceGarminArchive::slotExpanded(QTreeWidgetItem * item)
             delete project;
         }
     }
-    umount();
     CCanvas::restoreOverrideCursor("CDeviceGarminArchive::slotExpanded()");
 }
 

--- a/src/qmapshack/device/IDevice.cpp
+++ b/src/qmapshack/device/IDevice.cpp
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 **********************************************************************************************/
+#include "canvas/CCanvas.h"
 #include "CMainWindow.h"
 #include "device/CDeviceGarmin.h"
 #include "device/IDevice.h"
@@ -309,15 +310,15 @@ void IDevice::updateProject(IGisProject * project)
 
 bool IDevice::testForExternalProject(const QString& filename)
 {
-    mount();
+    CDeviceMountLock mountLock(*this);
 
     if(QDir(filename).exists() || QFile::exists(filename))
     {
+        CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
         QString msg = tr("There is another project with the same name. If you press 'ok' it will be removed and replaced.");
         int res = QMessageBox::warning(CMainWindow::getBestWidgetForParent(), getName(), msg, QMessageBox::Ok|QMessageBox::Abort, QMessageBox::Ok);
         if(res != QMessageBox::Ok)
         {
-            umount();
             return true;
         }
 
@@ -335,7 +336,7 @@ bool IDevice::testForExternalProject(const QString& filename)
         const int N = childCount();
         for(int n = 0; n < N; n++)
         {
-            QTreeWidgetItem * item = child(n);            
+            QTreeWidgetItem * item = child(n);
             if(item->text(CGisListWks::eColumnName) == fi.baseName())
             {
                 delete item;
@@ -343,7 +344,6 @@ bool IDevice::testForExternalProject(const QString& filename)
             }
         }
     }
-    umount();
     return false;
 }
 

--- a/src/qmapshack/device/IDevice.h
+++ b/src/qmapshack/device/IDevice.h
@@ -116,5 +116,24 @@ protected:
     QString key;
 };
 
+class CDeviceMountLock
+{
+public:
+    CDeviceMountLock(IDevice& device)
+        : device(device)
+    {
+        device.mount();
+    }
+
+    ~CDeviceMountLock()
+    {
+        device.umount();
+    }
+
+private:
+    IDevice& device;
+};
+
+
 #endif //IDEVICE_H
 

--- a/src/qmapshack/device/IDeviceWatcher.cpp
+++ b/src/qmapshack/device/IDeviceWatcher.cpp
@@ -47,7 +47,8 @@ void IDeviceWatcher::probeForDevice(const QString& mountPoint, const QString& pa
     qDebug() << "Probe device at" << mountPoint << path << label;
     QStringList entries = dir.entryList();
 
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "probeForDevice");
+
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     if(entries.contains("Garmin"))
     {
         if(dir.exists("Garmin/GarminDevice.xml"))
@@ -73,5 +74,4 @@ void IDeviceWatcher::probeForDevice(const QString& mountPoint, const QString& pa
     {
         qDebug() << "Don't know it :(";
     }
-    CCanvas::restoreOverrideCursor("probeForDevice");
 }

--- a/src/qmapshack/gis/CGisListDB.cpp
+++ b/src/qmapshack/gis/CGisListDB.cpp
@@ -779,9 +779,8 @@ void CGisListDB::slotDelLostFound()
         return;
     }
 
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "slotDelLostFound");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     folder->clear();
-    CCanvas::restoreOverrideCursor("slotDelLostFound");
 
     IDBFolderSql * dbfolder = folder->getDBFolder();
     if(dbfolder)
@@ -800,7 +799,7 @@ void CGisListDB::slotDelLostFoundItem()
         return;
     }
 
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "slotDelLostFoundItem");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     QSet<CDBFolderLostFound*> folders;
     QList<QTreeWidgetItem*> delItems;
     QList<QTreeWidgetItem*> items = selectedItems();
@@ -836,7 +835,6 @@ void CGisListDB::slotDelLostFoundItem()
             dbfolder->announceChange();
         }
     }
-    CCanvas::restoreOverrideCursor("slotDelLostFoundItem");
 }
 
 

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -1441,12 +1441,14 @@ void CGisListWks::slotDeleteProject()
         IGisProject * project = dynamic_cast<IGisProject*>(item);
         if(nullptr != project)
         {
-            CCanvas::setOverrideCursor(Qt::ArrowCursor, "slotDeleteProject");
-            int res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete project..."), tr("Do you really want to delete %1?").arg(project->getFilename()), QMessageBox::Ok|QMessageBox::No, QMessageBox::Ok);
-            CCanvas::restoreOverrideCursor("slotDeleteProject");
-            if(res != QMessageBox::Ok)
             {
-                continue;
+                CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
+                int res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete project..."), tr("Do you really want to delete %1?").arg(project->getFilename()), QMessageBox::Ok|QMessageBox::No, QMessageBox::Ok);
+
+                if(res != QMessageBox::Ok)
+                {
+                    continue;
+                }
             }
 
 

--- a/src/qmapshack/gis/IGisItem.cpp
+++ b/src/qmapshack/gis/IGisItem.cpp
@@ -599,7 +599,7 @@ bool IGisItem::setReadOnlyMode(bool readOnly)
 
         if(isReadOnly() && !readOnly && !doNotAsk)
         {
-            CCanvas::setOverrideCursor(Qt::ArrowCursor, "setReadOnlyMode");
+            CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
 
             QCheckBox * checkBox = new QCheckBox(tr("Never ask again."), 0);
             QString msg = tr("<h3>%1</h3> This element is probably read-only because it was not created within QMapShack. Usually you should not want to change imported data. But if you think that is ok press 'Ok'.").arg(getName());
@@ -608,7 +608,6 @@ bool IGisItem::setReadOnlyMode(bool readOnly)
             box.setCheckBox(checkBox);
             int res = box.exec();
 
-            CCanvas::restoreOverrideCursor("setReadOnlyMode");
 
             if(res != QMessageBox::Ok)
             {

--- a/src/qmapshack/gis/gpx/CGpxProject.cpp
+++ b/src/qmapshack/gis/gpx/CGpxProject.cpp
@@ -250,7 +250,8 @@ bool CGpxProject::saveAs(const QString& fn, IGisProject& project, bool strictGpx
         _fn_ += ".gpx";
     }
 
-    project.mount();
+
+    CProjectMountLock mountLock(project);
 
     // safety check for existing files
     QFile file(_fn_);
@@ -280,7 +281,6 @@ bool CGpxProject::saveAs(const QString& fn, IGisProject& project, bool strictGpx
                                            , QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
             if(res == QMessageBox::No)
             {
-                project.umount();
                 return false;
             }
         }
@@ -425,7 +425,6 @@ bool CGpxProject::saveAs(const QString& fn, IGisProject& project, bool strictGpx
         }
         res = false;
     }
-    project.umount();
     return res;
 }
 

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -1160,12 +1160,13 @@ void CDeviceGarmin::createAdventureFromProject(IGisProject * project, const QStr
     QString filename = dirAdventures.absoluteFilePath(project->getKey() + ".adv");
     QFile file(filename);
 
-    mount();
+    CDeviceMountLock mountLock(*this);
+
     file.open(QIODevice::WriteOnly);
     QTextStream out(&file);
     out.setCodec("UTF-8");
     out << "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>" << endl;
     out << doc.toString();
     file.close();
-    umount();
+
 }

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -167,28 +167,29 @@ void CDetailsPrj::slotSetupGui()
     }
     X_____________UnBlockAllSignals_____________X(this);
 
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CDetailsPrj::slotSetupGui()");
-    // Create a new document, fill it and attach it to the text browser.
-    // This is much faster than to use the current one of the text browser.
-    // According to the docs, the text browser's current document should be
-    // deleted because the text browser is it's parent.
-    QTextDocument * doc = new QTextDocument();
-    doc->setTextWidth(textDesc->size().width() - 20);
-    draw(*doc, false);
-    doc->setParent(textDesc);
-    textDesc->setDocument(doc);
-
-    QTabWidget * tabWidget = dynamic_cast<QTabWidget*>(parentWidget() ? parentWidget()->parentWidget() : nullptr);
-    if(tabWidget)
     {
-        int idx = tabWidget->indexOf(this);
-        if(idx != NOIDX)
+        CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
+        // Create a new document, fill it and attach it to the text browser.
+        // This is much faster than to use the current one of the text browser.
+        // According to the docs, the text browser's current document should be
+        // deleted because the text browser is it's parent.
+        QTextDocument * doc = new QTextDocument();
+        doc->setTextWidth(textDesc->size().width() - 20);
+        draw(*doc, false);
+        doc->setParent(textDesc);
+        textDesc->setDocument(doc);
+
+        QTabWidget * tabWidget = dynamic_cast<QTabWidget*>(parentWidget() ? parentWidget()->parentWidget() : nullptr);
+        if(tabWidget)
         {
-            setObjectName(prj.getName());
-            tabWidget->setTabText(idx, prj.getName().replace("&", "&&"));
+            int idx = tabWidget->indexOf(this);
+            if(idx != NOIDX)
+            {
+                setObjectName(prj.getName());
+                tabWidget->setTabText(idx, prj.getName().replace("&", "&&"));
+            }
         }
     }
-    CCanvas::restoreOverrideCursor("CDetailsPrj::slotSetupGui()");
     mutex.unlock();
 }
 

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -176,10 +176,10 @@ bool IGisProject::askBeforClose()
     int res = QMessageBox::Ok;
     if(isChanged())
     {
-        CCanvas::setOverrideCursor(Qt::ArrowCursor, "askBeforClose");
-
-        res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Save project?"), tr("<h3>%1</h3>The project was changed. Save before closing it?").arg(getName()), QMessageBox::Save|QMessageBox::No|QMessageBox::Abort, QMessageBox::No);
-        CCanvas::restoreOverrideCursor("askBeforClose");
+        {
+            CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
+            res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Save project?"), tr("<h3>%1</h3>The project was changed. Save before closing it?").arg(getName()), QMessageBox::Save|QMessageBox::No|QMessageBox::Abort, QMessageBox::No);
+        }
 
         if(res == QMessageBox::Save)
         {

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -969,7 +969,7 @@ void IGisProject::umount()
 
 bool IGisProject::remove()
 {
-    mount();
+    CProjectMountLock mountLock(*this);
 
     /*
        Check if parent is a device and give it a chance to take care of data.
@@ -992,7 +992,6 @@ bool IGisProject::remove()
         QDir(filename).removeRecursively();
     }
 
-    umount();
     return true;
 }
 

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -614,5 +614,23 @@ protected:
     QString hashTrkWpt[2];
 };
 
+class CProjectMountLock
+{
+public:
+    CProjectMountLock(IGisProject& project)
+        : project(project)
+    {
+        project.mount();
+    }
+
+    ~CProjectMountLock()
+    {
+        project.umount();
+    }
+
+private:
+    IGisProject& project;
+};
+
 #endif //IGISPROJECT_H
 

--- a/src/qmapshack/gis/tcx/CTcxProject.cpp
+++ b/src/qmapshack/gis/tcx/CTcxProject.cpp
@@ -16,6 +16,7 @@
 
 **********************************************************************************************/
 
+#include "canvas/CCanvas.h"
 #include "CMainWindow.h"
 #include "device/IDevice.h"
 #include "gis/CGisListWks.h"
@@ -309,6 +310,7 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
 
         if (!createdByQMS)
         {
+            CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
             int res = QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("File exists ...")
                                            , tr("The file exists and it has not been created by QMapShack. "
                                                 "If you press 'yes' all data in this file will be lost. "
@@ -347,6 +349,7 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
         {
             if (!trkItem->isTrkTimeValid())
             {
+                CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
                 int res = QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Track with invalid timestamps...")
                                                , tr("The track <b>%1</b> you have selected contains trackpoints with "
                                                     "invalid timestamps. "
@@ -385,7 +388,10 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
                 }
                 else if (!tcx->trackTypes.contains(trkItem->getKey().item))   // if this is an added track
                 {
-                    courseOrActivityMsgBox.exec();
+                    {
+                        CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
+                        courseOrActivityMsgBox.exec();
+                    }
 
                     if (courseOrActivityMsgBox.clickedButton() == pButtonCourse)
                     {
@@ -415,7 +421,10 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
             }
             else // not a TCX project, then it is necessary to ask for each track
             {
-                courseOrActivityMsgBox.exec();
+                {
+                    CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
+                    courseOrActivityMsgBox.exec();
+                }
 
                 if (courseOrActivityMsgBox.clickedButton() == pButtonCourse)
                 {
@@ -472,6 +481,7 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
         msg = tr("Failed to create file '%1'").arg(_fn_);
         if (QThread::currentThread() == qApp->thread())
         {
+            CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
             QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Saving GIS data failed..."), msg, QMessageBox::Abort);
         }
         else
@@ -490,6 +500,7 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
     {
         if (QThread::currentThread() == qApp->thread())
         {
+            CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
             msg = tr("Failed to write file '%1'").arg(_fn_);
             QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Saving GIS data failed..."), msg, QMessageBox::Abort);
         }

--- a/src/qmapshack/gis/tcx/CTcxProject.cpp
+++ b/src/qmapshack/gis/tcx/CTcxProject.cpp
@@ -285,7 +285,8 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
         _fn_ += ".tcx";
     }
 
-    project.mount();
+
+    CProjectMountLock mountLock(project);
 
     // safety check for existing files
     QFile file(_fn_);
@@ -318,7 +319,6 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
                                            , QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
             if (res == QMessageBox::No)
             {
-                project.umount();
                 return false;
             }
         }
@@ -499,7 +499,6 @@ bool CTcxProject::saveAs(const QString& fn, IGisProject& project)
         }
         res = false;
     }
-    project.umount();
     return res;
 }
 

--- a/src/qmapshack/gis/tnv/CTwoNavProject.cpp
+++ b/src/qmapshack/gis/tnv/CTwoNavProject.cpp
@@ -76,7 +76,7 @@ CTwoNavProject::~CTwoNavProject()
 bool CTwoNavProject::save()
 {
     bool res = true;
-    mount();
+    CProjectMountLock mountLock(*this);
     QDir().mkpath(filename);
     QDir dir(filename);
 
@@ -150,7 +150,6 @@ bool CTwoNavProject::save()
     {
         markAsSaved();
     }
-    umount();
     return res;
 }
 

--- a/src/qmapshack/gis/trk/CDetailsTrk.cpp
+++ b/src/qmapshack/gis/trk/CDetailsTrk.cpp
@@ -374,7 +374,7 @@ void CDetailsTrk::updateData()
     {
         return;
     }
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CDetailsTrk::updateData");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     originator = true;
 
     bool isReadOnly = trk.isReadOnly();
@@ -533,7 +533,6 @@ void CDetailsTrk::updateData()
 
     enableTabFilter();
     originator = false;
-    CCanvas::restoreOverrideCursor("CDetailsTrk::updateData");
 }
 
 void CDetailsTrk::setMouseFocus(const CTrackData::trkpt_t * pt)

--- a/src/qmapshack/gis/trk/filter/CFilterChangeStartPoint.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterChangeStartPoint.cpp
@@ -32,12 +32,10 @@ CFilterChangeStartPoint::CFilterChangeStartPoint(CGisItemTrk &trk, QWidget *pare
 
 void CFilterChangeStartPoint::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "filterChangeStartPoint");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
 
     trk.filterChangeStartPoint(comboBox->currentData().toInt(), comboBox->currentText());
     updateUi();
-
-    CCanvas::restoreOverrideCursor("filterChangeStartPoint");
 }
 
 void CFilterChangeStartPoint::updateUi()

--- a/src/qmapshack/gis/trk/filter/CFilterDelete.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterDelete.cpp
@@ -31,7 +31,6 @@ CFilterDelete::CFilterDelete(CGisItemTrk &trk, QWidget *parent)
 
 void CFilterDelete::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterDelete");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterDelete();
-    CCanvas::restoreOverrideCursor("CFilterDelete");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterDeleteExtension.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterDeleteExtension.cpp
@@ -60,11 +60,9 @@ void CFilterDeleteExtension::updateUi()
 
 void CFilterDeleteExtension::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterDeleteExtension");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
 
     int idx = comboExtensions->currentIndex();
     trk.filterDeleteExtension(comboExtensions->itemData(idx).toString());
-
-    CCanvas::restoreOverrideCursor("CFilterDeleteExtension");
 }
 

--- a/src/qmapshack/gis/trk/filter/CFilterDouglasPeuker.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterDouglasPeuker.cpp
@@ -46,7 +46,6 @@ CFilterDouglasPeuker::~CFilterDouglasPeuker()
 
 void CFilterDouglasPeuker::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterDouglasPeuker");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterReducePoints(spinBox->value()/IUnit::self().basefactor);
-    CCanvas::restoreOverrideCursor("CFilterDouglasPeuker");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterInterpolateElevation.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterInterpolateElevation.cpp
@@ -52,15 +52,14 @@ CFilterInterpolateElevation::~CFilterInterpolateElevation()
 
 void CFilterInterpolateElevation::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterInterpolateElevation");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterInterpolateElevation();
     checkPreview->setChecked(trk.isInterpolationEnabled());
-    CCanvas::restoreOverrideCursor("CFilterInterpolateElevation");
 }
 
 void CFilterInterpolateElevation::slotPreview()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterInterpolateElevation::slotPreview()");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     bool yes = checkPreview->isChecked();
     qint32 Q = comboQuality->currentData().toInt();
     trk.setupInterpolation(yes, Q);
@@ -68,5 +67,4 @@ void CFilterInterpolateElevation::slotPreview()
     yes = trk.isInterpolationEnabled();
     checkPreview->setChecked(yes);
     toolApply->setEnabled(yes);
-    CCanvas::restoreOverrideCursor("CFilterInterpolateElevation::slotPreview()");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterInvalid.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterInvalid.cpp
@@ -32,7 +32,6 @@ CFilterInvalid::CFilterInvalid(CGisItemTrk &trk, QWidget *parent)
 
 void CFilterInvalid::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterInvalid");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterRemoveInvalidPoints();
-    CCanvas::restoreOverrideCursor("CFilterInvalid");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterLoopsCut.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterLoopsCut.cpp
@@ -47,9 +47,8 @@ CFilterLoopsCut::~CFilterLoopsCut()
 
 void CFilterLoopsCut::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterLoopsCut");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterLoopsCut(spinBox->value()/IUnit::self().basefactor);
-    CCanvas::restoreOverrideCursor("CFilterLoopsCut");
 }
 
 void CFilterLoopsCut::showHelp()

--- a/src/qmapshack/gis/trk/filter/CFilterMedian.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterMedian.cpp
@@ -42,7 +42,6 @@ CFilterMedian::~CFilterMedian()
 
 void CFilterMedian::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterMedian");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterSmoothProfile(spinBox->value());
-    CCanvas::restoreOverrideCursor("CFilterMedian");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterNewDate.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterNewDate.cpp
@@ -34,8 +34,7 @@ CFilterNewDate::CFilterNewDate(CGisItemTrk &trk, QWidget *parent)
 
 void CFilterNewDate::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterNewDate");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterNewDate(dateTimeEdit->dateTime().toUTC());
-    CCanvas::restoreOverrideCursor("CFilterNewDate");
 }
 

--- a/src/qmapshack/gis/trk/filter/CFilterObscureDate.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterObscureDate.cpp
@@ -41,8 +41,7 @@ CFilterObscureDate::~CFilterObscureDate()
 
 void CFilterObscureDate::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterObscureDate");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterObscureDate(spinBox->value());
-    CCanvas::restoreOverrideCursor("CFilterObscureDate");
 }
 

--- a/src/qmapshack/gis/trk/filter/CFilterOffsetElevation.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterOffsetElevation.cpp
@@ -44,7 +44,6 @@ CFilterOffsetElevation::~CFilterOffsetElevation()
 
 void CFilterOffsetElevation::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterOffsetElevation");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterOffsetElevation(spinBox->value()/IUnit::self().basefactor);
-    CCanvas::restoreOverrideCursor("CFilterOffsetElevation");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterReplaceElevation.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterReplaceElevation.cpp
@@ -34,14 +34,13 @@ CFilterReplaceElevation::CFilterReplaceElevation(CGisItemTrk &trk, QWidget *pare
 
 void CFilterReplaceElevation::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterReplaceElevation");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
 
     CCanvas * canvas = comboView->currentData().value<CCanvas*>();
     if(canvas != nullptr)
     {
         trk.filterReplaceElevation(canvas);
     }
-    CCanvas::restoreOverrideCursor("CFilterReplaceElevation");
 }
 
 

--- a/src/qmapshack/gis/trk/filter/CFilterReset.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterReset.cpp
@@ -32,7 +32,6 @@ CFilterReset::CFilterReset(CGisItemTrk &trk, QWidget *parent)
 
 void CFilterReset::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterReset");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterReset();
-    CCanvas::restoreOverrideCursor("CFilterReset");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterSpeed.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterSpeed.cpp
@@ -86,7 +86,7 @@ CFilterSpeed::~CFilterSpeed()
 
 void CFilterSpeed::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterSpeed");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
 
     switch (comboActivityType->currentIndex())
     {
@@ -109,8 +109,6 @@ void CFilterSpeed::slotApply()
     default:
         break;
     }
-
-    CCanvas::restoreOverrideCursor("CFilterSpeed");
 }
 
 void CFilterSpeed::slotSetActivityType(int type)

--- a/src/qmapshack/gis/trk/filter/CFilterSplitSegment.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterSplitSegment.cpp
@@ -32,7 +32,6 @@ CFilterSplitSegment::CFilterSplitSegment(CGisItemTrk &trk, QWidget *parent)
 
 void CFilterSplitSegment::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterSplitSegment");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterSplitSegment();
-    CCanvas::restoreOverrideCursor("CFilterSplitSegment");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterSubPt2Pt.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterSubPt2Pt.cpp
@@ -32,7 +32,6 @@ CFilterSubPt2Pt::CFilterSubPt2Pt(CGisItemTrk &trk, QWidget *parent)
 
 void CFilterSubPt2Pt::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterSubPt2Pt");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterSubPt2Pt();
-    CCanvas::restoreOverrideCursor("CFilterSubPt2Pt");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterTerrainSlope.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterTerrainSlope.cpp
@@ -31,7 +31,6 @@ CFilterTerrainSlope::CFilterTerrainSlope(CGisItemTrk &trk, QWidget *parent)
 
 void CFilterTerrainSlope::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "CFilterTerrainSlope");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterTerrainSlope();
-    CCanvas::restoreOverrideCursor("CFilterTerrainSlope");
 }

--- a/src/qmapshack/gis/trk/filter/CFilterZeroSpeedDriftCleaner.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterZeroSpeedDriftCleaner.cpp
@@ -49,9 +49,8 @@ CFilterZeroSpeedDriftCleaner::~CFilterZeroSpeedDriftCleaner()
 
 void CFilterZeroSpeedDriftCleaner::slotApply()
 {
-    CCanvas::setOverrideCursor(Qt::WaitCursor, "FilterZeroSpeedDriftCleaner");
+    CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     trk.filterZeroSpeedDriftCleaner(distance->value()/IUnit::self().basefactor, ratio->value());
-    CCanvas::restoreOverrideCursor("CFilterZeroSpeedDriftCleaner");
 }
 
 void CFilterZeroSpeedDriftCleaner::showHelp()

--- a/src/qmapshack/mouse/line/ILineOp.cpp
+++ b/src/qmapshack/mouse/line/ILineOp.cpp
@@ -234,7 +234,7 @@ void ILineOp::finalizeOperation(qint32 idx)
 
     if(parentHandler->useAutoRouting())
     {
-        CCanvas::setOverrideCursor(Qt::WaitCursor, "ILineOp::finalizeOperation");
+        CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
         if(idx > 0)
         {
             tryRouting(points[idx - 1], points[idx]);
@@ -243,7 +243,6 @@ void ILineOp::finalizeOperation(qint32 idx)
         {
             tryRouting(points[idx], points[idx + 1]);
         }
-        CCanvas::restoreOverrideCursor("ILineOp::finalizeOperation");
     }
     else if(parentHandler->useVectorRouting() || parentHandler->useTrackRouting())
     {


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** #26 

**Describe roughly what you have done:**

I added `CDeviceMountLock` and `CProjectMountLock` to safely a mounted partition on loosing focus.

I added `CCanvasCursorLock` to safely restore an overridden cursor when loosing focus.

**What steps have to be done to perform a simple smoke test:**

There should be any change in the behavior of QMapShack unless I broke something :)

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [ ] yes,
- [x] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [ ] yes
