### PR TITLE
[QMS-53] Unload Garmin `Archive` when folder is deflated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,9 +8,11 @@ V1.XX.X
 [QMS-18] Improved explanation of 'Date equals'
 [QMS-19] Invalid GPX due to `::` in `ql` namespace
 [QMS-20] Windows Start Menu - change links from bitbucket to github
+[QMS-22] Aviation units: nm for distances and feet for altitude
 [QMS-27] Error in workspace search for attributes
 [QMS-31] Fix all links to Bitbucket in the code
-[QMS-22] Aviation units: nm for distances and feet for altitude
+[QMS-53] Unload Garmin `Archive` when folder is deflated
+
 
 ------------------------------------------------------------------------
 ---------Restart issue numbering because of migration to GitHub---------

--- a/src/qmapshack/device/CDeviceGarminArchive.h
+++ b/src/qmapshack/device/CDeviceGarminArchive.h
@@ -39,6 +39,7 @@ protected:
 
 private slots:
     void slotExpanded(QTreeWidgetItem * item);
+    void slotCollapsed(QTreeWidgetItem * item);
 };
 
 #endif //CDEVICEGARMINARCHIVE_H


### PR DESCRIPTION
Simply remove all child items on deflating the `Archive` folder.

**What is the linked issue for this pull request (start with a `#`):** QMS-#53

**Describe roughly what you have done:**

I added a signal handler for `itemCollapsed` signal in `CDeviceGarminArchive`. The handler removes all child items.

**What steps have to be done to perform a simple smoke test:**

* Connect a Garmin with an archive folder
* Expand the archive folder -> all items loaded and visible on the map
* Collapse the archive folder -> all items removed on the map

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
