### PR TITLE
[QMS-118] Too much whitespace in extended search help window

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ V1.XX.X
 [QMS-109] Direct link to geocaching logging page
 [QMS-111] Geocaching logging page - only 1 server used
 [QMS-116] Filter edit field lost
+[QMS-118] Too much whitespace in extended search help window
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/search/ISearchExplanationDialog.ui
+++ b/src/qmapshack/gis/search/ISearchExplanationDialog.ui
@@ -23,26 +23,40 @@
    <iconset resource="../../resources.qrc">
     <normaloff>:/icons/48x48/CSrcUnknown.png</normaloff>:/icons/48x48/CSrcUnknown.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QTextBrowser" name="textBrowserExplanation"/>
-   </item>
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Following keywords are available for searching:</string>
+    <widget class="QSplitter" name="splitter_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
+     <widget class="QTextBrowser" name="textBrowserExplanation"/>
+     <widget class="QWidget" name="">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Following keywords are available for searching:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSplitter" name="splitter">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <widget class="QListWidget" name="listWidgetProperties"/>
+         <widget class="QListWidget" name="listWidgetComparison"/>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QListWidget" name="listWidgetProperties"/>
-     </item>
-     <item>
-      <widget class="QListWidget" name="listWidgetComparison"/>
-     </item>
-    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#118

**Describe roughly what you have done:**

I enabled user to resize boxes in the window

**What steps have to be done to perform a simple smoke test:**

1. Open help dialog for extended search

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
