### PR TITLE
[QMS-73] Info of a geocache is not correctly shown in Copy Element Window

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ V1.XX.X
 [QMS-58] Windows Build and Installer: use PROJ 6.2
 [QMS-59] Version information in window title does not contain VERSION_SUFFIX "development"
 [QMS-64] Cleanup code in IUnit and subclasses
-
+[QMS-73] Info of a geocache is not correctly shown in Copy Element Window
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/IGisItem.h
+++ b/src/qmapshack/gis/IGisItem.h
@@ -99,6 +99,12 @@ public:
             dgpsid(NOINT)
         {
         }
+
+        operator QPointF() const
+        {
+            return QPointF(lon, lat);
+        }
+
         // -- all gpx tags - start
         qreal lat;
         qreal lon;

--- a/src/qmapshack/gis/trk/CTrackData.h
+++ b/src/qmapshack/gis/trk/CTrackData.h
@@ -175,11 +175,6 @@ public:
             }
         }
 
-        operator QPointF() const
-        {
-            return QPointF(lon, lat);
-        }
-
         act20_e activity = eAct20None;
         quint32 flags = 0;
         quint32 valid = 0;

--- a/src/qmapshack/gis/wpt/CDetailsGeoCache.cpp
+++ b/src/qmapshack/gis/wpt/CDetailsGeoCache.cpp
@@ -130,22 +130,12 @@ CDetailsGeoCache::CDetailsGeoCache(CGisItemWpt &wpt, QWidget *parent)
     webDesc->setPage(webDescPage);
     webDesc->setHtml(desc);
 
-    QDateTime lastFound;
-    QString logs;
-    for(const CGisItemWpt::geocachelog_t& log:geocache.logs)
-    {
-        QString thislog = log.text;
-        logs+="<p><b>"+log.date.date().toString(Qt::SystemLocaleShortDate) + ": " + log.type + tr(" by ") + log.finder + "</b></p><p>" + thislog.replace("\n", "<br/>") + "</p><hr>";
-        if(lastFound.isValid() == false || (log.type == "Found It" && log.date > lastFound))
-        {
-            lastFound=log.date;
-        }
-    }
+    const QDateTime& lastFound = geocache.getLastFound();
     labelLastFound->setText(lastFound.date().toString(Qt::SystemLocaleShortDate));
 
     CWebPage * webLogPage = new CWebPage(webLogs);
     webLogs->setPage(webLogPage);
-    webLogs->setHtml(logs);
+    webLogs->setHtml(geocache.getLogs());
 
     timerDownload = new QTimer(this);
     timerDownload->setSingleShot(true);

--- a/src/qmapshack/gis/wpt/CGisItemWpt.h
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.h
@@ -86,6 +86,8 @@ public:
         const static QList<QString> attributeMeanings;
         static QList<QString> attributeMeaningsTranslated;
         static QList<QString> initAttributeMeaningsTranslated();
+        QDateTime getLastFound() const;
+        QString getLogs() const;
     };
 
     struct image_t

--- a/src/qmapshack/helpers/CSelectCopyAction.cpp
+++ b/src/qmapshack/helpers/CSelectCopyAction.cpp
@@ -34,8 +34,6 @@ CSelectCopyAction::CSelectCopyAction(const IGisItem *src, const IGisItem *tar, Q
     labelIcon2->setPixmap(tar->getDisplayIcon());
     labelInfo2->setText(tar->getInfo(IGisItem::eFeatureShowName));
 
-    adjustSize();
-
     connect(pushCopy,  &QPushButton::clicked, this, &CSelectCopyAction::slotSelectResult);
     connect(pushSkip,  &QPushButton::clicked, this, &CSelectCopyAction::slotSelectResult);
     connect(pushClone, &QPushButton::clicked, this, &CSelectCopyAction::slotSelectResult);

--- a/src/qmapshack/helpers/ISelectCopyAction.ui
+++ b/src/qmapshack/helpers/ISelectCopyAction.ui
@@ -6,42 +6,41 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>471</width>
-    <height>251</height>
+    <width>449</width>
+    <height>408</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Copy item...</string>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::ExpandingFieldsGrow</enum>
-   </property>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="pushCopy">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="1">
+    <widget class="QPushButton" name="pushSkip">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="minimumSize">
+      <size>
+       <width>330</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="text">
-      <string>Replace existing item</string>
+      <string>Do not copy item</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="labelIcon1">
-     <property name="text">
-      <string>TextLabel</string>
+   <item row="7" column="1">
+    <widget class="QLabel" name="labelInfo2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="labelInfo1">
      <property name="text">
       <string>TextLabel</string>
      </property>
@@ -60,31 +59,47 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="pushSkip">
+   <item row="6" column="1">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Keep item:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="2">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QPushButton" name="pushCopy">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="minimumSize">
+      <size>
+       <width>330</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="text">
-      <string>Do not copy item</string>
+      <string>Replace existing item</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="labelIcon2">
-     <property name="text">
-      <string>TextLabel</string>
+   <item row="2" column="1">
+    <widget class="QLabel" name="labelInfo1">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QLabel" name="labelInfo2">
      <property name="text">
       <string>TextLabel</string>
      </property>
@@ -96,15 +111,8 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QPushButton" name="pushClone">
+   <item row="13" column="1">
+    <widget class="QCheckBox" name="checkAllOtherToo">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -112,7 +120,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Create a clone</string>
+      <string>And for all other items, too.</string>
      </property>
     </widget>
    </item>
@@ -123,15 +131,33 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QLabel" name="label_2">
+   <item row="10" column="1">
+    <widget class="QPushButton" name="pushClone">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>330</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="text">
-      <string>Keep item:</string>
+      <string>Create a clone</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="11" column="1">
     <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>The clone's name will be appended with '_Clone'</string>
      </property>
@@ -140,19 +166,45 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="Line" name="line_3">
+   <item row="8" column="0" colspan="2">
+    <widget class="Line" name="line_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
-    <widget class="QCheckBox" name="checkAllOtherToo">
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelIcon1">
      <property name="text">
-      <string>And for all other items, too.</string>
+      <string>TextLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
     </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="labelIcon2">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#73

**Describe roughly what you have done:**

* Finetune dialog layout
* Create getLastLog() and getLogs() in CGisItemWpt::geocache_t
* Enhance getInfo() text for geocache

**What steps have to be done to perform a simple smoke test:**

* Open a pocket query
* Copy first cache into another project
* Copy the same cache into the same project

Enhanced test:

* Get an updated pocket query
* Copy the same cache into the same project

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
