### PR TITLE
[QMS-8] Incorrect elevation for fit files from GPSMAP 66s

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-5] App crashes on using the "Change Start Point" filter
+[QMS-8] Incorrect elevation for fit files from GPSMAP 66s
 [QMS-12] Unify versions of all QMapShack tools
 [QMS-13] Add support for Garmin Edge 500
 [QMS-31] Fix all links to Bitbucket in the code

--- a/src/qmapshack/gis/fit/decoder/CFitMessage.cpp
+++ b/src/qmapshack/gis/fit/decoder/CFitMessage.cpp
@@ -84,7 +84,10 @@ void CFitMessage::addField(CFitField &  field)
         {
             qCritical("fit field %d already added to map.", (int) field.getFieldDefNr());
         }
-        fields.insert(field.getFieldDefNr(), field);
+        else
+        {
+            fields.insert(field.getFieldDefNr(), field);
+        }
     }
     if (field.profile().getFieldType() == eFieldTypeDevelopment)
     {
@@ -92,7 +95,10 @@ void CFitMessage::addField(CFitField &  field)
         {
             qCritical("fit dev field %d already added to map.", (int) field.getFieldDefNr());
         }
-        devFields.insert(field.getFieldDefNr(), field);
+        else
+        {
+            devFields.insert(field.getFieldDefNr(), field);
+        }
     }
 }
 

--- a/src/qmapshack/gis/fit/defs/fit_const.h
+++ b/src/qmapshack/gis/fit/defs/fit_const.h
@@ -26,7 +26,7 @@
  * 1: prints fit messages and definitions after finishing decoding
  * 2: 1 + prints fit messages and definitions during decoding (just after finishing one)
  */
-#define FITDEBUGLVL 1
+#define FITDEBUGLVL 0
 
 #define FITDEBUG(level, cmd) if(FITDEBUGLVL >= level) { cmd; }
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** #8

**Describe roughly what you have done:**

Couldn't really determine the root cause. However the fields
`eRecordEnhancedSpeed` and `eRecordEnhancedAltitude`
seemed to be decoded twice in each trackpoint record. Can't tell if
this is a bug in QMS or the device. Anyway, if the code ignores the
second set everything seems to be fine.

**What steps have to be done to perform a simple smoke test:**

The example file from the ticket loads well.

[2019-09-06 18-00-09.fit.gz](https://github.com/Maproom/qmapshack/files/3672794/2019-09-06.18-00-09.fit.gz)

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
