### PR TITLE
[QMS-22] Nautical miles for distances and feet for altitude

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-20] Windows Start Menu - change links from bitbucket to github
 [QMS-27] Error in workspace search for attributes
 [QMS-31] Fix all links to Bitbucket in the code
+[QMS-22] Aviation units: nm for distances and feet for altitude
 
 ------------------------------------------------------------------------
 ---------Restart issue numbering because of migration to GitHub---------

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -315,6 +315,7 @@ set( SRCS
     units/CUnitImperial.cpp
     units/CUnitMetric.cpp
     units/CUnitNautic.cpp
+    units/CUnitAviation.cpp
     units/CUnitsSetup.cpp
     units/IUnit.cpp
     widgets/CColorLegend.cpp
@@ -655,6 +656,7 @@ set( HDRS
     units/CUnitImperial.h
     units/CUnitMetric.h
     units/CUnitNautic.h
+    units/CUnitAviation.h
     units/CUnitsSetup.h
     units/IUnit.h
     version.h

--- a/src/qmapshack/units/CUnitAviation.cpp
+++ b/src/qmapshack/units/CUnitAviation.cpp
@@ -1,0 +1,127 @@
+/**********************************************************************************************
+    Copyright (C) 2008 Oliver Eichler oliver.eichler@gmx.de
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111 USA
+
+**********************************************************************************************/
+
+#include "units/CUnitAviation.h"
+
+CUnitAviation::CUnitAviation(QObject * parent)
+    : IUnit(eTypeAviation, "ft", footPerMeter, "kn", meterPerSecToKnots, parent)
+{
+}
+
+
+void CUnitAviation::meter2elevation(qreal meter, QString& val, QString& unit) const /* override */
+{
+    if(meter == NOFLOAT)
+    {
+        val  = "-";
+        unit.clear();
+    }
+    else
+    {
+        val.sprintf("%1.0f", meter * footPerMeter);
+        unit = "ft";
+    }
+}
+
+void CUnitAviation::meter2elevation(qreal meter, qreal& val, QString& unit) const /* override */
+{
+    if(meter == NOFLOAT)
+    {
+        val  = NOFLOAT;
+        unit.clear();
+    }
+    else
+    {
+        val =  meter * footPerMeter;
+        unit = "ft";
+    }
+}
+
+void CUnitAviation::meter2distance(qreal meter, QString& val, QString& unit) const /* override */
+{
+    if(meter == NOFLOAT)
+    {
+        val  = "-";
+        unit.clear();
+    }
+    else if(meter < 1852)
+    {
+        val.sprintf("%g", meter * nauticalMilePerMeter);
+        unit = "nm";
+    }
+    else
+    {
+        val.sprintf("%1.1f", meter * nauticalMilePerMeter);
+        unit = "nm";
+    }
+}
+
+void CUnitAviation::meter2distance(qreal meter, qreal& val, QString& unit) const /* override */
+{
+    if(meter == NOFLOAT)
+    {
+        val  = NOFLOAT;
+        unit.clear();
+    }
+    else
+    {
+        val = meter * nauticalMilePerMeter;
+        unit = "nm";
+    }
+}
+
+void CUnitAviation::meter2area(qreal meter, QString& val, QString& unit) const /* override */
+{
+    if(meter == NOFLOAT)
+    {
+        val  = "-";
+        unit.clear();
+    }
+    else
+    {
+        val.sprintf("%1.2f", meter / (1/nauticalMilePerMeter * 1/nauticalMilePerMeter));
+        unit = "nm²";
+    }
+}
+
+void CUnitAviation::meter2area(qreal meter, qreal& val, QString& unit) const /* override */
+{
+    if(meter == NOFLOAT)
+    {
+        val  = NOFLOAT;
+        unit.clear();
+    }
+    else
+    {
+        val= meter / (1/nauticalMilePerMeter * 1/nauticalMilePerMeter);
+        unit = "nm²";
+    }
+}
+
+qreal CUnitAviation::elevation2meter(const QString& val) const /* override */
+{
+    return val.toDouble() / footPerMeter;
+}
+
+void CUnitAviation::meter2unit(qreal meter, qreal& scale, QString&  unit) const
+{
+    scale = nauticalMilePerMeter;
+    unit  = "nm";
+}
+

--- a/src/qmapshack/units/CUnitAviation.cpp
+++ b/src/qmapshack/units/CUnitAviation.cpp
@@ -1,5 +1,6 @@
 /**********************************************************************************************
     Copyright (C) 2008 Oliver Eichler oliver.eichler@gmx.de
+                  2019 Johannes Zellner johannes@zellner.org
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/qmapshack/units/CUnitAviation.h
+++ b/src/qmapshack/units/CUnitAviation.h
@@ -1,0 +1,43 @@
+/**********************************************************************************************
+    Copyright (C) 2008 Oliver Eichler oliver.eichler@gmx.de
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111 USA
+
+**********************************************************************************************/
+#ifndef CUNITAVIATION_H
+#define CUNITAVIATION_H
+
+#include "IUnit.h"
+
+class CUnitAviation : public IUnit
+{
+public:
+    static constexpr qreal footPerMeter = 3.28084;
+    static constexpr qreal nauticalMilePerMeter = 1. / 1852;
+    static constexpr qreal meterPerSecToKnots = 1.94361780;
+
+    CUnitAviation(QObject * parent);
+    virtual ~CUnitAviation() = default;
+
+    void meter2elevation(qreal meter, QString& val, QString& unit) const override;
+    void meter2elevation(qreal meter, qreal& val, QString& unit) const override;
+    void meter2distance(qreal meter, QString& val, QString& unit) const override;
+    void meter2distance(qreal meter, qreal& val, QString& unit) const override;
+    void meter2area(qreal meter, QString& val, QString& unit) const override;
+    void meter2area(qreal meter, qreal& val, QString& unit) const override;
+    qreal elevation2meter(const QString& val) const override;
+    void meter2unit(qreal meter, qreal& scale, QString&  unit) const override;
+};
+#endif //CUNITAVIATION_H

--- a/src/qmapshack/units/CUnitAviation.h
+++ b/src/qmapshack/units/CUnitAviation.h
@@ -1,5 +1,6 @@
 /**********************************************************************************************
     Copyright (C) 2008 Oliver Eichler oliver.eichler@gmx.de
+                  2019 Johannes Zellner johannes@zellner.org
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/qmapshack/units/CUnitsSetup.cpp
+++ b/src/qmapshack/units/CUnitsSetup.cpp
@@ -38,6 +38,10 @@ CUnitsSetup::CUnitsSetup(QWidget *parent)
     case IUnit::eTypeNautic:
         radioNautic->setChecked(true);
         break;
+
+    case IUnit::eTypeAviation:
+        radioAviation->setChecked(true);
+        break;
     }
 
     switch(IUnit::getSlopeMode())
@@ -67,6 +71,10 @@ void CUnitsSetup::accept()
     else if(radioNautic->isChecked())
     {
         IUnit::setUnitType(IUnit::eTypeNautic, &CMainWindow::self());
+    }
+    else if(radioAviation->isChecked())
+    {
+        IUnit::setUnitType(IUnit::eTypeAviation, &CMainWindow::self());
     }
 
     if(radioDegrees->isChecked())

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -21,6 +21,7 @@
 #include "units/CUnitImperial.h"
 #include "units/CUnitMetric.h"
 #include "units/CUnitNautic.h"
+#include "units/CUnitAviation.h"
 
 #include <proj_api.h>
 #include <QtWidgets>
@@ -593,6 +594,10 @@ void IUnit::setUnitType(type_e t, QObject * parent)
 
     case eTypeNautic:
         new CUnitNautic(parent);
+        break;
+
+    case eTypeAviation:
+        new CUnitAviation(parent);
         break;
     }
 

--- a/src/qmapshack/units/IUnit.h
+++ b/src/qmapshack/units/IUnit.h
@@ -78,7 +78,7 @@ public:
         return list;
     }
 
-    enum type_e {eTypeMetric, eTypeImperial, eTypeNautic};
+    enum type_e {eTypeMetric, eTypeImperial, eTypeNautic, eTypeAviation};
     /// instantiate the correct unit object
     static void setUnitType(type_e t, QObject * parent);
 

--- a/src/qmapshack/units/IUnitsSetup.ui
+++ b/src/qmapshack/units/IUnitsSetup.ui
@@ -45,6 +45,13 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QRadioButton" name="radioAviation">
+         <property name="text">
+          <string>Aviation (nm, feet)</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabSlope">


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** #22 

**Describe roughly what you have done:**

* added CUnitAviation.cpp and CUnitAviation.h to src/qmapshack/units
* modfied other files in src/qmapshack/units to use CUnitAviation.cpp and CUnitAviation.h

**What steps have to be done to perform a simple smoke test:**

Open "unit settings" where a fourth item "Aviation (nm / feet)" appears.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes, I copied CUnitAviation.cpp and CUnitAviation.h from other files mostly.

**Is every user facing string in a tr() macro?**

- what's this?

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
