### PR TITLE
[QMS-49] Add "elevation limit" to DEM to

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-22] Aviation units: nm for distances and feet for altitude
 [QMS-27] Error in workspace search for attributes
 [QMS-31] Fix all links to Bitbucket in the code
+[QMS-49] Add "elevation limit" to DEM to highlight elevation above the limit
 [QMS-53] Unload Garmin `Archive` when folder is deflated
 [QMS-54] Invalid point cannot be deactivated when tracks are read from the navigation device
 

--- a/src/qmapshack/dem/CDemPropSetup.h
+++ b/src/qmapshack/dem/CDemPropSetup.h
@@ -1,5 +1,6 @@
 /**********************************************************************************************
     Copyright (C) 2014 Oliver Eichler oliver.eichler@gmx.de
+                  2019 Johannes Zellner johannes@zellner.org
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -42,6 +43,7 @@ private slots:
     void slotGradeIndex(int idx);
     void slotSlopeValiddateAfterEdit();
     void slotSlopeChanged(int val);
+    void slotElevationAfterEdit();
 
 private:
     CTinySpinBox* slopeSpins[SLOPE_LEVELS];

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -1,5 +1,6 @@
 /**********************************************************************************************
     Copyright (C) 2014 Oliver Eichler oliver.eichler@gmx.de
+                  2019 Johannes Zellner johannes@zellner.org
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -231,7 +232,7 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
         return;
     }
 
-    if(!doHillshading() && !doSlopeColor())
+    if(!doHillshading() && !doSlopeColor() && !doElevationLimit())
     {
         QThread::msleep(100);
         return;
@@ -408,6 +409,20 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
                     img.setColorTable(slopetable);
 
                     slopecolor(data, w_used, h_used, img);
+
+                    p.setOpacity(o2);
+                    drawTile(img, r, p);
+                    p.setOpacity(o1);
+                }
+
+                if(doElevationLimit())
+                {
+                    QPolygonF r = l;
+
+                    QImage img(w_used, h_used, QImage::Format_Indexed8);
+                    img.setColorTable(elevationtable);
+
+                    elevationLimit(data, w_used, h_used, img);
 
                     p.setOpacity(o2);
                     drawTile(img, r, p);

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -1,5 +1,6 @@
 /**********************************************************************************************
     Copyright (C) 2014 Oliver Eichler oliver.eichler@gmx.de
+                  2019 Johannes Zellner johannes@zellner.org
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -80,6 +81,16 @@ public:
         return bSlopeColor;
     }
 
+    bool doElevationLimit()
+    {
+        return bElevationLimit;
+    }
+
+    int getElevationLimit()
+    {
+        return elevationValue;
+    }
+
     const QVector<QRgb> getSlopeColorTable()
     {
         return slopetable;
@@ -97,6 +108,7 @@ public:
 
     void setSlopeStepTable(int idx);
     void setSlopeStepTableCustomValue(int idx, int val);
+    void setElevationLimit(int val);
 
     enum winsize_e {eWinsize3x3 = 9, eWinsize4x4 = 16};
 
@@ -113,11 +125,18 @@ public slots:
         bSlopeColor = yes;
     }
 
+    void slotSetElevationLimit(bool yes)
+    {
+        bElevationLimit = yes;
+    }
+
 protected:
 
     void hillshading(QVector<qint16>& data, qreal w, qreal h, QImage &img);
 
     void slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage &img);
+
+    void elevationLimit(QVector<qint16>& data, qreal w, qreal h, QImage &img);
 
     /**
        @brief Slope in degrees based on a window. Origin is at point (1,1), counting from zero.
@@ -174,6 +193,8 @@ protected:
 
     QVector<QRgb> slopetable;
 
+    QVector<QRgb> elevationtable;
+
     int hasNoData = 0;
 
     double noData = 0;
@@ -183,8 +204,10 @@ private:
     qreal factorHillshading = 0.1666666716337204;
 
     bool bSlopeColor = false;
+    bool bElevationLimit = false;
     int gradeSlopeColor = 0;
     qreal slopeCustomStepTable[5];
+    int elevationValue;
 };
 
 #endif //IDEM_H

--- a/src/qmapshack/dem/IDemPropSetup.ui
+++ b/src/qmapshack/dem/IDemPropSetup.ui
@@ -590,6 +590,67 @@
      </item>
     </layout>
    </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkElevationLimit">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Elevation Limit</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="spinBoxElevationLimit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="maximum">
+        <number>99999</number>
+       </property>
+       <property name="singleStep">
+        <number>50</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="elevationLimitUnit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>m/ft</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#49

**Describe roughly what you have done:**

Added "elevation limit" to DEM to highlight elevation above the limit.
    
Added a Checkbox "Elevation Limit" to the DEM
dialog to toggle visualization of the limit.
    
Added a Spinbox to the DEM dialog to set the
elevation limit.
    
If enabled, terrain above the limit will be
colored in magenta.
    
This feature is useful for VFR flight planning to
check if the planned route is above the terrain.

**What steps have to be done to perform a simple smoke test:**

1. Go to DEM settings
2. Enable the checkbox "elevation limit"
3. adjust the elevation limit to your needs. You can adjust the elevation limit by using the mouse wheel in the spinbox. The elevation limit is to be given in the units which are set as altitude  units, e.g. m for metric or ft for "aviation units".

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [ ] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
