### PR TITLE
[QMS-37] Inconsistent use of time zones

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-37] Inconsistent use of time zones
 [QMS-49] Add "elevation limit" to DEM to highlight elevation above the limit
 [QMS-58] Windows Build and Installer: use PROJ 6.2
 [QMS-59] Version information in window title does not contain VERSION_SUFFIX "development"

--- a/src/qmapshack/gis/trk/CTrackData.h
+++ b/src/qmapshack/gis/trk/CTrackData.h
@@ -175,6 +175,11 @@ public:
             }
         }
 
+        operator QPointF() const
+        {
+            return QPointF(lon, lat);
+        }
+
         act20_e activity = eAct20None;
         quint32 flags = 0;
         quint32 valid = 0;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#37

**Describe roughly what you have done:**

Query the current time zone setup and create time zone label and correct
date/time edit accordingly. Each of the 4 modes need special handling. 

**What steps have to be done to perform a simple smoke test:**

* Select one of the modes in View->Setup Time Zone
* Edit a track.
* Go to Filter->Change timestamp of track points->Change Time
* Check if the time zone and the time matches the current settings

The initial time is always the current time (UTC) transformed into the selected time zone.

For automatic mode create a track somewhere outside your time zone and test.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
