### PR TITLE
[QMS-126] Wrong search results of status search

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,8 @@ V1.XX.X
 [QMS-118] Too much whitespace in extended search help window
 [QMS-119] Better handling of disabled and archived geocaches
 [QMS-125] Missing icon for not available geocache
+[QMS-126] Wrong results searching for geocache status
+
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -1348,11 +1348,16 @@ QMap<searchProperty_e, CGisItemWpt::fSearch> CGisItemWpt::initKeywordLambdaMap()
     });
     map.insert(eSearchPropertyGeocacheStatus, [](CGisItemWpt* item){
         searchValue_t searchValue;
+        if(!item->geocache.hasData)
+        {
+            return searchValue;
+        }
+
         if(item->geocache.archived)
         {
             searchValue.str1 = tr("archived");
         }
-        else if (item->geocache.available)
+        else if(item->geocache.available)
         {
             searchValue.str1 = tr("available");
         }
@@ -1360,6 +1365,7 @@ QMap<searchProperty_e, CGisItemWpt::fSearch> CGisItemWpt::initKeywordLambdaMap()
         {
             searchValue.str1 = tr("not available");
         }
+
         return searchValue;
     });
     return map;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#126

**Describe roughly what you have done:**

Added an if clause to fix the error.

**What steps have to be done to perform a simple smoke test:**

1. Search for `status equals available `
2. No waypoints should be shown

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
