### PR TITLE
[QMS-100] Avoid whitespaces in project name and keywords

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-100] Avoid whitespaces in project name and keywords
 [QMS-37] Inconsistent use of time zones
 [QMS-43] Individual filter for each project
 [QMS-49] Add "elevation limit" to DEM to highlight elevation above the limit

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,4 @@
 V1.XX.X
-[QMS-100] Avoid whitespaces in project name and keywords
 [QMS-37] Inconsistent use of time zones
 [QMS-43] Individual filter for each project
 [QMS-49] Add "elevation limit" to DEM to highlight elevation above the limit
@@ -9,6 +8,7 @@ V1.XX.X
 [QMS-73] Info of a geocache is not correctly shown in Copy Element Window
 [QMS-80] Use ASAN to enhance code quality
 [QMS-83] Application Crash
+[QMS-100] Avoid whitespaces in project name and keywords
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -994,7 +994,7 @@ void CDetailsPrj::slotLinkActivated(const QString& link)
     if(link == "name")
     {
         QString name = QInputDialog::getText(this, tr("Edit name..."), tr("Enter new project name."), QLineEdit::Normal, prj.getName());
-        if(name.isEmpty())
+        if(name.trimmed().isEmpty())
         {
             return;
         }
@@ -1003,7 +1003,7 @@ void CDetailsPrj::slotLinkActivated(const QString& link)
     else if(link == "keywords")
     {
         QString keywords = QInputDialog::getText(this, tr("Edit keywords..."), tr("Enter keywords."), QLineEdit::Normal, prj.getKeywords());
-        if(keywords.isEmpty())
+        if(keywords.trimmed().isEmpty())
         {
             return;
         }
@@ -1021,7 +1021,7 @@ void CDetailsPrj::slotLinkActivated(const QUrl& url)
     if(url.path() == "name")
     {
         QString name = QInputDialog::getText(this, tr("Edit name..."), tr("Enter new project name."), QLineEdit::Normal, prj.getName());
-        if(!name.isEmpty())
+        if(!name.trimmed().isEmpty())
         {
             prj.setName(name);
         }


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a #):** QMS-#100

**Describe roughly what you have done:**

Trim project keywords and name
to avoid unique whitespaces for
name and keywords

I used QString QString::trimmed() const to avoid unique whitespaces 

**What steps have to be done to perform a simple smoke test:**
Simple test in GUI

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
