### PR TITLE
[QMS-122] Windows: support for offline help

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,7 +19,7 @@ V1.XX.X
 [QMS-119] Better handling of disabled and archived geocaches
 [QMS-125] Missing icon for not available geocache
 [QMS-126] Wrong results searching for geocache status
-
+[QMS-122] Windows: support for offline help
 
 V1.14.0
 [QMS-5] App crashes on using the "Change Start Point" filter

--- a/msvc_64/QMapShack_Installer.nsi
+++ b/msvc_64/QMapShack_Installer.nsi
@@ -122,12 +122,16 @@ Section "QMapShack" QMapShack
   SetOutPath "$INSTDIR\translations"
     File Files\translations\qmapshack_*.qm
     File Files\translations\qmaptool_*.qm
-  ;END QMapShack Files    
-   
+  SetOutPath "$INSTDIR\doc\HTML"
+    File Files\doc\HTML\QMSHelp.*
+    File Files\doc\HTML\QMTHelp.*
+  ;END QMapShack Files
+
   ;BEGIN Qt Files
   SetOutPath $INSTDIR
     File Files\Qt5Core.dll
     File Files\Qt5Gui.dll
+    File Files\Qt5Help.dll
     File Files\Qt5Multimedia.dll
     File Files\Qt5MultimediaWidgets.dll
     File Files\Qt5Network.dll

--- a/msvc_64/copyfiles.bat
+++ b/msvc_64/copyfiles.bat
@@ -31,6 +31,7 @@ rem Section 2.1) Copy Qt files
 rem Note: Qt5WebEngine deployment is super crazy - see https://doc.qt.io/qt-5.12/qtwebengine-deploying.html
 copy %QMSI_QT_PATH%\bin\Qt5Core.dll
 copy %QMSI_QT_PATH%\bin\Qt5Gui.dll
+copy %QMSI_QT_PATH%\bin\Qt5Help.dll
 copy %QMSI_QT_PATH%\bin\Qt5Multimedia.dll
 copy %QMSI_QT_PATH%\bin\Qt5MultimediaWidgets.dll
 copy %QMSI_QT_PATH%\bin\Qt5Network.dll
@@ -141,6 +142,15 @@ copy %QMSI_BUILD_PATH%\bin\Release\qmt_rgb2pct.exe
 copy %QMSI_BUILD_PATH%\src\qmapshack\*.qm translations
 copy %QMSI_BUILD_PATH%\src\qmaptool\*.qm translations
 copy ..\*.ico
+
+rem section 2.4.1) Copy the documentation files
+mkdir doc
+cd doc
+mkdir HTML
+copy ..\..\..\src\qmapshack\doc\QMSHelp.* HTML
+copy ..\..\..\src\qmaptool\doc\QMTHelp.* HTML
+cd ..
+
 
 rem section 2.5) 3rd party SW description
 copy ..\3rdparty.txt

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -1848,7 +1848,11 @@ void CMainWindow::slotHelp()
 {
     if(help.isNull())
     {
-        help = new CHelp(_MKSTR(HELPPATH) "/QMSHelp.qhc", "qthelp://qms/doc/doc/html/DocMain.html", this);
+        help = new CHelp(
+            IAppSetup::getPlatformInstance()->helpFile(),
+            "qthelp://qms/doc/doc/html/DocMain.html",
+            this
+            );
         addDockWidget(Qt::AllDockWidgetAreas, help);
     }
 

--- a/src/qmapshack/setup/CAppSetupLinux.cpp
+++ b/src/qmapshack/setup/CAppSetupLinux.cpp
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "CAppSetupLinux.h"
+#include "version.h"
 
 #ifndef _MKSTR_1
 #define _MKSTR_1(x)    #x
@@ -65,4 +66,10 @@ QString CAppSetupLinux::userDataPath(QString subdir)
 QString CAppSetupLinux::logDir()
 {
     return QDir::temp().absolutePath();
+}
+
+QString CAppSetupLinux::helpFile()
+{
+    QDir dir(_MKSTR(HELPPATH));
+    return dir.absoluteFilePath("QMSHelp.qhc");
 }

--- a/src/qmapshack/setup/CAppSetupLinux.h
+++ b/src/qmapshack/setup/CAppSetupLinux.h
@@ -32,6 +32,7 @@ public:
     QString userDataPath(QString subdir = 0) override;
     QString logDir() override;
     QString findExecutable(const QString &name) override { return QStandardPaths::findExecutable(name); }
+    QString helpFile() override;
 };
 
 

--- a/src/qmapshack/setup/CAppSetupWin.cpp
+++ b/src/qmapshack/setup/CAppSetupWin.cpp
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "CAppSetupWin.h"
+#include "version.h"
 
 
 void CAppSetupWin::initQMapShack()
@@ -77,3 +78,11 @@ QString CAppSetupWin::findExecutable(const QString &name)
 {
     return QStandardPaths::findExecutable(name);
 }
+
+QString CAppSetupWin::helpFile()
+{
+    QDir dirApp(QCoreApplication::applicationDirPath());
+    QDir dirHelp(dirApp.absoluteFilePath(_MKSTR(HELPPATH)));
+    return dirHelp.absoluteFilePath("QMSHelp.qhc");
+}
+

--- a/src/qmapshack/setup/CAppSetupWin.h
+++ b/src/qmapshack/setup/CAppSetupWin.h
@@ -32,6 +32,7 @@ public:
     QString userDataPath(QString subdir = 0) override;
     QString logDir() override;
     QString findExecutable(const QString &name) override;
+    QString helpFile() override;
 
     QByteArray path;
 };

--- a/src/qmapshack/setup/IAppSetup.h
+++ b/src/qmapshack/setup/IAppSetup.h
@@ -37,6 +37,7 @@ public:
     virtual QString userDataPath(QString subdir = 0) = 0;
     virtual QString logDir() = 0;
     virtual QString findExecutable(const QString &name) = 0;
+    virtual QString helpFile() = 0;
 
 protected:
     void prepareGdal(QString gdalDir, QString projDir);

--- a/src/qmaptool/CMainWindow.cpp
+++ b/src/qmaptool/CMainWindow.cpp
@@ -18,8 +18,10 @@
 
 #include "CAbout.h"
 #include "CMainWindow.h"
+#include "help/CHelp.h"
 #include "helpers/CSettings.h"
 #include "setup/CSetupExtTools.h"
+#include "setup/IAppSetup.h"
 #include "tool/CToolAddOverview.h"
 #include "tool/CToolBox.h"
 #include "tool/CToolCutMap.h"
@@ -31,14 +33,13 @@
 #include "units/CUnitsSetup.h"
 #include "units/IUnit.h"
 #include "version.h"
-#include "help/CHelp.h"
 
 CMainWindow * CMainWindow::pSelf = nullptr;
 
 CMainWindow::CMainWindow()
 {
     SETTINGS;
-    IUnit::setUnitType((IUnit::type_e)cfg.value("Units/units",IUnit::eTypeMetric).toInt(), this);
+    IUnit::setUnitType((IUnit::type_e)cfg.value("Units/units", IUnit::eTypeMetric).toInt(), this);
     IUnit::setCoordFormat((IUnit::coord_format_e)cfg.value("Units/coordFormat", IUnit::eCoordFormat1).toInt());
 
     pSelf = this;
@@ -95,7 +96,7 @@ CMainWindow::CMainWindow()
     }
     // end ---- restore window geometry -----
     //toolStack->setCurrentIndex(cfg.value("Tool/Stack/current",0).toInt());
-    toolBox->setCurrentIndex(cfg.value("Tool/Box/current",0).toInt());
+    toolBox->setCurrentIndex(cfg.value("Tool/Box/current", 0).toInt());
     actionShowToolHelp->setChecked(cfg.value("Tool/showHelp", true).toBool());
     mapFont = cfg.value("Canvas/mapFont", font()).value<QFont>();
     actionFlipMouseWheel->setChecked(cfg.value("Canvas/flipMouseWheel", false).toBool());
@@ -187,7 +188,11 @@ void CMainWindow::slotHelp()
 {
     if(help.isNull())
     {
-        help = new CHelp(_MKSTR(HELPPATH) "/QMTHelp.qhc", "qthelp://qmt/doc/doc/html/QMapTool/QMTDocMain.html", this);
+        help = new CHelp(
+            IAppSetup::self().helpFile(),
+            "qthelp://qmt/doc/doc/html/QMapTool/QMTDocMain.html",
+            this
+            );
         addDockWidget(Qt::AllDockWidgetAreas, help);
     }
 

--- a/src/qmaptool/setup/CAppSetupLinux.cpp
+++ b/src/qmaptool/setup/CAppSetupLinux.cpp
@@ -60,3 +60,9 @@ QString CAppSetupLinux::logDir()
 {
     return QDir::temp().absolutePath();
 }
+
+QString CAppSetupLinux::helpFile()
+{
+    QDir dir(_MKSTR(HELPPATH));
+    return dir.absoluteFilePath("QMTHelp.qhc");
+}

--- a/src/qmaptool/setup/CAppSetupLinux.h
+++ b/src/qmaptool/setup/CAppSetupLinux.h
@@ -38,6 +38,7 @@ public:
     QString userDataPath(QString subdir = 0) override;
     QString logDir() override;
     QString findExecutable(const QString &name) override { return QStandardPaths::findExecutable(name); }
+    QString helpFile() override;
 };
 
 

--- a/src/qmaptool/setup/CAppSetupWin.cpp
+++ b/src/qmaptool/setup/CAppSetupWin.cpp
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "setup/CAppSetupWin.h"
+#include "version.h"
 
 
 void CAppSetupWin::initQMapTool()
@@ -66,4 +67,11 @@ QString CAppSetupWin::logDir()
 QString CAppSetupWin::findExecutable(const QString &name)
 {
     return QStandardPaths::findExecutable(name);
+}
+
+QString CAppSetupWin::helpFile()
+{
+    QDir dirApp = QDir(QCoreApplication::applicationDirPath());
+    QDir dirHelp = QDir(dirApp.absoluteFilePath(_MKSTR(HELPPATH)));
+    return dirHelp.absoluteFilePath("QMTHelp.qhc");
 }

--- a/src/qmaptool/setup/CAppSetupWin.h
+++ b/src/qmaptool/setup/CAppSetupWin.h
@@ -38,6 +38,7 @@ public:
     QString userDataPath(QString subdir = 0) override;
     QString logDir() override;
     QString findExecutable(const QString &name) override;
+    QString helpFile() override;
 
     QByteArray path;
 };

--- a/src/qmaptool/setup/IAppSetup.h
+++ b/src/qmaptool/setup/IAppSetup.h
@@ -174,6 +174,8 @@ public:
         return !pathQmtmap2jnxOverride.isEmpty();
     }
 
+
+    virtual QString helpFile() = 0;
 signals:
     void sigSetupChanged();
 


### PR DESCRIPTION
Adapt Windows installer for offline help support

**What is the linked issue for this pull request (start with a `#`):** QMS-#122

**Describe roughly what you have done:**

I adapted the Windows installer scripts;
- add Qt5Help.dll
- add the offline documenation files

**What steps have to be done to perform a simple smoke test:**

1. Create a Windows Installer
2. Press F1 or call for help via the menu

**Does the code comply to the coding rules and naming conventions [Coding Guidleines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] N/A

**Is every user facing string in a tr() macro?**

- [X] N/A

**Is the change user facing?**

- [X] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [X] yes, I didn't forget to change changelog.txt
