### PR TITLE
[QMS-59] Add VERSION_SUFFIX to main widget title

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
 V1.XX.X
 [QMS-49] Add "elevation limit" to DEM to highlight elevation above the limit
 [QMS-58] Windows Build and Installer: use PROJ 6.2
+[QMS-59] Version information in window title does not contain VERSION_SUFFIX "development"
 [QMS-64] Cleanup code in IUnit and subclasses
+
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -94,7 +94,7 @@ CMainWindow::CMainWindow()
 
     pSelf = this;
     setupUi(this);
-    setWindowTitle(WHAT_STR);
+    setWindowTitle(WHAT_STR + (QString(VER_SUFFIX).isEmpty() ? "" : QString(".") + VER_SUFFIX));
     dockRealtime->toggleViewAction()->setChecked(false);
 
     CSearch::init();


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#59

**Describe roughly what you have done:**

Append the string for the widget title if `VERSION_SUFFIX` is set.

**What steps have to be done to perform a simple smoke test:**

Set `VERSION_SUFFIX` in `CMakeLists.txt`, compile and see if the app title has been appended.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
