### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/qmapshack/gis/IGisItemRate.ui
+++ b/src/qmapshack/gis/IGisItemRate.ui
@@ -136,7 +136,7 @@
    <item>
     <widget class="QLabel" name="keywordLabel">
      <property name="text">
-      <string>Seperate keywords by colons:</string>
+      <string>Separate keywords by colons:</string>
      </property>
     </widget>
    </item>

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -418,7 +418,7 @@ QString CGisItemWpt::getInfo(quint32 feature) const
                 str += QString("<a href='%1'>%2</a>").arg(link.uri.toString()).arg(link.text);
             }
         }
-        //Add logging link seperately, since the link to the geocache site is extracted from the gpx file.
+        //Add logging link separately, since the link to the geocache site is extracted from the gpx file.
         if(geocache.hasData && geocache.service == eGcCom)
         {
             str += " <a href='https://www.geocaching.com/play/geocache/" + wpt.name + "/log'>Log Geocache</a>";

--- a/src/qmapshack/locale/qmapshack.ts
+++ b/src/qmapshack/locale/qmapshack.ts
@@ -10311,7 +10311,7 @@ It is either a new item or it has been deleted in the database by someone else.<
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_ca.ts
+++ b/src/qmapshack/locale/qmapshack_ca.ts
@@ -10462,7 +10462,7 @@ Es tracta d&apos;un element nou o bé algú l&apos;ha esborrat de la base de dad
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_cs.ts
+++ b/src/qmapshack/locale/qmapshack_cs.ts
@@ -10381,7 +10381,7 @@ Buď je to nový prvek nebo byl v databázi někým smazán.</translation>
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_de.ts
+++ b/src/qmapshack/locale/qmapshack_de.ts
@@ -10473,7 +10473,7 @@ It is either a new item or it has been deleted in the database by someone else.<
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation>Schlagwortemit Komma trennen:</translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_es.ts
+++ b/src/qmapshack/locale/qmapshack_es.ts
@@ -10493,7 +10493,7 @@ Es un elemento nuevo o ha sido eliminado en la base de datos por alguien.</trans
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation>Separar palabras clave con dos puntos:</translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_fr.ts
+++ b/src/qmapshack/locale/qmapshack_fr.ts
@@ -10357,7 +10357,7 @@ It is either a new item or it has been deleted in the database by someone else.<
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_it.ts
+++ b/src/qmapshack/locale/qmapshack_it.ts
@@ -10455,7 +10455,7 @@ It is either a new item or it has been deleted in the database by someone else.<
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_nl.ts
+++ b/src/qmapshack/locale/qmapshack_nl.ts
@@ -10356,7 +10356,7 @@ It is either a new item or it has been deleted in the database by someone else.<
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qmapshack/locale/qmapshack_ru.ts
+++ b/src/qmapshack/locale/qmapshack_ru.ts
@@ -10640,7 +10640,7 @@ It is either a new item or it has been deleted in the database by someone else.<
     </message>
     <message>
         <location filename="../gis/IGisItemRate.ui" line="139"/>
-        <source>Seperate keywords by colons:</source>
+        <source>Separate keywords by colons:</source>
         <translation>(Разделить ключевые слова двоеточиями)</translation>
     </message>
 </context>


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * Seperate -> Separate
