### PR TITLE
[QMS-125] Missing icon for not available geocache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ V1.XX.X
 [QMS-116] Filter edit field lost
 [QMS-118] Too much whitespace in extended search help window
 [QMS-119] Better handling of disabled and archived geocaches
-
+[QMS-125] Missing icon for not available geocache
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -474,7 +474,7 @@ void CGisItemWpt::setIcon()
         }
         else
         {
-            IGisItem::setIcon(CWptIconManager::self().getWptIconByName("gray:"+geocache.type, focus));
+            IGisItem::setIcon(CWptIconManager::self().getWptIconByName("gray_"+geocache.type, focus));
         }
     }
     else

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -124,18 +124,18 @@ void CWptIconManager::init()
     setWptIconByName("Virtual Cache", "://icons/geocaching/icons/virtual.png");
     setWptIconByName("Webcam Cache", "://icons/geocaching/icons/webcam.png");
 
-    setWptIconByName("gray:Traditional Cache", createGrayscale("://icons/geocaching/icons/traditional.png"));
-    setWptIconByName("gray:Multi-cache", createGrayscale("://icons/geocaching/icons/multi.png"));
-    setWptIconByName("gray:Unknown Cache", createGrayscale("://icons/geocaching/icons/unknown.png"));
-    setWptIconByName("gray:Wherigo Cache", createGrayscale("://icons/geocaching/icons/wherigo.png"));
-    setWptIconByName("gray:Event Cache", createGrayscale("://icons/geocaching/icons/event.png"));
-    setWptIconByName("gray:Mega-Event Cache", createGrayscale("://icons/geocaching/icons/mega.png"));
-    setWptIconByName("gray:Giga-Event Cache", createGrayscale("://icons/geocaching/icons/giga.png"));
-    setWptIconByName("gray:Cache In Trash Out Event", createGrayscale("://icons/geocaching/icons/cito.png"));
-    setWptIconByName("gray:Earthcache", createGrayscale("://icons/geocaching/icons/earth.png"));
-    setWptIconByName("gray:Letterbox Hybrid", createGrayscale("://icons/geocaching/icons/letterbox.png"));
-    setWptIconByName("gray:Virtual Cache", createGrayscale("://icons/geocaching/icons/virtual.png"));
-    setWptIconByName("gray:Webcam Cache", createGrayscale("://icons/geocaching/icons/webcam.png"));
+    setWptIconByName("gray_Traditional Cache", createGrayscale("://icons/geocaching/icons/traditional.png"));
+    setWptIconByName("gray_Multi-cache", createGrayscale("://icons/geocaching/icons/multi.png"));
+    setWptIconByName("gray_Unknown Cache", createGrayscale("://icons/geocaching/icons/unknown.png"));
+    setWptIconByName("gray_Wherigo Cache", createGrayscale("://icons/geocaching/icons/wherigo.png"));
+    setWptIconByName("gray_Event Cache", createGrayscale("://icons/geocaching/icons/event.png"));
+    setWptIconByName("gray_Mega-Event Cache", createGrayscale("://icons/geocaching/icons/mega.png"));
+    setWptIconByName("gray_Giga-Event Cache", createGrayscale("://icons/geocaching/icons/giga.png"));
+    setWptIconByName("gray_Cache In Trash Out Event", createGrayscale("://icons/geocaching/icons/cito.png"));
+    setWptIconByName("gray_Earthcache", createGrayscale("://icons/geocaching/icons/earth.png"));
+    setWptIconByName("gray_Letterbox Hybrid", createGrayscale("://icons/geocaching/icons/letterbox.png"));
+    setWptIconByName("gray_Virtual Cache", createGrayscale("://icons/geocaching/icons/virtual.png"));
+    setWptIconByName("gray_Webcam Cache", createGrayscale("://icons/geocaching/icons/webcam.png"));
 
     SETTINGS;
     QDir dirIcon(cfg.value("Paths/externalWptIcons", IAppSetup::getPlatformInstance()->userDataPath("WaypointIcons")).toString());


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#

**Describe roughly what you have done:**

I changed the name prefix.

**What steps have to be done to perform a simple smoke test:**

1. Open an archived or disabled geocache
2. Check if you see the icon

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
