### PR TITLE
[QMS-31] Replace links into Bitbucket Wiki

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-5] App crashes on using the "Change Start Point" filter
 [QMS-12] Unify versions of all QMapShack tools
 [QMS-13] Add support for Garmin Edge 500
+[QMS-31] Fix all links to Bitbucket in the code
 
 ------------------------------------------------------------------------
 ---------Restart issue numbering because of migration to GitHub---------

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -928,7 +928,7 @@ void CMainWindow::slotAbout()
 
 void CMainWindow::slotHelp()
 {
-    QDesktopServices::openUrl(QUrl("https://bitbucket.org/maproom/qmapshack/wiki/DocMain"));
+    QDesktopServices::openUrl(QUrl("https://github.com/Maproom/qmapshack/wiki/DocMain"));
 }
 
 void CMainWindow::slotQuickstart()
@@ -940,24 +940,24 @@ void CMainWindow::slotQuickstart()
         locale = locale.left(2).toLower();
         if(locale == "de")
         {
-            QDesktopServices::openUrl(QUrl("https://bitbucket.org/maproom/qmapshack/wiki/DocQuickStartGerman"));
+            QDesktopServices::openUrl(QUrl("https://github.com/Maproom/qmapshack/wiki/DocQuickStartGerman"));
         }
         else if(locale == "ru")
         {
-            QDesktopServices::openUrl(QUrl("https://bitbucket.org/maproom/qmapshack/wiki/DocQuickStartRussian"));
+            QDesktopServices::openUrl(QUrl("https://github.com/Maproom/qmapshack/wiki/DocQuickStartRussian"));
         }
         else if(locale == "es")
         {
-            QDesktopServices::openUrl(QUrl("https://bitbucket.org/maproom/qmapshack/wiki/DocQuickStartSpanish"));
+            QDesktopServices::openUrl(QUrl("https://github.com/Maproom/qmapshack/wiki/DocQuickStartSpanish"));
         }
         else
         {
-            QDesktopServices::openUrl(QUrl("https://bitbucket.org/maproom/qmapshack/wiki/DocQuickStartEnglish"));
+            QDesktopServices::openUrl(QUrl("https://github.com/Maproom/qmapshack/wiki/DocQuickStartEnglish"));
         }
     }
     else
     {
-        QDesktopServices::openUrl(QUrl("https://bitbucket.org/maproom/qmapshack/wiki/DocQuickStartEnglish"));
+        QDesktopServices::openUrl(QUrl("https://github.com/Maproom/qmapshack/wiki/DocQuickStartEnglish"));
     }
 }
 

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -267,10 +267,10 @@ void CCanvas::buildHelpText()
                                     "<p>Patient Users:<p>"
                                     "<ul>"
                                     "<li><a href='ShowQuickStart'>Quick Start Guide.</a></li>"
-                                    "<li><a href='https://bitbucket.org/maproom/qmapshack/wiki/DocGettingStarted#markdown-header-add-maps'>Getting Started.</a></li>"
-                                    "<li><a href='https://bitbucket.org/maproom/qmapshack/wiki/DocInstallMapDem'>Install Maps & DEM</a></li>"
-                                    "<li><a href='https://bitbucket.org/maproom/qmapshack/wiki/DocBasicsMapDem'>Basics Maps & DEM.</a></li>"
-                                    "<li><a href='https://bitbucket.org/maproom/qmapshack/wiki/DocMapDemSources'>Sources for Maps</a></li>"
+                                    "<li><a href='https://github.com/Maproom/qmapshack/wiki/DocGettingStarted#markdown-header-add-maps'>Getting Started.</a></li>"
+                                    "<li><a href='https://github.com/Maproom/qmapshack/wiki/DocInstallMapDem'>Install Maps & DEM</a></li>"
+                                    "<li><a href='https://github.com/Maproom/qmapshack/wiki/DocBasicsMapDem'>Basics Maps & DEM.</a></li>"
+                                    "<li><a href='https://github.com/Maproom/qmapshack/wiki/DocMapDemSources'>Sources for Maps</a></li>"
                                     "</ul>"
                                     );
 
@@ -292,8 +292,8 @@ void CCanvas::buildHelpText()
 
     const QString msgDataLinks = tr("<h2>&nbsp;</h2>"
                                     "<ul>"
-                                    "<li><a href='https://bitbucket.org/maproom/qmapshack/wiki/DocGisDatabase'>Databases</a></li>"
-                                    "<li><a href='https://bitbucket.org/maproom/qmapshack/wiki/AdvProjects'>Databases & Projects</a></li>"
+                                    "<li><a href='https://github.com/Maproom/qmapshack/wiki/DocGisDatabase'>Databases</a></li>"
+                                    "<li><a href='https://github.com/Maproom/qmapshack/wiki/AdvProjects'>Databases & Projects</a></li>"
                                     "</ul>"
                                     );
 
@@ -312,7 +312,7 @@ void CCanvas::buildHelpText()
                                     "</ul>"
                                     "<p>Patient Users:<p>"
                                     "<ul>"
-                                    "<li><a href='https://bitbucket.org/maproom/qmapshack/wiki/DocMapDemSources'>Sources for DEM</a></li>"
+                                    "<li><a href='https://github.com/Maproom/qmapshack/wiki/DocMapDemSources'>Sources for DEM</a></li>"
                                     "</ul>"
                                     );
 

--- a/src/qmapshack/gis/db/CSetupDatabase.cpp
+++ b/src/qmapshack/gis/db/CSetupDatabase.cpp
@@ -45,7 +45,7 @@ CSetupDatabase::CSetupDatabase(CGisListDB &parent)
         gridLayout->removeWidget(frameMysql);
 
         QString errorTitle = tr("Missing Requirement");
-        QString errorText  = tr("MySQL cannot be used at this point, because the corresponding driver (QMYSQL) is not available.<br />Please make sure you have installed the corresponding package.<br />If you don't know what to do now you should have <a href=\"%1\">a look at the wiki</a>.").arg("https://bitbucket.org/maproom/qmapshack/wiki/DocGisDatabaseAddRemove#markdown-header-mysql-565");
+        QString errorText  = tr("MySQL cannot be used at this point, because the corresponding driver (QMYSQL) is not available.<br />Please make sure you have installed the corresponding package.<br />If you don't know what to do now you should have <a href=\"%1\">a look at the wiki</a>.").arg("https://github.com/Maproom/qmapshack/wiki/DocGisDatabaseAddRemove#mysql--565");
 
         QLabel *errorMissingMySQL = new QLabel(QString("<b>%1</b><br /><br />%2").arg(errorTitle).arg(errorText));
         errorMissingMySQL->setOpenExternalLinks(true);


### PR DESCRIPTION
Replaced all links with links into the GitHub Wiki

**What is the linked issue for this pull request (start with a `#`):** QMS-#31

**Describe roughly what you have done:**

Simply replaced all links to Bitbucket pages via search and replace.

**What steps have to be done to perform a simple smoke test:**

* Tested links in the `About` menu
* Tested links in the first start page

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
