### PR TITLE
[QMS-119] Better handling of disabled and archived geocaches

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ V1.XX.X
 [QMS-111] Geocaching logging page - only 1 server used
 [QMS-116] Filter edit field lost
 [QMS-118] Too much whitespace in extended search help window
+[QMS-119] Better handling of disabled and archived geocaches
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/search/CSearch.cpp
+++ b/src/qmapshack/gis/search/CSearch.cpp
@@ -471,6 +471,7 @@ QMap<QString, searchProperty_e> CSearch::initSearchPropertyEnumMap()
     map.insert(tr("size"), eSearchPropertyGeocacheSize);
     map.insert(tr("GCCode"), eSearchPropertyGeocacheGCCode);
     map.insert(tr("GCName"), eSearchPropertyGeocacheGCName);
+    map.insert(tr("status"), eSearchPropertyGeocacheStatus);
 
     //Waypoint keywords
 
@@ -521,6 +522,7 @@ QMap<searchProperty_e, QString> CSearch::initSearchPropertyMeaningMap()
     map.insert(eSearchPropertyGeocacheSize, tr("searches the size of a geocache. (micro, small, regular, large)"));
     map.insert(eSearchPropertyGeocacheGCCode, tr("searches the GCCode of a geocache."));
     map.insert(eSearchPropertyGeocacheGCName, tr("searches the Name of a geocache."));
+    map.insert(eSearchPropertyGeocacheStatus, tr("searches the status of a geocache. (available, not available, archived)"));
 
     //Waypoint keywords
 

--- a/src/qmapshack/gis/search/CSearch.h
+++ b/src/qmapshack/gis/search/CSearch.h
@@ -84,6 +84,7 @@ enum searchProperty_e: unsigned int
     eSearchPropertyGeocacheSize,
     eSearchPropertyGeocacheGCCode,
     eSearchPropertyGeocacheGCName,
+    eSearchPropertyGeocacheStatus,
 
     //Waypoint keywords
 

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -468,7 +468,14 @@ void CGisItemWpt::setIcon()
 {
     if(geocache.hasData)
     {
-        IGisItem::setIcon(CWptIconManager::self().getWptIconByName(geocache.type, focus));
+        if(geocache.available)
+        {
+            IGisItem::setIcon(CWptIconManager::self().getWptIconByName(geocache.type, focus));
+        }
+        else
+        {
+            IGisItem::setIcon(CWptIconManager::self().getWptIconByName("gray:"+geocache.type, focus));
+        }
     }
     else
     {

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -1339,6 +1339,22 @@ QMap<searchProperty_e, CGisItemWpt::fSearch> CGisItemWpt::initKeywordLambdaMap()
         searchValue.str1 = item->geocache.name;
         return searchValue;
     });
+    map.insert(eSearchPropertyGeocacheStatus, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        if(item->geocache.archived)
+        {
+            searchValue.str1 = tr("archived");
+        }
+        else if (item->geocache.available)
+        {
+            searchValue.str1 = tr("available");
+        }
+        else
+        {
+            searchValue.str1 = tr("not available");
+        }
+        return searchValue;
+    });
     return map;
 }
 

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -49,6 +49,16 @@ void CWptIconManager::removeNumberedBullets()
     mapNumberedBullets.clear();
 }
 
+QPixmap CWptIconManager::createGrayscale(QString path)
+{
+    QPixmap pixmap(path);
+    QBitmap alpha = pixmap.createHeuristicMask();
+    QImage image = pixmap.toImage().convertToFormat(QImage::Format_Grayscale8);
+    QPixmap pixmap_gray = QPixmap::fromImage(image.convertToFormat(QImage::Format_ARGB32));
+    pixmap_gray.setMask(alpha);
+    return pixmap_gray;
+}
+
 void CWptIconManager::init()
 {
     wptIcons.clear();
@@ -106,10 +116,26 @@ void CWptIconManager::init()
     setWptIconByName("Unknown Cache", "://icons/geocaching/icons/unknown.png");
     setWptIconByName("Wherigo Cache", "://icons/geocaching/icons/wherigo.png");
     setWptIconByName("Event Cache", "://icons/geocaching/icons/event.png");
+    setWptIconByName("Mega-Event Cache", "://icons/geocaching/icons/mega.png");
+    setWptIconByName("Giga-Event Cache", "://icons/geocaching/icons/giga.png");
+    setWptIconByName("Cache In Trash Out Event", "://icons/geocaching/icons/cito.png");
     setWptIconByName("Earthcache", "://icons/geocaching/icons/earth.png");
     setWptIconByName("Letterbox Hybrid", "://icons/geocaching/icons/letterbox.png");
     setWptIconByName("Virtual Cache", "://icons/geocaching/icons/virtual.png");
     setWptIconByName("Webcam Cache", "://icons/geocaching/icons/webcam.png");
+
+    setWptIconByName("gray:Traditional Cache", createGrayscale("://icons/geocaching/icons/traditional.png"));
+    setWptIconByName("gray:Multi-cache", createGrayscale("://icons/geocaching/icons/multi.png"));
+    setWptIconByName("gray:Unknown Cache", createGrayscale("://icons/geocaching/icons/unknown.png"));
+    setWptIconByName("gray:Wherigo Cache", createGrayscale("://icons/geocaching/icons/wherigo.png"));
+    setWptIconByName("gray:Event Cache", createGrayscale("://icons/geocaching/icons/event.png"));
+    setWptIconByName("gray:Mega-Event Cache", createGrayscale("://icons/geocaching/icons/mega.png"));
+    setWptIconByName("gray:Giga-Event Cache", createGrayscale("://icons/geocaching/icons/giga.png"));
+    setWptIconByName("gray:Cache In Trash Out Event", createGrayscale("://icons/geocaching/icons/cito.png"));
+    setWptIconByName("gray:Earthcache", createGrayscale("://icons/geocaching/icons/earth.png"));
+    setWptIconByName("gray:Letterbox Hybrid", createGrayscale("://icons/geocaching/icons/letterbox.png"));
+    setWptIconByName("gray:Virtual Cache", createGrayscale("://icons/geocaching/icons/virtual.png"));
+    setWptIconByName("gray:Webcam Cache", createGrayscale("://icons/geocaching/icons/webcam.png"));
 
     SETTINGS;
     QDir dirIcon(cfg.value("Paths/externalWptIcons", IAppSetup::getPlatformInstance()->userDataPath("WaypointIcons")).toString());

--- a/src/qmapshack/helpers/CWptIconManager.h
+++ b/src/qmapshack/helpers/CWptIconManager.h
@@ -76,6 +76,8 @@ private:
     QMap<QString, icon_t> wptIcons;
 
     QMap<qint32, QString> mapNumberedBullets;
+
+    QPixmap createGrayscale(QString path);
 };
 
 #endif //CWPTICONMANAGER_H


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#119

**Describe roughly what you have done:**

I added the possibility to filter for the status of a geocache and greyed out geocaches that are disabled.

**What steps have to be done to perform a simple smoke test:**

1. Open a file with active, disabled and archived geocaches
2. Filter for "status with archived" or similar
3. See that the icon is grey

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
