### PR TITLE
[QMS-6] Enhance overview detection for VRT maps

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,13 +1,14 @@
 V1.XX.X
-[QMS-27] Error in workspace search for attributes
-[QMS-18] Improved explanation of 'Date equals'
 [QMS-5] App crashes on using the "Change Start Point" filter
+[QMS-6] Enhance overview detection for VRT maps
 [QMS-8] Incorrect elevation for fit files from GPSMAP 66s
 [QMS-12] Unify versions of all QMapShack tools
 [QMS-13] Add support for Garmin Edge 500
-[QMS-31] Fix all links to Bitbucket in the code
+[QMS-18] Improved explanation of 'Date equals'
 [QMS-19] Invalid GPX due to `::` in `ql` namespace
 [QMS-20] Windows Start Menu - change links from bitbucket to github
+[QMS-27] Error in workspace search for attributes
+[QMS-31] Fix all links to Bitbucket in the code
 
 ------------------------------------------------------------------------
 ---------Restart issue numbering because of migration to GitHub---------

--- a/src/qmapshack/map/CMapVRT.h
+++ b/src/qmapshack/map/CMapVRT.h
@@ -34,9 +34,13 @@ public:
 
     void draw(IDrawContext::buffer_t& buf) override;
 
-
-
 private:
+    /**
+       @brief Test subfiles of VRT for overviews
+       @param filename The VRT filename to inspect
+       @return Return true if all subfiles have overviews.
+     */
+    bool testForOverviews(const QString& filename);
     QString filename;
     /// instance of GDAL dataset
     GDALDataset * dataset;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS #6

**Describe roughly what you have done:**

Search submaps of a VRT. If all contain overviews set the overview
flag. If one of them does not contain overviews the complete map is
assumed to have no overviews.

**What steps have to be done to perform a simple smoke test:**

* Open a VRT map with more than one submap. Each submap must contain overviews. 
* The debug output should read `has overviews true`
* The map should be displayed over all zoom levels.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
