### PR TITLE
[QMS-111] Geocaching logging page - only 1 server used

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-89] Geo search hidden after restarting QMapShack
 [QMS-100] Avoid whitespaces in project name and keywords
 [QMS-109] Direct link to geocaching logging page
+[QMS-111] Geocaching logging page - only 1 server used
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -622,7 +622,24 @@ void CGisItemWpt::save(QDomNode& gpx, bool strictGpx11)
 
 void CGisItemWpt::readGcExt(const QDomNode& xmlCache)
 {
-    geocache.service = eGC;
+    //Geocaches only have one link
+    if(wpt.links.first().uri.url(QUrl::RemovePath).contains("geocaching.com"))
+    {
+        geocache.service = eGcCom;
+    }
+    else if(wpt.links.first().uri.url(QUrl::RemovePath).contains("opencaching"))
+    {
+        geocache.service = eOc;
+    }
+    else if(wpt.links.first().uri.url(QUrl::RemovePath).contains("geocaching.su"))
+    {
+        geocache.service = eGcSu;
+    }
+    else
+    {
+        geocache.service = eUnknown;
+    }
+
     const QDomNamedNodeMap& attr = xmlCache.attributes();
     geocache.id = attr.namedItem("id").nodeValue().toInt();
 
@@ -1168,5 +1185,4 @@ void CDeviceGarmin::createAdventureFromProject(IGisProject * project, const QStr
     out << "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>" << endl;
     out << doc.toString();
     file.close();
-
 }

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -419,7 +419,7 @@ QString CGisItemWpt::getInfo(quint32 feature) const
             }
         }
         //Add logging link seperately, since the link to the geocache site is extracted from the gpx file.
-        if(geocache.hasData)
+        if(geocache.hasData && geocache.service == eGcCom)
         {
             str += " <a href='https://www.geocaching.com/play/geocache/" + wpt.name + "/log'>Log Geocache</a>";
         }

--- a/src/qmapshack/gis/wpt/CGisItemWpt.h
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.h
@@ -40,7 +40,7 @@ class CGisItemWpt : public IGisItem
 {
     Q_DECLARE_TR_FUNCTIONS(CGisItemWpt)
 public:
-    enum geocacheservice_e {eGC, eOC, eTC};
+    enum geocacheservice_e {eGcCom, eOc, eTc, eGcSu, eUnknown=-1};
 
     struct geocachelog_t
     {
@@ -58,7 +58,7 @@ public:
      */
     struct geocache_t
     {
-        geocacheservice_e service = eOC;
+        geocacheservice_e service = eUnknown;
         bool hasData = false;
         quint32 id = 0;
         bool available = true;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#111

**Describe roughly what you have done:**

* Added recognition for listing services
* Only display logging link for geocaching.com listings

**What steps have to be done to perform a simple smoke test:**

1. Open geocaches from different listing services
2. Open "speech bubble" for each of those

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
