### PR TITLE
[QMS-20] Windows Start Menu - link to github

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-12] Unify versions of all QMapShack tools
 [QMS-13] Add support for Garmin Edge 500
 [QMS-31] Fix all links to Bitbucket in the code
+[QMS-20] Windows Start Menu - change links from bitbucket to github
 
 ------------------------------------------------------------------------
 ---------Restart issue numbering because of migration to GitHub---------

--- a/msvc_64/QMapShack_Installer.nsi
+++ b/msvc_64/QMapShack_Installer.nsi
@@ -23,6 +23,7 @@
 ;  Note: the command line parameter "--style fusion" for qmapshack.exe switches to a GUI appearance which is perceived as less antique than the default
 ;  See https://doc.qt.io/qt-5/qstyle.html https://doc.qt.io/qt-5/qstylefactory.html https://forum.qt.io/topic/23978/qfusionstyle https://forum.qt.io/topic/23978/qfusionstyle)
 ; 08-Apr-2019 Adapt to use of PROJ4 version 6.0
+; 27-Sep-2019 Adapt start menue links from bitbucket to github
 
 ;=================== BEGIN SCRIPT ====================
 ; Include for nice Setup UI, see http://nsis.sourceforge.net/Docs/Modern%20UI%202/Readme.html
@@ -276,8 +277,8 @@ Section "StartMenue" StartMenue
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\QMapShack.lnk" "$INSTDIR\qmapshack.exe" "--style fusion" "$INSTDIR\QMapShack.ico"
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\QMapTool.lnk" "$INSTDIR\qmaptool.exe" "--style fusion" "$INSTDIR\QMapTool.ico"
-    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\qmapshack.org.lnk" "https://bitbucket.org/maproom/qmapshack/wiki/Home" "" "$INSTDIR\kfm_home.ico"
-    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Help.lnk" "https://bitbucket.org/maproom/qmapshack/wiki/DocMain" "" "$INSTDIR\Help.ico"
+    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\qmapshack.org.lnk" "https://github.com/Maproom/qmapshack/wiki" "" "$INSTDIR\kfm_home.ico"
+    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Help.lnk" "https://github.com/Maproom/qmapshack/wiki/DocMain" "" "$INSTDIR\Help.ico"
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\gdal.org.lnk" "http://www.gdal.org/" "" "$INSTDIR\gdalicon.ico"
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\GDAL shell.lnk" %COMSPEC% "/k $\"$INSTDIR\gdal_shell.bat$\"" "" "" "" "" "GDAL shell"
    !insertmacro MUI_STARTMENU_WRITE_END


### PR DESCRIPTION
The links for the 2 start menu entries
- Help
- qmapshack.org
now point to the new location at github

**What is the linked issue for this pull request (start with a `#`):** #20

**Describe roughly what you have done:**

Link targets in the Windows start menu which previously pointing to 
bitbucket now point to the respective github locations.

**What steps have to be done to perform a simple smoke test:**

1. Create a Windows Installer created with the updated QMapShack_Installer.nsi
2. Run the Windows installer
3. Verify that the QMapstack start menu entries "Help" and "qmapshack.org" now direct to pages on github 

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] N/A for the installer script

**Is every user facing string in a tr() macro?**

- [X] yes

**Is the change user facing?**

- [X] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [X] yes
