### PR TITLE
do not try to examine devices with no path

### DIFF
--- a/src/qmapshack/device/CDeviceWatcherLinux.cpp
+++ b/src/qmapshack/device/CDeviceWatcherLinux.cpp
@@ -58,6 +58,10 @@ void CDeviceWatcherLinux::slotDeviceAdded(const QDBusObjectPath& path, const QVa
     // create path of to drive the block device belongs to
     QDBusInterface * blockIface = new QDBusInterface("org.freedesktop.UDisks2", path.path(), "org.freedesktop.UDisks2.Block", QDBusConnection::systemBus(), this);
     QDBusObjectPath drive_object = blockIface->property("Drive").value<QDBusObjectPath>();
+    if(drive_object.path() == nullptr)
+    {
+        return;
+    }
     QString idLabel = blockIface->property("IdLabel").toString().toUpper();
 
     // read vendor string attached to drive


### PR DESCRIPTION
On FreeBSD, bsdisks cannot (yet) return details on nvme devices.
This wouldn't be much of a problem, since we're searching for
removable devices here - but when we try to get the driveIface for
that device-with-NULL-path, the dbus library triggers an abort(),
which crashes the whole qmapshack. So we catch that nullptr and
return. This is portable across all relevant platforms, as a NULL
drive_object.path() would cause that abort() about anywhere; and
it is safe (no leakage) as all objects created so far in slotDeviceAdded()
only have local scope.

**What is the linked issue for this pull request (start with a `#`):** QMS-#

**Describe roughly what you have done:**

I added...

**What steps have to be done to perform a simple smoke test:**

1. Open whatever
2. Click here

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [ ] yes

**Is every user facing string in a tr() macro?**

- [ ] yes

**Is the change user facing?**

- [ ] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [ ] yes, I didn't forget to change changelog.txt
