### PR TITLE
[QMS-89] Geo search hidden after restarting QMapShack

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-73] Info of a geocache is not correctly shown in Copy Element Window
 [QMS-80] Use ASAN to enhance code quality
 [QMS-83] Application Crash
+[QMS-89] Geo search hidden after restarting QMapShack
 [QMS-100] Avoid whitespaces in project name and keywords
 
 V1.14.0

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -476,6 +476,7 @@ CMainWindow::CMainWindow()
         }
     }
 
+    QTimer::singleShot(100, widgetGisWorkspace, SLOT(slotLateInit()));
 
     QTimer::singleShot(100, this, SLOT(slotSanityTest()));
 }

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -72,10 +72,6 @@ CGisWorkspace::CGisWorkspace(QMenu *menuProject, QWidget *parent)
     connect(treeWks, &CGisListWks::itemPressed, this, &CGisWorkspace::slotWksItemPressed);
     connect(treeWks, &CGisListWks::itemSelectionChanged, this, &CGisWorkspace::slotWksItemSelectionChanged);
     connect(treeWks, &CGisListWks::sigItemDeleted, this, &CGisWorkspace::slotWksItemSelectionChanged);
-
-    // [Issue #265] Delay the loading of the workspace to make sure the complete IUnit system
-    //              is up and running.
-    QTimer::singleShot(1000, treeWks, SLOT(slotLoadWorkspace()));
 }
 
 CGisWorkspace::~CGisWorkspace()
@@ -90,6 +86,13 @@ CGisWorkspace::~CGisWorkspace()
 
      */
     delete treeWks;
+}
+
+void CGisWorkspace::slotLateInit()
+{
+    // [Issue #265] Delay the loading of the workspace to make sure the complete IUnit system
+    //              is up and running.
+    QTimer::singleShot(1000, treeWks, SLOT(slotLoadWorkspace()));
 }
 
 void CGisWorkspace::setOpacity(qreal val)

--- a/src/qmapshack/gis/CGisWorkspace.h
+++ b/src/qmapshack/gis/CGisWorkspace.h
@@ -434,6 +434,7 @@ signals:
     void sigChanged();
 
 public slots:
+    void slotLateInit();
     void slotSaveAll();
     void slotWksItemSelectionReset();
     void slotActivityTrkByKey(const QList<IGisItem::key_t>& keys, trkact_t act);


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#89

**Describe roughly what you have done:**

The progress dialog shown when loading a garmin map operates
the event loop. This causes the workspace widget to proceed with
it's initialization. However at this point the QAction objects in
CMainWidget are not restored from configuration, yet.  Including
the Geo search action.

The fix adds a late initialization to CGisWorkspace. It is called via
timer short after the main widget's ctor loading all maps finished.

**What steps have to be done to perform a simple smoke test:**

* Load a Gamin map
* Enable geo search
* Close QMapShack
* Clear the file cache e.g. on Linux `sync; echo 2 > /proc/sys/vm/drop_caches`
* Start QMapShack.

After loading the map (progress bar) the geo search item must be in the workspace list.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
