### PR TITLE
[QMS-14] Drawing track: Change key bindings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V1.XX.X
 [QMS-8] Incorrect elevation for fit files from GPSMAP 66s
 [QMS-12] Unify versions of all QMapShack tools
 [QMS-13] Add support for Garmin Edge 500
+[QMS-14] Drawing track: Alternate mode O A V T with a simple key with no modifiers
 [QMS-18] Improved explanation of 'Date equals'
 [QMS-19] Invalid GPX due to `::` in `ql` namespace
 [QMS-20] Windows Start Menu - change links from bitbucket to github

--- a/src/qmapshack/mouse/line/IScrOptEditLine.ui
+++ b/src/qmapshack/mouse/line/IScrOptEditLine.ui
@@ -212,7 +212,7 @@
         <item>
          <widget class="QToolButton" name="toolNoRoute">
           <property name="toolTip">
-           <string>No auto-routing or line snapping (Ctrl+O)</string>
+           <string>No auto-routing or line snapping (Key: O)</string>
           </property>
           <property name="text">
            <string>0</string>
@@ -222,7 +222,7 @@
             <normaloff>:/icons/32x32/O.png</normaloff>:/icons/32x32/O.png</iconset>
           </property>
           <property name="shortcut">
-           <string>Ctrl+O</string>
+           <string>O</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -235,7 +235,7 @@
         <item>
          <widget class="QToolButton" name="toolAutoRoute">
           <property name="toolTip">
-           <string>Use auto-routing to between points. (Ctrl+A)</string>
+           <string>Use auto-routing to between points. (Key: A)</string>
           </property>
           <property name="text">
            <string>A</string>
@@ -245,7 +245,7 @@
             <normaloff>:/icons/32x32/A.png</normaloff>:/icons/32x32/A.png</iconset>
           </property>
           <property name="shortcut">
-           <string>Ctrl+A</string>
+           <string>A</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -258,7 +258,7 @@
         <item>
          <widget class="QToolButton" name="toolVectorRoute">
           <property name="toolTip">
-           <string>Snap line along lines of a vector map. (Ctrl+V)</string>
+           <string>Snap line along lines of a vector map. (Key: V)</string>
           </property>
           <property name="text">
            <string>V</string>
@@ -268,7 +268,7 @@
             <normaloff>:/icons/32x32/V.png</normaloff>:/icons/32x32/V.png</iconset>
           </property>
           <property name="shortcut">
-           <string>Ctrl+V</string>
+           <string>V</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -281,7 +281,7 @@
         <item>
          <widget class="QToolButton" name="toolTrackRoute">
           <property name="toolTip">
-           <string>Connect points with a line from a loaded track if possible.</string>
+           <string>Connect points with a line from a loaded track if possible. (Key: T)</string>
           </property>
           <property name="text">
            <string>...</string>
@@ -289,6 +289,9 @@
           <property name="icon">
            <iconset resource="../../resources.qrc">
             <normaloff>:/icons/32x32/T.png</normaloff>:/icons/32x32/T.png</iconset>
+          </property>
+          <property name="shortcut">
+           <string>T</string>
           </property>
           <property name="checkable">
            <bool>true</bool>


### PR DESCRIPTION
Use the keys O, V, A and T without any control key to switch between
routing modes.

**What is the linked issue for this pull request (start with a `#`):** QMS #14

**Describe roughly what you have done:**

Simply changed key bindings and tool tips.

**What steps have to be done to perform a simple smoke test:**

Start editing a track. Using the keys O, V, A and T should visibly switch the tool buttons.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes
