### PR TITLE
[QMS-83] Application Crash

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-59] Version information in window title does not contain VERSION_SUFFIX "development"
 [QMS-64] Cleanup code in IUnit and subclasses
 [QMS-73] Info of a geocache is not correctly shown in Copy Element Window
+[QMS-83] Application Crash
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
@@ -69,6 +69,11 @@ bool CLineOpAddPoint::abortStep()
 
 void CLineOpAddPoint::leftClick(const QPoint& pos)
 {
+    if(idxFocus == NOIDX)
+    {
+        return;
+    }
+
     if(addPoint)
     {
         // drop the new point at current position


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#83

**Describe roughly what you have done:**

This is a race condition between events for left and right click when
adding points to a track. If the right click ist handled first `idxFocus` is
set to NOIDX. The following left click event did not check for an invalid
`idxFocus` resulting in an out of bounds array access.

-> Check for `idxFocus == NOIDX` 

**What steps have to be done to perform a simple smoke test:**

Follow the instructions in the ticket.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
