### PR TITLE
[QMS-109] Direct link to geocaching logging page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V1.XX.X
 [QMS-83] Application Crash
 [QMS-89] Geo search hidden after restarting QMapShack
 [QMS-100] Avoid whitespaces in project name and keywords
+[QMS-109] Direct link to geocaching logging page
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -418,6 +418,11 @@ QString CGisItemWpt::getInfo(quint32 feature) const
                 str += QString("<a href='%1'>%2</a>").arg(link.uri.toString()).arg(link.text);
             }
         }
+        //Add logging link seperately, since the link to the geocache site is extracted from the gpx file.
+        if(geocache.hasData)
+        {
+            str += " <a href='https://www.geocaching.com/play/geocache/" + wpt.name + "/log'>Log Geocache</a>";
+        }
     }
 
     return str + "</div>";


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#109

**Describe roughly what you have done:**

I added a link to getInfo() for geocaches, so you can directly fo to the logging page. I diverged from the original feature request, since for me it desn't really make a large difference wether the "Log Geocache" is right aligned or not, so I decided that the effort was not worth it after a html snipped found online didn't achieve what I wanted.

**What steps have to be done to perform a simple smoke test:**

1. Click on a geocache on the map
2. Click on the logging link

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
