### PR TITLE
[QMS-19] Invalid GPX due to `::` in `ql` namespace

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-12] Unify versions of all QMapShack tools
 [QMS-13] Add support for Garmin Edge 500
 [QMS-31] Fix all links to Bitbucket in the code
+[QMS-19] Invalid GPX due to `::` in `ql` namespace
 [QMS-20] Windows Start Menu - change links from bitbucket to github
 
 ------------------------------------------------------------------------

--- a/src/qmapshack/gis/trk/CKnownExtension.cpp
+++ b/src/qmapshack/gis/trk/CKnownExtension.cpp
@@ -21,12 +21,12 @@
 #include "units/IUnit.h"
 #include <QStringBuilder>
 
-const QString CKnownExtension::internalSlope    = "::ql:slope";
-const QString CKnownExtension::internalSpeedDist    = "::ql:speeddist";
-const QString CKnownExtension::internalSpeedTime    = "::ql:speedtime";
-const QString CKnownExtension::internalEle      = "::ql:ele";
-const QString CKnownExtension::internalProgress = "::ql:progress";
-const QString CKnownExtension::internalTerrainSlope = "::ql:terrainslope";
+const QString CKnownExtension::internalSlope    = "ql:slope";
+const QString CKnownExtension::internalSpeedDist    = "ql:speeddist";
+const QString CKnownExtension::internalSpeedTime    = "ql:speedtime";
+const QString CKnownExtension::internalEle      = "ql:ele";
+const QString CKnownExtension::internalProgress = "ql:progress";
+const QString CKnownExtension::internalTerrainSlope = "ql:terrainslope";
 
 QHash<QString, CKnownExtension> CKnownExtension::knownExtensions;
 QSet<QString> CKnownExtension::registeredNS;

--- a/src/qmapshack/gis/trk/filter/filter.cpp
+++ b/src/qmapshack/gis/trk/filter/filter.cpp
@@ -482,7 +482,7 @@ void CGisItemTrk::filterSpeed(const CFilterSpeedHike::hiking_type_t &hikingType)
 
 void CGisItemTrk::filterGetSlopeLimits(qreal &minSlope, qreal &maxSlope) const
 {
-    const limits_t& limit = extrema["::ql:slope"];
+    const limits_t& limit = extrema["ql:slope"];
     minSlope = limit.min;
     maxSlope = limit.max;
 }


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS #19

**Describe roughly what you have done:**

The `ql` namespace was prepended by `::` causing the files to fail
on some other applications. Removed all occurences of `::ql`

**What steps have to be done to perform a simple smoke test:**

1. Use the `Calculate Terrain Slope` filter on a track
2. Save track as GPX.
3. Test on Oruxmap

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
