### PR TITLE
[QMS-54] Disable invalid points dialog for devices

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V1.XX.X
 [QMS-27] Error in workspace search for attributes
 [QMS-31] Fix all links to Bitbucket in the code
 [QMS-53] Unload Garmin `Archive` when folder is deflated
+[QMS-54] Invalid point cannot be deactivated when tracks are read from the navigation device
 
 
 ------------------------------------------------------------------------

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -3006,7 +3006,7 @@ void CGisItemTrk::checkForInvalidPoints()
         return;
     }
 
-    if((cntInvalidPoints != 0) && (cntInvalidPoints < cntVisiblePoints))
+    if((cntInvalidPoints != 0) && (cntInvalidPoints < cntVisiblePoints) && !isOnDevice())
     {
         CInvalidTrk dlg(*this, CMainWindow::self().getBestWidgetForParent());
         dlg.exec();


### PR DESCRIPTION
Don't show CInvalidTrk if track is on a device because the user's
decision can't be stored for the track on the device.

**What is the linked issue for this pull request (start with a `#`):** QMS-#54

**Describe roughly what you have done:**

Simply added `isOnDevice()` check to the condition showing `CInvalidTrk` dialog.

**What steps have to be done to perform a simple smoke test:**

* Store a track with invalid data on the device.
* When loading the device's data no dialog about invalid points should pop-up.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
