### PR TITLE
Qms 80

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ project(QMapShack VERSION 1.14.0)
 # FOR A RELEASE:
 # remove "development" for a release
 set(VERSION_SUFFIX "development")
-# !!! Do not forget to update versions in the sub-repos, too!!!
 
 
 ###############################################################################################
@@ -129,6 +128,16 @@ endif(MSVC)
 if(UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -lstdc++ -lm")
     add_definitions(-Wall -Wpedantic -Wno-switch -Wno-strict-aliasing)
+
+    # Use ASAN for development versions
+    if(NOT ${VERSION_SUFFIX} STREQUAL "")
+        check_cxx_compiler_flag("-fsanitize=address" WITH_ASAN)
+        if(NOT ${WITH_ASAN})
+            message(FATAL_ERROR "Could not find ASAN! Please install ASAN if you want to compile development versions." )
+        endif(NOT ${WITH_ASAN})
+        message(STATUS "Using ASAN")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+    endif(NOT ${VERSION_SUFFIX} STREQUAL "")
 endif(UNIX)
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-59] Version information in window title does not contain VERSION_SUFFIX "development"
 [QMS-64] Cleanup code in IUnit and subclasses
 [QMS-73] Info of a geocache is not correctly shown in Copy Element Window
+[QMS-80] Use ASAN to enhance code quality
 [QMS-83] Application Crash
 
 V1.14.0

--- a/src/qmapshack/gis/fit/defs/CFitBaseType.cpp
+++ b/src/qmapshack/gis/fit/defs/CFitBaseType.cpp
@@ -28,6 +28,11 @@ CFitBaseType::CFitBaseType() : CFitBaseType(eBaseTypeNrInvalid, "invalid", 0,
 CFitBaseType::CFitBaseType(fit_base_type_nr_e baseTypeNr, QString name, quint8 size, std::initializer_list<quint8> invalid)
     : typeSize(size), baseTypeNr(baseTypeNr), namestr(name)
 {
+    if(size == 0)
+    {
+        return;
+    }
+
     quint8 i = (quint8) (size - 1);
     for(quint8 bit : invalid)
     {

--- a/src/qmapshack/gis/fit/defs/CFitBaseType.h
+++ b/src/qmapshack/gis/fit/defs/CFitBaseType.h
@@ -65,7 +65,7 @@ public:
 
 private:
     // fixed size to 8, which is enough for float64
-    quint8 invalidBytes[8];
+    quint8 invalidBytes[8] {0,0,0,0,0,0,0,0};
     quint8 typeSize;
     fit_base_type_nr_e baseTypeNr;
     QString namestr;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#80

**Describe roughly what you have done:**

* Check for Unix environment
* Enable ASAN compile and link flags for development versions
* Fix all immediate crashes due to memory violations.

**What steps have to be done to perform a simple smoke test:**

Compile and run QMapShack. The memory leak messages when terminating QMapShack are unavoidable as they are part of the Qt5 library.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [ ] yes,
- [x] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
