### PR TITLE
[QMS-64] Cleanup code in IUnit and subclasses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 V1.XX.X
+[QMS-49] Add "elevation limit" to DEM to highlight elevation above the limit
 [QMS-58] Windows Build and Installer: use PROJ 6.2
+[QMS-64] Cleanup code in IUnit and subclasses
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter
@@ -14,7 +16,6 @@ V1.14.0
 [QMS-22] Aviation units: nm for distances and feet for altitude
 [QMS-27] Error in workspace search for attributes
 [QMS-31] Fix all links to Bitbucket in the code
-[QMS-49] Add "elevation limit" to DEM to highlight elevation above the limit
 [QMS-53] Unload Garmin `Archive` when folder is deflated
 [QMS-54] Invalid point cannot be deactivated when tracks are read from the navigation device
 

--- a/src/qmapshack/dem/CDemPropSetup.cpp
+++ b/src/qmapshack/dem/CDemPropSetup.cpp
@@ -129,15 +129,7 @@ void CDemPropSetup::slotPropertiesChanged()
 
     checkElevationLimit->setChecked(demfile->doElevationLimit());
     spinBoxElevationLimit->setValue(demfile->getElevationLimit());
-
-    qreal meter = 0;
-    qreal val = 0;
-    QString elevationUnit;
-    IUnit::self().meter2elevation(meter, val, elevationUnit);
-    if(elevationLimitUnit->text() != elevationUnit)
-    {
-        elevationLimitUnit->setText(elevationUnit);
-    }
+    spinBoxElevationLimit->setSuffix(IUnit::self().elevationUnit);
 
     dem->emitSigCanvasUpdate();
 

--- a/src/qmapshack/dem/IDemPropSetup.ui
+++ b/src/qmapshack/dem/IDemPropSetup.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>269</width>
-    <height>173</height>
+    <height>181</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -592,22 +592,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="checkElevationLimit">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Elevation Limit</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <widget class="QSpinBox" name="spinBoxElevationLimit">
        <property name="sizePolicy">
@@ -636,16 +620,19 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="elevationLimitUnit">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkElevationLimit">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
        <property name="text">
-        <string>m/ft</string>
+        <string>Elevation Limit</string>
        </property>
       </widget>
      </item>

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -1337,14 +1337,14 @@ void CGisWorkspace::editPrxWpt(const QList<IGisItem::key_t>& keys)
     QMutexLocker lock(&IGisItem::mutexItems);
 
     QVariant var;
-    CInputDialog dlg(this, tr("Enter new proximity range."), var, QVariant(NOFLOAT), IUnit::self().baseunit);
+    CInputDialog dlg(this, tr("Enter new proximity range."), var, QVariant(NOFLOAT), IUnit::self().baseUnit);
     dlg.setOption(tr("Is no-go area"), false);
     if(dlg.exec() != QDialog::Accepted)
     {
         return;
     }
 
-    qreal proximity = var.toDouble()/IUnit::self().basefactor;
+    qreal proximity = var.toDouble()/IUnit::self().baseFactor;
     bool isNoGo = dlg.optionIsChecked();
     for(const IGisItem::key_t& key : keys)
     {

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -2507,7 +2507,7 @@ void CGisItemTrk::setElevation(qint32 idx, qint32 ele)
     {
         trkpt->ele = ele;
         deriveSecondaryData();
-        changed(tr("Changed elevation of point %1 to %2 %3").arg(idx).arg(ele).arg(IUnit::self().baseunit), "://icons/48x48/SetEle.png");
+        changed(tr("Changed elevation of point %1 to %2 %3").arg(idx).arg(ele*IUnit::self().elevationFactor).arg(IUnit::self().elevationUnit), "://icons/48x48/SetEle.png");
     }
 }
 

--- a/src/qmapshack/gis/trk/CKnownExtension.cpp
+++ b/src/qmapshack/gis/trk/CKnownExtension.cpp
@@ -73,7 +73,7 @@ void CKnownExtension::initGarminTPXv1(const IUnit &units, const QString &ns)
                              getExtensionValueFunc(ns % ":TrackPointExtension|" % ns % ":wtemp")});
 
     knownExtensions.insert(ns % ":TrackPointExtension|" % ns % ":depth",
-                           { tr("Depth", "extShortName"), tr("Depth", "extLongName"), 2, 0., 12000., units.basefactor, units.baseunit, "://icons/32x32/CSrcDepth.png", true, false,
+                           { tr("Depth", "extShortName"), tr("Depth", "extLongName"), 2, 0., 12000., units.elevationFactor, units.elevationUnit, "://icons/32x32/CSrcDepth.png", true, false,
                              getExtensionValueFunc(ns % ":TrackPointExtension|" % ns % ":depth")});
 
     knownExtensions.insert(ns % ":TrackPointExtension|" % ns % ":hr",
@@ -97,11 +97,11 @@ void CKnownExtension::initMioTPX(const IUnit &units)
                              getExtensionValueFunc("cadence")});
 
     knownExtensions.insert("speed",
-                           { tr("Speed", "extShortName"), tr("Speed", "extLongName"), NOORDER, 0., 600., units.speedfactor, units.speedunit, "://icons/32x32/CSrcSpeed.png", true, false,
+                           { tr("Speed", "extShortName"), tr("Speed", "extLongName"), NOORDER, 0., 600., units.speedFactor, units.speedUnit, "://icons/32x32/CSrcSpeed.png", true, false,
                              getExtensionValueFunc("speed")});
 
     knownExtensions.insert("acceleration",
-                           { tr("Accel.", "extShortName"), tr("Acceleration", "extLongName"), NOORDER, std::numeric_limits<qreal>::lowest(), std::numeric_limits<qreal>::max(), units.basefactor, units.baseunit + "/s²", "://icons/32x32/CSrcAccel.png", true, false,
+                           { tr("Accel.", "extShortName"), tr("Acceleration", "extLongName"), NOORDER, std::numeric_limits<qreal>::lowest(), std::numeric_limits<qreal>::max(), units.baseFactor, units.baseUnit + "/s²", "://icons/32x32/CSrcAccel.png", true, false,
                              getExtensionValueFunc("acceleration")});
 
     knownExtensions.insert("course",
@@ -120,11 +120,11 @@ void CKnownExtension::initClueTrustTPXv1(const IUnit &units, const QString &ns)
                              getExtensionValueFunc(ns % ":temp")});
 
     knownExtensions.insert(ns % ":distance",
-                           { tr("Dist.", "extShortName"), tr("Distance", "extLongName"), 2, 0., +100000000., units.basefactor, units.baseunit, "://icons/32x32/CSrcDistance.png", true, false,
+                           { tr("Dist.", "extShortName"), tr("Distance", "extLongName"), 2, 0., +100000000., units.baseFactor, units.baseUnit, "://icons/32x32/CSrcDistance.png", true, false,
                              getExtensionValueFunc(ns % ":distance") });
 
     knownExtensions.insert(ns % ":altitude",
-                           { tr("Ele.", "extShortName"), tr("Elevation", "extLongName"), 3, -1000., +10000., units.basefactor, units.baseunit, "://icons/32x32/CSrcElevation.png", true, false,
+                           { tr("Ele.", "extShortName"), tr("Elevation", "extLongName"), 3, -1000., +10000., units.elevationFactor, units.elevationUnit, "://icons/32x32/CSrcElevation.png", true, false,
                              getExtensionValueFunc(ns % ":altitude") });
 
     knownExtensions.insert(ns % ":energy",
@@ -137,11 +137,11 @@ void CKnownExtension::initClueTrustTPXv1(const IUnit &units, const QString &ns)
                              getExtensionValueFunc(ns % ":seaLevelPressure") });
 
     knownExtensions.insert(ns % ":speed",
-                           { tr("Speed", "extShortName"), tr("Speed", "extLongName"), 6, 0., 600., units.speedfactor, units.speedunit, "://icons/32x32/CSrcSpeed.png", true, false,
+                           { tr("Speed", "extShortName"), tr("Speed", "extLongName"), 6, 0., 600., units.speedFactor, units.speedUnit, "://icons/32x32/CSrcSpeed.png", true, false,
                              getExtensionValueFunc(ns % ":speed")});
 
     knownExtensions.insert(ns % ":verticalSpeed",
-                           { tr("v. Speed", "extShortName"), tr("Vertical Speed", "extLongName"), 7, 0., 50., units.speedfactor, units.speedunit, "://icons/32x32/CSrcVertSpeed.png", true, false,
+                           { tr("v. Speed", "extShortName"), tr("Vertical Speed", "extLongName"), 7, 0., 50., units.speedFactor, units.speedUnit, "://icons/32x32/CSrcVertSpeed.png", true, false,
                              getExtensionValueFunc(ns % ":verticalSpeed")});
 }
 
@@ -156,22 +156,22 @@ void CKnownExtension::init(const IUnit &units)
         },
 
         {internalSpeedDist,
-         { tr("Speed", "extShortName"), tr("Speed over Distance*", "extLongName"), -1, 0., 600., units.speedfactor, units.speedunit, "://icons/32x32/CSrcSpeed.png", true, true,
+         { tr("Speed", "extShortName"), tr("Speed over Distance*", "extLongName"), -1, 0., 600., units.speedFactor, units.speedUnit, "://icons/32x32/CSrcSpeed.png", true, true,
            [](const CTrackData::trkpt_t &p) { return p.speed; }}
         },
 
         {internalSpeedTime,
-         { tr("Speed", "extShortName"), tr("Speed over Time*", "extLongName"), -1, 0., NOFLOAT, units.speedfactor, units.speedunit, "://icons/32x32/CSrcSpeed.png", true, true,
+         { tr("Speed", "extShortName"), tr("Speed over Time*", "extLongName"), -1, 0., NOFLOAT, units.speedFactor, units.speedUnit, "://icons/32x32/CSrcSpeed.png", true, true,
            [](const CTrackData::trkpt_t &p) { return p.speed; }}
         },
 
         {internalEle,
-         { tr("Ele.", "extShortName"), tr("Elevation*", "extLongName"), -1, 0., 100000., units.basefactor, units.baseunit, "://icons/32x32/CSrcElevation.png", true, true,
+         { tr("Ele.", "extShortName"), tr("Elevation*", "extLongName"), -1, 0., 100000., units.elevationFactor, units.elevationUnit, "://icons/32x32/CSrcElevation.png", true, true,
            [](const CTrackData::trkpt_t &p) { return (NOINT == p.ele) ? NOFLOAT : p.ele; }}
         },
 
         {internalProgress,
-         { tr("Progress", "extShortName"), tr("Progress*", "extLongName"), -1, 0., NOFLOAT, units.basefactor, units.baseunit, "://icons/32x32/Progress.png", true, true,
+         { tr("Progress", "extShortName"), tr("Progress*", "extLongName"), -1, 0., NOFLOAT, units.baseFactor, units.baseUnit, "://icons/32x32/Progress.png", true, true,
            [](const CTrackData::trkpt_t &p) { return p.distance; }}
         },
 

--- a/src/qmapshack/gis/trk/filter/CFilterDouglasPeuker.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterDouglasPeuker.cpp
@@ -30,7 +30,7 @@ CFilterDouglasPeuker::CFilterDouglasPeuker(CGisItemTrk &trk, QWidget * parent)
 {
     setupUi(this);
 
-    spinBox->setSuffix(IUnit::self().baseunit);
+    spinBox->setSuffix(IUnit::self().baseUnit);
 
     SETTINGS;
     spinBox->setValue(cfg.value("TrackDetails/Filter/DouglasPeuker/distance", 5).toInt());
@@ -47,5 +47,5 @@ CFilterDouglasPeuker::~CFilterDouglasPeuker()
 void CFilterDouglasPeuker::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterReducePoints(spinBox->value()/IUnit::self().basefactor);
+    trk.filterReducePoints(spinBox->value()/IUnit::self().baseFactor);
 }

--- a/src/qmapshack/gis/trk/filter/CFilterLoopsCut.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterLoopsCut.cpp
@@ -30,10 +30,10 @@ CFilterLoopsCut::CFilterLoopsCut(CGisItemTrk &trk, QWidget * parent)
 {
     setupUi(this);
 
-    spinBox->setSuffix(IUnit::self().baseunit);
+    spinBox->setSuffix(IUnit::self().baseUnit);
 
     SETTINGS;
-    spinBox->setValue(cfg.value("TrackDetails/Filter/LoopsCut/minLoopLength", 10 * IUnit::self().basefactor).toInt() * IUnit::self().basefactor);
+    spinBox->setValue(cfg.value("TrackDetails/Filter/LoopsCut/minLoopLength", 10 * IUnit::self().baseFactor).toInt() * IUnit::self().baseFactor);
 
     connect(toolApply, &QToolButton::clicked, this, &CFilterLoopsCut::slotApply);
     connect(help, &QToolButton::clicked, this, &CFilterLoopsCut::showHelp);
@@ -42,13 +42,13 @@ CFilterLoopsCut::CFilterLoopsCut(CGisItemTrk &trk, QWidget * parent)
 CFilterLoopsCut::~CFilterLoopsCut()
 {
     SETTINGS;
-    cfg.setValue("TrackDetails/Filter/LoopsCut/minLoopLength", spinBox->value() / IUnit::self().basefactor);
+    cfg.setValue("TrackDetails/Filter/LoopsCut/minLoopLength", spinBox->value() / IUnit::self().baseFactor);
 }
 
 void CFilterLoopsCut::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterLoopsCut(spinBox->value()/IUnit::self().basefactor);
+    trk.filterLoopsCut(spinBox->value()/IUnit::self().baseFactor);
 }
 
 void CFilterLoopsCut::showHelp()

--- a/src/qmapshack/gis/trk/filter/CFilterOffsetElevation.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterOffsetElevation.cpp
@@ -28,7 +28,7 @@ CFilterOffsetElevation::CFilterOffsetElevation(CGisItemTrk &trk, QWidget *parent
 {
     setupUi(this);
 
-    spinBox->setSuffix(IUnit::self().baseunit);
+    spinBox->setSuffix(IUnit::self().elevationUnit);
 
     SETTINGS;
     spinBox->setValue(cfg.value("TrackDetails/Filter/OffsetElevation/offset", 0).toInt());
@@ -45,5 +45,5 @@ CFilterOffsetElevation::~CFilterOffsetElevation()
 void CFilterOffsetElevation::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterOffsetElevation(spinBox->value()/IUnit::self().basefactor);
+    trk.filterOffsetElevation(spinBox->value()/IUnit::self().elevationFactor);
 }

--- a/src/qmapshack/gis/trk/filter/CFilterSpeedConst.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterSpeedConst.cpp
@@ -29,15 +29,15 @@ CFilterSpeedConst::CFilterSpeedConst(QWidget *parent)
 
 void CFilterSpeedConst::loadSettings(QSettings& cfg)
 {
-    spinConstantSpeed->setValue(cfg.value("speed", 18.0 * IUnit::self().speedfactor).toDouble() * IUnit::self().speedfactor);
+    spinConstantSpeed->setValue(cfg.value("speed", 18.0 * IUnit::self().speedFactor).toDouble() * IUnit::self().speedFactor);
 }
 
 void CFilterSpeedConst::saveSettings(QSettings& cfg)
 {
-    cfg.setValue("speed", spinConstantSpeed->value() / IUnit::self().speedfactor);
+    cfg.setValue("speed", spinConstantSpeed->value() / IUnit::self().speedFactor);
 }
 
 void CFilterSpeedConst::apply(CGisItemTrk& trk)
 {
-    trk.filterSpeed(spinConstantSpeed->value() / IUnit::self().speedfactor);
+    trk.filterSpeed(spinConstantSpeed->value() / IUnit::self().speedFactor);
 }

--- a/src/qmapshack/gis/trk/filter/CFilterZeroSpeedDriftCleaner.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterZeroSpeedDriftCleaner.cpp
@@ -30,10 +30,10 @@ CFilterZeroSpeedDriftCleaner::CFilterZeroSpeedDriftCleaner(CGisItemTrk &trk, QWi
 {
     setupUi(this);
 
-    distance->setSuffix(IUnit::self().baseunit);
+    distance->setSuffix(IUnit::self().baseUnit);
 
     SETTINGS;
-    distance->setValue(cfg.value("TrackDetails/Filter/ZeroSpeedDriftCleaner/distance", 0.75 * IUnit::self().basefactor).toDouble() * IUnit::self().basefactor);
+    distance->setValue(cfg.value("TrackDetails/Filter/ZeroSpeedDriftCleaner/distance", 0.75 * IUnit::self().baseFactor).toDouble() * IUnit::self().baseFactor);
     ratio->setValue(cfg.value("TrackDetails/Filter/ZeroSpeedDriftCleaner/ratio", 2).toDouble());
 
     connect(toolApply, &QToolButton::clicked, this, &CFilterZeroSpeedDriftCleaner::slotApply);
@@ -43,14 +43,14 @@ CFilterZeroSpeedDriftCleaner::CFilterZeroSpeedDriftCleaner(CGisItemTrk &trk, QWi
 CFilterZeroSpeedDriftCleaner::~CFilterZeroSpeedDriftCleaner()
 {
     SETTINGS;
-    cfg.setValue("TrackDetails/Filter/ZeroSpeedDriftCleaner/distance", distance->value() / IUnit::self().basefactor);
+    cfg.setValue("TrackDetails/Filter/ZeroSpeedDriftCleaner/distance", distance->value() / IUnit::self().baseFactor);
     cfg.setValue("TrackDetails/Filter/ZeroSpeedDriftCleaner/ratio", ratio->value());
 }
 
 void CFilterZeroSpeedDriftCleaner::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterZeroSpeedDriftCleaner(distance->value()/IUnit::self().basefactor, ratio->value());
+    trk.filterZeroSpeedDriftCleaner(distance->value()/IUnit::self().baseFactor, ratio->value());
 }
 
 void CFilterZeroSpeedDriftCleaner::showHelp()

--- a/src/qmapshack/gis/trk/filter/filter.cpp
+++ b/src/qmapshack/gis/trk/filter/filter.cpp
@@ -357,10 +357,10 @@ void CGisItemTrk::filterSpeed(qreal speed) // Constant speed
 
 void CGisItemTrk::filterSpeed(const CFilterSpeedCycle::cycling_type_t &cyclingType)
 {
-    qreal plainSpeed = cyclingType.plainSpeed / IUnit::self().speedfactor;
-    qreal minSpeed = cyclingType.minSpeed / IUnit::self().speedfactor;
+    qreal plainSpeed = cyclingType.plainSpeed / IUnit::self().speedFactor;
+    qreal minSpeed = cyclingType.minSpeed / IUnit::self().speedFactor;
     qreal slopeAtMinSpeed = cyclingType.slopeAtMinSpeed;
-    qreal maxSpeed = cyclingType.maxSpeed / IUnit::self().speedfactor;
+    qreal maxSpeed = cyclingType.maxSpeed / IUnit::self().speedFactor;
     qreal slopeAtMaxSpeed = cyclingType.slopeAtMaxSpeed;
 
     QDateTime timestamp = timeStart;
@@ -433,7 +433,7 @@ void CGisItemTrk::filterSpeed(const CFilterSpeedHike::hiking_type_t &hikingType)
     // Curve algorithm based on carloscoi curves
     // variable names according to carloscoi xls cell names, A9, B4, B5, B6
     // for better interpretation of formula
-    qreal B4 = hikingType.plainSpeed / IUnit::self().speedfactor * 3.6; // Transform from set format to km/h
+    qreal B4 = hikingType.plainSpeed / IUnit::self().speedFactor * 3.6; // Transform from set format to km/h
     qreal B5 = hikingType.ascending;
     qreal B6 = hikingType.descending;
 

--- a/src/qmapshack/gis/wpt/CDetailsWpt.cpp
+++ b/src/qmapshack/gis/wpt/CDetailsWpt.cpp
@@ -161,12 +161,12 @@ void CDetailsWpt::slotLinkActivated(const QString& link)
     }
     else if(link == "proximity")
     {
-        QVariant var(wpt.getProximity()*IUnit::self().basefactor);
-        CInputDialog dlg(this, tr("Enter new proximity range."), var, QVariant(NOFLOAT), IUnit::self().baseunit);
+        QVariant var(wpt.getProximity()*IUnit::self().baseFactor);
+        CInputDialog dlg(this, tr("Enter new proximity range."), var, QVariant(NOFLOAT), IUnit::self().baseUnit);
         dlg.setOption(tr("Is no-go area"), wpt.isNogo());
         if(dlg.exec() == QDialog::Accepted)
         {
-            wpt.setProximity(var.toDouble()/IUnit::self().basefactor);
+            wpt.setProximity(var.toDouble()/IUnit::self().baseFactor);
             wpt.setNogo(dlg.optionIsChecked());
         }
     }

--- a/src/qmapshack/helpers/CElevationDialog.cpp
+++ b/src/qmapshack/helpers/CElevationDialog.cpp
@@ -35,14 +35,13 @@ CElevationDialog::CElevationDialog(QWidget * parent, QVariant &val, const QVaria
     connect(pushReset,  &QPushButton::clicked, this, &CElevationDialog::slotReset);
     connect(toolGetEle, &QToolButton::clicked, this, &CElevationDialog::slotGetEle);
 
-    QString str, unit;
-    IUnit::self().meter2elevation(100, str, unit);
-
-    labelUnit->setText(unit);
+    labelUnit->setText(IUnit::self().elevationUnit);
     if(val != NOINT)
     {
-        IUnit::self().meter2elevation(val.toDouble(), str, unit);
-        lineValue->setText(str);
+        QString unit;
+        QString value;
+        IUnit::self().meter2elevation(val.toDouble(), value, unit);
+        lineValue->setText(value);
     }
 }
 
@@ -58,7 +57,7 @@ void CElevationDialog::accept()
     }
     else
     {
-        val.setValue(lineValue->text().toDouble() / IUnit::self().basefactor);
+        val.setValue(lineValue->text().toDouble() / IUnit::self().elevationFactor);
     }
 
     QDialog::accept();

--- a/src/qmapshack/plot/CPlotProfile.cpp
+++ b/src/qmapshack/plot/CPlotProfile.cpp
@@ -99,7 +99,7 @@ void CPlotProfile::updateData()
     else
     {
         setXLabel(tr("Distance [%1]").arg(unit));
-        setYLabel(tr("Ele. [%1]").arg(IUnit::self().baseunit));
+        setYLabel(tr("Ele. [%1]").arg(IUnit::self().elevationUnit));
     }
 
     QPolygonF lineEle;
@@ -108,7 +108,7 @@ void CPlotProfile::updateData()
 
     IGisProject * project = dynamic_cast<IGisProject*>(trk->parent());
 
-    qreal basefactor = IUnit::self().basefactor;
+    qreal elevationFactor = IUnit::self().elevationFactor;
     const CTrackData& t = trk->getTrackData();
     for(const CTrackData::trkpt_t& trkpt : t)
     {
@@ -122,7 +122,7 @@ void CPlotProfile::updateData()
             continue;
         }
 
-        lineEle << QPointF(trkpt.distance, trkpt.ele * basefactor);
+        lineEle << QPointF(trkpt.distance, trkpt.ele * elevationFactor);
         coords << QPointF(trkpt.lon * DEG_TO_RAD, trkpt.lat * DEG_TO_RAD);
         lineDem << QPointF(trkpt.distance, NOFLOAT);
 
@@ -153,7 +153,7 @@ void CPlotProfile::updateData()
             }
 
             CPlotData::point_t tag;
-            tag.point = QPointF(trkpt.distance, trkpt.ele * basefactor);
+            tag.point = QPointF(trkpt.distance, trkpt.ele * elevationFactor);
             tag.icon  = CDraw::number(cnt++, Qt::black);
             tag.label = trkpt.desc.size() < 20 ? trkpt.desc : trkpt.desc.left(17) + "...";
             data->tags << tag;
@@ -163,7 +163,7 @@ void CPlotProfile::updateData()
     CMainWindow::self().getElevationAt(coords, lineDem);
     for(QPointF& pt : lineDem)
     {
-        pt.ry() *= basefactor;
+        pt.ry() *= elevationFactor;
     }
 
     newLine(lineEle, "GPS");
@@ -177,7 +177,7 @@ void CPlotProfile::updateData()
         QPolygonF spline;
         for(const QPointF& pt : lineEle)
         {
-            spline << QPointF(pt.x(), trk->getElevationInterpolated(pt.x()) * basefactor);
+            spline << QPointF(pt.x(), trk->getElevationInterpolated(pt.x()) * elevationFactor);
         }
 
         addLine(spline, "Interp.");

--- a/src/qmapshack/units/CUnitAviation.cpp
+++ b/src/qmapshack/units/CUnitAviation.cpp
@@ -21,38 +21,10 @@
 #include "units/CUnitAviation.h"
 
 CUnitAviation::CUnitAviation(QObject * parent)
-    : IUnit(eTypeAviation, "ft", footPerMeter, "kn", meterPerSecToKnots, parent)
+    : IUnit(eTypeAviation, "ft", footPerMeter, "kn", meterPerSecToKnots, "ft", footPerMeter, parent)
 {
 }
 
-
-void CUnitAviation::meter2elevation(qreal meter, QString& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT)
-    {
-        val  = "-";
-        unit.clear();
-    }
-    else
-    {
-        val.sprintf("%1.0f", meter * footPerMeter);
-        unit = "ft";
-    }
-}
-
-void CUnitAviation::meter2elevation(qreal meter, qreal& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT)
-    {
-        val  = NOFLOAT;
-        unit.clear();
-    }
-    else
-    {
-        val =  meter * footPerMeter;
-        unit = "ft";
-    }
-}
 
 void CUnitAviation::meter2distance(qreal meter, QString& val, QString& unit) const /* override */
 {

--- a/src/qmapshack/units/CUnitAviation.h
+++ b/src/qmapshack/units/CUnitAviation.h
@@ -25,15 +25,9 @@
 class CUnitAviation : public IUnit
 {
 public:
-    static constexpr qreal footPerMeter = 3.28084;
-    static constexpr qreal nauticalMilePerMeter = 1. / 1852;
-    static constexpr qreal meterPerSecToKnots = 1.94361780;
-
     CUnitAviation(QObject * parent);
     virtual ~CUnitAviation() = default;
 
-    void meter2elevation(qreal meter, QString& val, QString& unit) const override;
-    void meter2elevation(qreal meter, qreal& val, QString& unit) const override;
     void meter2distance(qreal meter, QString& val, QString& unit) const override;
     void meter2distance(qreal meter, qreal& val, QString& unit) const override;
     void meter2area(qreal meter, QString& val, QString& unit) const override;

--- a/src/qmapshack/units/CUnitImperial.cpp
+++ b/src/qmapshack/units/CUnitImperial.cpp
@@ -20,38 +20,10 @@
 #include "units/CUnitImperial.h"
 
 CUnitImperial::CUnitImperial(QObject * parent)
-    : IUnit(eTypeImperial, "ft", footPerMeter, "mi/h", meterPerSecToMilePerHour, parent)
+    : IUnit(eTypeImperial, "ft", footPerMeter, "mi/h", meterPerSecToMilePerHour, "ft", footPerMeter, parent)
 {
 }
 
-
-void CUnitImperial::meter2elevation(qreal meter, QString& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT)
-    {
-        val  = "-";
-        unit.clear();
-    }
-    else
-    {
-        val.sprintf("%1.0f", meter * footPerMeter);
-        unit = "ft";
-    }
-}
-
-void CUnitImperial::meter2elevation(qreal meter, qreal& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT)
-    {
-        val  = NOFLOAT;
-        unit.clear();
-    }
-    else
-    {
-        val =  meter * footPerMeter;
-        unit = "ft";
-    }
-}
 
 void CUnitImperial::meter2distance(qreal meter, QString& val, QString& unit) const /* override */
 {

--- a/src/qmapshack/units/CUnitImperial.h
+++ b/src/qmapshack/units/CUnitImperial.h
@@ -24,15 +24,9 @@
 class CUnitImperial : public IUnit
 {
 public:
-    static constexpr qreal footPerMeter = 3.28084;
-    static constexpr qreal milePerMeter = 0.6213699E-3;
-    static constexpr qreal meterPerSecToMilePerHour = 2.23693164;
-
     CUnitImperial(QObject * parent);
     virtual ~CUnitImperial() = default;
 
-    void meter2elevation(qreal meter, QString& val, QString& unit) const override;
-    void meter2elevation(qreal meter, qreal& val, QString& unit) const override;
     void meter2distance(qreal meter, QString& val, QString& unit) const override;
     void meter2distance(qreal meter, qreal& val, QString& unit) const override;
     void meter2area(qreal meter, QString& val, QString& unit) const override;

--- a/src/qmapshack/units/CUnitMetric.cpp
+++ b/src/qmapshack/units/CUnitMetric.cpp
@@ -19,38 +19,10 @@
 #include "units/CUnitMetric.h"
 
 CUnitMetric::CUnitMetric(QObject * parent)
-    : IUnit(eTypeMetric, "m", 1.0, "km/h", 3.6, parent)
+    : IUnit(eTypeMetric, "m", 1.0, "km/h", 3.6, "m", 1.0, parent)
 {
 }
 
-
-void CUnitMetric::meter2elevation(qreal meter, QString& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT || meter == NOINT)
-    {
-        val  = "-";
-        unit.clear();
-    }
-    else
-    {
-        val.sprintf("%1.0f", meter);
-        unit = "m";
-    }
-}
-
-void CUnitMetric::meter2elevation(qreal meter, qreal& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT || meter == NOINT)
-    {
-        val  = NOFLOAT;
-        unit.clear();
-    }
-    else
-    {
-        val = meter;
-        unit = "m";
-    }
-}
 
 void CUnitMetric::meter2distance(qreal meter, QString& val, QString& unit) const /* override */
 {
@@ -114,18 +86,18 @@ void CUnitMetric::meter2speed(qreal meter, QString& val, QString& unit) const /*
     }
     else if (meter < 0.27)
     {
-        val.sprintf("%1.0f", meter * speedfactor * 1000);
+        val.sprintf("%1.0f", meter * speedFactor * 1000);
         unit = "m/h";
     }
     else if (meter < 10.0)
     {
-        val.sprintf("%1.1f", meter * speedfactor);
-        unit = speedunit;
+        val.sprintf("%1.1f", meter * speedFactor);
+        unit = speedUnit;
     }
     else
     {
-        val.sprintf("%1.0f", meter * speedfactor);
-        unit = speedunit;
+        val.sprintf("%1.0f", meter * speedFactor);
+        unit = speedUnit;
     }
 }
 
@@ -138,13 +110,13 @@ void CUnitMetric::meter2speed(qreal meter, qreal& val, QString& unit) const /* o
     }
     else if (meter < 0.27)
     {
-        val = meter * speedfactor * 1000;
+        val = meter * speedFactor * 1000;
         unit = "m/h";
     }
     else
     {
-        val = meter * speedfactor;
-        unit = speedunit;
+        val = meter * speedFactor;
+        unit = speedUnit;
     }
 }
 

--- a/src/qmapshack/units/CUnitMetric.h
+++ b/src/qmapshack/units/CUnitMetric.h
@@ -27,8 +27,6 @@ public:
     CUnitMetric(QObject * parent);
     virtual ~CUnitMetric() = default;
 
-    void meter2elevation(qreal meter, QString& val, QString& unit) const override;
-    void meter2elevation(qreal meter, qreal& val, QString& unit) const override;
     void meter2distance(qreal meter, QString& val, QString& unit) const override;
     void meter2distance(qreal meter, qreal& val, QString& unit) const override;
     void meter2speed(qreal meter, QString& val, QString& unit) const override;

--- a/src/qmapshack/units/CUnitNautic.cpp
+++ b/src/qmapshack/units/CUnitNautic.cpp
@@ -20,37 +20,8 @@
 #include "units/CUnitNautic.h"
 
 CUnitNautic::CUnitNautic(QObject * parent)
-    : IUnit(eTypeNautic, "nm", 0.00053989, "nm/h", 1.94361780, parent)
+    : IUnit(eTypeNautic, "nm", 0.00053989, "nm/h", 1.94361780, "m", 1.0, parent)
 {
-}
-
-
-void CUnitNautic::meter2elevation(qreal meter, QString& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT)
-    {
-        val  = "-";
-        unit.clear();
-    }
-    else
-    {
-        val.sprintf("%1.0f", meter);
-        unit = "m";
-    }
-}
-
-void CUnitNautic::meter2elevation(qreal meter, qreal& val, QString& unit) const /* override */
-{
-    if(meter == NOFLOAT)
-    {
-        val  = NOFLOAT;
-        unit.clear();
-    }
-    else
-    {
-        val = meter;
-        unit = "m";
-    }
 }
 
 void CUnitNautic::meter2distance(qreal meter, QString& val, QString& unit) const /* override */
@@ -62,8 +33,8 @@ void CUnitNautic::meter2distance(qreal meter, QString& val, QString& unit) const
     }
     else
     {
-        val.sprintf("%1.2f", meter * basefactor);
-        unit = baseunit;
+        val.sprintf("%1.2f", meter * baseFactor);
+        unit = baseUnit;
     }
 }
 
@@ -76,8 +47,8 @@ void CUnitNautic::meter2distance(qreal meter, qreal& val, QString& unit) const /
     }
     else
     {
-        val = meter * basefactor;
-        unit = baseunit;
+        val = meter * baseFactor;
+        unit = baseUnit;
     }
 }
 
@@ -90,8 +61,8 @@ void CUnitNautic::meter2speed(qreal meter, QString& val, QString& unit) const /*
     }
     else
     {
-        val.sprintf("%1.2f", meter * speedfactor);
-        unit = speedunit;
+        val.sprintf("%1.2f", meter * speedFactor);
+        unit = speedUnit;
     }
 }
 
@@ -104,8 +75,8 @@ void CUnitNautic::meter2speed(qreal meter, qreal& val, QString& unit) const /* o
     }
     else
     {
-        val=meter * speedfactor;
-        unit = speedunit;
+        val=meter * speedFactor;
+        unit = speedUnit;
     }
 }
 
@@ -144,6 +115,6 @@ qreal CUnitNautic::elevation2meter(const QString& val) const /* override */
 
 void CUnitNautic::meter2unit(qreal meter, qreal& scale, QString&  unit) const
 {
-    scale = basefactor;
+    scale = baseFactor;
     unit  = "nm";
 }

--- a/src/qmapshack/units/CUnitNautic.h
+++ b/src/qmapshack/units/CUnitNautic.h
@@ -27,8 +27,6 @@ public:
     CUnitNautic(QObject * parent);
     virtual ~CUnitNautic() = default;
 
-    void meter2elevation(qreal meter, QString& val, QString& unit) const override;
-    void meter2elevation(qreal meter, qreal& val, QString& unit) const override;
     void meter2distance(qreal meter, QString& val, QString& unit) const override;
     void meter2distance(qreal meter, qreal& val, QString& unit) const override;
     void meter2speed(qreal meter, QString& val, QString& unit) const override;

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -434,23 +434,54 @@ const QRegExp IUnit::reCoord4("^\\s*([N|S]){1}\\s*([0-9]+)\\W+([0-9]+)\\W+([0-9]
 
 const QRegExp IUnit::reCoord5("^\\s*([-0-9]+\\.[0-9]+)([N|S])\\s+([-0-9]+\\.[0-9]+)([W|E])\\s*$");
 
-IUnit::IUnit(const type_e &type, const QString& baseunit, const qreal basefactor, const QString& speedunit, const qreal speedfactor, QObject * parent)
+IUnit::IUnit(const type_e &type, const QString& baseUnit, const qreal baseFactor, const QString& speedUnit, const qreal speedFactor, const QString &elevationUnit, const qreal elevationFactor, QObject * parent)
     : QObject(parent)
     , type(type)
-    , baseunit(baseunit)
-    , basefactor(basefactor)
-    , speedunit(speedunit)
-    , speedfactor(speedfactor)
+    , baseUnit(baseUnit)
+    , baseFactor(baseFactor)
+    , speedUnit(speedUnit)
+    , speedFactor(speedFactor)
+    , elevationUnit(elevationUnit)
+    , elevationFactor(elevationFactor)
 {
     //there can be only one...
     delete m_self;
     m_self = this;
 }
 
+void IUnit::meter2elevation(qreal meter, QString& val, QString& unit) const
+{
+    if(meter == NOFLOAT)
+    {
+        val  = "-";
+        unit.clear();
+    }
+    else
+    {
+        val.sprintf("%1.0f", meter * elevationFactor);
+        unit = elevationUnit;
+    }
+}
+
+void IUnit::meter2elevation(qreal meter, qreal& val, QString& unit) const
+{
+    if(meter == NOFLOAT)
+    {
+        val  = NOFLOAT;
+        unit.clear();
+    }
+    else
+    {
+        val = meter * elevationFactor;
+        unit = elevationUnit;
+    }
+}
+
+
 void IUnit::meter2base(qreal meter, QString& val, QString& unit) const
 {
-    unit = baseunit;
-    val.sprintf("%1.0f", meter * basefactor);
+    unit = baseUnit;
+    val.sprintf("%1.0f", meter * baseFactor);
 }
 
 bool IUnit::convert(qreal &value, QString &unit, const QString &targetUnit)
@@ -614,8 +645,8 @@ void IUnit::meter2speed(qreal meter, QString& val, QString& unit) const
         return;
     }
 
-    val.sprintf("%2.2f", meter * speedfactor);
-    unit = speedunit;
+    val.sprintf("%2.2f", meter * speedFactor);
+    unit = speedUnit;
 }
 
 void IUnit::meter2speed(qreal meter, qreal& val, QString& unit) const
@@ -627,8 +658,8 @@ void IUnit::meter2speed(qreal meter, qreal& val, QString& unit) const
         return;
     }
 
-    val = meter * speedfactor;
-    unit = speedunit;
+    val = meter * speedFactor;
+    unit = speedUnit;
 }
 
 void IUnit::seconds2time(quint32 ttime, QString& val, QString& unit) const

--- a/src/qmapshack/units/IUnit.h
+++ b/src/qmapshack/units/IUnit.h
@@ -34,6 +34,13 @@ class IUnit : public QObject
 {
     Q_OBJECT
 public:
+
+    static constexpr qreal footPerMeter = 3.28084;
+    static constexpr qreal nauticalMilePerMeter = 1. / 1852;
+    static constexpr qreal meterPerSecToKnots = 1.94361780;
+    static constexpr qreal milePerMeter = 0.6213699E-3;
+    static constexpr qreal meterPerSecToMilePerHour = 2.23693164;
+
     virtual ~IUnit() = default;
 
     static const IUnit& self()
@@ -42,8 +49,8 @@ public:
     }
 
     /// convert meter of elevation into a value and unit string
-    virtual void meter2elevation(qreal meter, QString& val, QString& unit) const = 0;
-    virtual void meter2elevation(qreal meter, qreal& val, QString& unit) const = 0;
+    virtual void meter2elevation(qreal meter, QString& val, QString& unit) const;
+    virtual void meter2elevation(qreal meter, qreal& val, QString& unit) const;
     virtual void feet2elevation(qreal feet, QString& val, QString& unit) const
     {
         meter2elevation(feet / 3.28084, val, unit);
@@ -113,10 +120,12 @@ public:
     static QByteArray pos2timezone(const QPointF& pos);
 
     const type_e type;
-    const QString baseunit;
-    const qreal basefactor;
-    const QString speedunit;
-    const qreal speedfactor;
+    const QString baseUnit;
+    const qreal baseFactor;
+    const QString speedUnit;
+    const qreal speedFactor;
+    const QString elevationUnit;
+    const qreal elevationFactor;
     static const char *tblTimezone[];
 
     enum tz_mode_e
@@ -165,7 +174,14 @@ public:
     static bool isValidCoordString(const QString& str);
 
 protected:
-    IUnit(const type_e& type, const QString& baseunit, const qreal basefactor, const QString& speedunit, const qreal speedfactor, QObject *parent);
+    IUnit(const type_e& type,
+          const QString& baseUnit,
+          const qreal baseFactor,
+          const QString& speedUnit,
+          const qreal speedFactor,
+          const QString& elevationUnit,
+          const qreal elevationFactor,
+          QObject *parent);
 
     static slope_mode_e slopeMode;
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#64

**Describe roughly what you have done:**

* Change factor and unit constants to camelCase naming
* Add factor and unit for elevation
* Move meter2elevation() methods to IUnit
* Fix a few locations where baseFactor and baseUnit where used for
elevation.

**What steps have to be done to perform a simple smoke test:**

Try to find all locations in the GUI where the elevation is used and test if it fit's for different unit settings.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
