### PR TITLE
[QMS-37] Inconsistent use of time zones

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-37] Fix inconsistent use of time zones
 [QMS-27] Error in workspace search for attributes
 [QMS-18] Improved explanation of 'Date equals'
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/trk/filter/CFilterNewDate.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterNewDate.cpp
@@ -19,6 +19,7 @@
 #include "canvas/CCanvas.h"
 #include "gis/trk/CGisItemTrk.h"
 #include "gis/trk/filter/CFilterNewDate.h"
+#include "units/IUnit.h"
 
 CFilterNewDate::CFilterNewDate(CGisItemTrk &trk, QWidget *parent)
     : QWidget(parent)
@@ -26,7 +27,11 @@ CFilterNewDate::CFilterNewDate(CGisItemTrk &trk, QWidget *parent)
 {
     setupUi(this);
 
-    labelTimeZone->setText(QDateTime::currentDateTime().timeZone().abbreviation(QDateTime::currentDateTime()));
+    IUnit::tz_mode_e mode;
+    QByteArray zone;
+    bool format;
+    IUnit::getTimeZoneSetup(mode, zone, format);
+    labelTimeZone->setText(zone);
     dateTimeEdit->setDateTime(QDateTime::currentDateTime());
 
     connect(toolApply, &QToolButton::clicked, this, &CFilterNewDate::slotApply);
@@ -35,6 +40,12 @@ CFilterNewDate::CFilterNewDate(CGisItemTrk &trk, QWidget *parent)
 void CFilterNewDate::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterNewDate(dateTimeEdit->dateTime().toUTC());
+    IUnit::tz_mode_e mode;
+    QByteArray zone;
+    bool format;
+    IUnit::getTimeZoneSetup(mode, zone, format);
+    QDateTime newDateTime=dateTimeEdit->dateTime();
+    newDateTime.setTimeZone(QTimeZone(zone));
+    trk.filterNewDate(newDateTime.toUTC());
 }
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** #37

**Describe roughly what you have done:**

I made the newDate filter use IUnit time zones
instead of QDateTime local time zones

**What steps have to be done to perform a simple smoke test:**

1. Open track filters
2. Set new starting time of track

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
