### PR TITLE
[QMS-116] Filter edit field lost

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ V1.XX.X
 [QMS-100] Avoid whitespaces in project name and keywords
 [QMS-109] Direct link to geocaching logging page
 [QMS-111] Geocaching logging page - only 1 server used
+[QMS-116] Filter edit field lost
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/search/CProjectFilterItem.cpp
+++ b/src/qmapshack/gis/search/CProjectFilterItem.cpp
@@ -16,6 +16,7 @@
 
 **********************************************************************************************/
 #include "CProjectFilterItem.h"
+#include <gis/CGisListWks.h>
 #include <gis/search/CSearchLineEdit.h>
 
 CProjectFilterItem::CProjectFilterItem(IGisProject *parent) : QTreeWidgetItem ((QTreeWidgetItem*)parent)
@@ -39,6 +40,6 @@ void CProjectFilterItem::showLineEdit(CSearch *search)
         }
         lineEdit = new CSearchLineEdit(treeWidget(), parent, search);
 
-        treeWidget()->setItemWidget(this, 1, lineEdit);
+        treeWidget()->setItemWidget(this, CGisListWks::eColumnName, lineEdit);
     }
 }

--- a/src/qmapshack/gis/search/CSearch.cpp
+++ b/src/qmapshack/gis/search/CSearch.cpp
@@ -507,6 +507,8 @@ QMap<searchProperty_e, QString> CSearch::initSearchPropertyMeaningMap()
     map.insert(eSearchPropertyGeneralDate, tr("searches the Date"));
     map.insert(eSearchPropertyGeneralComment, tr("searches the Comment"));
     map.insert(eSearchPropertyGeneralDescription, tr("searches the Description"));
+    map.insert(eSearchPropertyGeneralKeywords, tr("searches the Keywords"));
+    map.insert(eSearchPropertyGeneralRating, tr("compares the Rating"));
 
     //Area keywords
     map.insert(eSearchPropertyAreaArea, tr("searches the area"));


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#116

**Describe roughly what you have done:**

* Fixed the cause of losing the field
* Add missing descriptions

**What steps have to be done to perform a simple smoke test:**

1. Open a project
2. Filter the project
3. The filter field should be there regardless of the rating column being shown or not.

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
