### PR TITLE
[QMS-58] Windows Build and Installer: use PROJ 6.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 V1.XX.X
+[QMS-58] Windows Build and Installer: use PROJ 6.2
+
+V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter
 [QMS-6] Enhance overview detection for VRT maps
 [QMS-8] Incorrect elevation for fit files from GPSMAP 66s

--- a/msvc_64/QMapShack_Installer.nsi
+++ b/msvc_64/QMapShack_Installer.nsi
@@ -193,7 +193,7 @@ Section "QMapShack" QMapShack
 
   ;BEGIN PROJ.4 Files    
   SetOutPath $INSTDIR
-    File Files\proj_6_1.dll
+    File Files\proj_6_2.dll
     File Files\proj.exe
     File Files\projinfo.exe
     File Files\cct.exe

--- a/msvc_64/cmake/FindPROJ4.cmake
+++ b/msvc_64/cmake/FindPROJ4.cmake
@@ -42,6 +42,7 @@ endif(WIN32)
     NAMES
         proj_6_0
         proj_6_1
+        proj_6_2
     PATHS
 if(WIN32)
       ${PROJ4_DEV_PATH}/lib

--- a/msvc_64/copyfiles.bat
+++ b/msvc_64/copyfiles.bat
@@ -97,7 +97,7 @@ copy %QMSI_GDAL_PATH%\bin\*.dll
 copy %QMSI_GDAL_PATH%\bin\*.exe
 rem section 2.2.4) PROJ.4
 xcopy %QMSI_PROJ_PATH%\share share /s /i
-copy %QMSI_PROJ_PATH%\bin\proj_6_1.dll
+copy %QMSI_PROJ_PATH%\bin\proj_6_2.dll
 copy %QMSI_PROJ_PATH%\bin\proj.exe
 copy %QMSI_PROJ_PATH%\bin\projinfo.exe
 copy %QMSI_PROJ_PATH%\bin\cct.exe


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#58

**Describe roughly what you have done:**

I added proj_6_2 to the find_library section of msvc_64/FindPROJ4.cmake.
I replaced proj_6_1.dll with proj_6_2.dll in both msvc_64/copyfiles.bat  and msvc_64/QMapShack_Installer.nsi.

**What steps have to be done to perform a simple smoke test:**

1. Build QMapShack for Windows, dependeing on teh PROJ library in version 6.2
2. There shall be no dependency errors related to PROJ reported by CMake
3. Neither the copyfiles.bat nor the NSIS installer shall report errors related to the version/filename pf the proj DLL

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] yes

**Is every user facing string in a tr() macro?**

- [X] N/A

**Is the change user facing?**

- [] yes,
- [] no
- [X] relevant for developers/integrators of the windows build

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [X] yes, I didn't forget to change changelog.txt
