### PR TITLE
[QMS-35] Display of predicted walking time

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-35] Add nominal walking time to track info
 [QMS-27] Error in workspace search for attributes
 [QMS-18] Improved explanation of 'Date equals'
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/trk/CActivityTrk.h
+++ b/src/qmapshack/gis/trk/CActivityTrk.h
@@ -181,7 +181,9 @@ public:
         return activityRanges;
     }
 
-
+    const summary_t getSummary(trkact_t act) const{
+        return activitySummary.value(act);
+    }
 private:
     friend class CGisItemTrk;
     CActivityTrk(CGisItemTrk * trk);

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -538,6 +538,15 @@ QString CGisItemTrk::getInfo(quint32 feature) const
         str += "<br />";
     }
 
+    //nominal walking time according to DIN 33466
+    CActivityTrk::summary_t walking = activities.getSummary(CTrackData::trkpt_t::eAct20Foot);
+    qreal elevationTime = walking.ascent/300 * 3600 + walking.descent/500 * 3600;
+    qreal distanceTime = walking.distance/4000 * 3600;
+    qreal nominalTime = qMax(elevationTime, distanceTime) + 0.5 * qMin(elevationTime, distanceTime);
+    IUnit::self().seconds2time(nominalTime, val1, unit1);
+    str += tr("Est. Walk. Time: %1%2").arg(val1).arg(unit1);
+
+    str += "<br/>";
     str += "<br/>";
 
     if(timeIsValid && timeStart.isValid())


### PR DESCRIPTION
Added walking time according to DIN 33466

**What is the linked issue for this pull request (start with a `#`):** #35

**Describe roughly what you have done:**

I added the walking time to the getInfo method. It is only calculated when elevation data is present and the activity is foot.

**What steps have to be done to perform a simple smoke test:**

1. Open any project with tracks with the activity set to foot
2. Open description or double click track

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
