### PR TITLE
[QMS-68] Route Optimization

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
-[QMS-135] Improved French translation
+[QMS-68] Route Optimization
 [QMS-134] Rework track range selection from scratch
+[QMS-135] Improved French translation
 [QMS-140] Enhancements for OS X release
 [QMS-148] Misplaced track info window
 [QMS-151] Missing tooltip in route toolbar

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -116,6 +116,7 @@ set( SRCS
     gis/rte/CScrOptRte.cpp
     gis/rte/router/CRouterBRouter.cpp
     gis/rte/router/CRouterMapQuest.cpp
+    gis/rte/router/CRouterOptimization.cpp
     gis/rte/router/CRouterRoutino.cpp
     gis/rte/router/CRouterSetup.cpp
     gis/rte/router/IRouter.cpp
@@ -464,6 +465,7 @@ set( HDRS
     gis/rte/CScrOptRte.h
     gis/rte/router/CRouterBRouter.h
     gis/rte/router/CRouterMapQuest.h
+    gis/rte/router/CRouterOptimization.h
     gis/rte/router/CRouterRoutino.h
     gis/rte/router/CRouterSetup.h
     gis/rte/router/IRouter.h

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.h
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.h
@@ -47,7 +47,7 @@ public:
     }
 
     void calcRoute(const IGisItem::key_t& key) override;
-    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords) override;
+    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr) override;
     bool hasFastRouting() override;
     QString getOptions() override;
     void routerSelected() override;
@@ -74,7 +74,7 @@ private:
     void getBRouterVersion();
     bool isMinimumVersion(int major, int minor, int patch) const;
     void updateBRouterStatus() const;
-    int synchronousRequest(const QVector<QPointF>& points, const QList<IGisItem *> &nogos, QPolygonF &coords);
+    int synchronousRequest(const QVector<QPointF>& points, const QList<IGisItem *> &nogos, QPolygonF &coords, qreal *costs);
     QNetworkRequest getRequest(const QVector<QPointF>& routePoints, const QList<IGisItem *> &nogos) const;
     QUrl getServiceUrl() const;
 

--- a/src/qmapshack/gis/rte/router/CRouterMapQuest.h
+++ b/src/qmapshack/gis/rte/router/CRouterMapQuest.h
@@ -35,7 +35,7 @@ public:
     virtual ~CRouterMapQuest();
 
     void calcRoute(const IGisItem::key_t& key) override;
-    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords) override
+    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr) override
     {
         return -1;
     }

--- a/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
@@ -1,0 +1,320 @@
+/**********************************************************************************************
+    Copyright (C) 2020 Henri Hornburg hrnbg@t-online.de
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#include "CRouterOptimization.h"
+#include <gis/rte/router/CRouterSetup.h>
+#include <GeoMath.h>
+
+CRouterOptimization::CRouterOptimization()
+{
+    routerOptions = CRouterSetup::self().getOptions();
+}
+
+int CRouterOptimization::optimize(SGisLine &line)
+{
+    checkRouter();
+    if(!CRouterSetup::self().hasFastRouting())
+    {
+        return -1;
+    }
+    if(line.length() < 4)
+    {
+        return 0; //There is nothing to optimize
+    }
+
+    //Optimize using air distance and known distances, since this is much faster than routing, especially brouter
+    SGisLine newAirdistanceOrder;
+    SGisLine oldAirdistanceOrder = line;
+    qreal gain = createNextBestOrder(oldAirdistanceOrder, newAirdistanceOrder);
+    while(gain < 0)
+    {
+        oldAirdistanceOrder = newAirdistanceOrder;
+        gain = createNextBestOrder(oldAirdistanceOrder, newAirdistanceOrder);
+    }
+    //Do routing and calculate cost for order found
+    qreal airdistanceOrderCosts = getRealRouteCosts(oldAirdistanceOrder);
+
+    //Do routing and calculate costs of the order the user supplied
+    //cancel the route calculation when the cost of the airdistance order is reached
+    qreal givenOrderCosts = getRealRouteCosts(line, airdistanceOrderCosts);
+    if(givenOrderCosts < 0 && airdistanceOrderCosts < 0)
+    {
+        return -1;
+    }
+
+    //determine starting order for optimization
+    qreal bestCosts = NOINT;
+    if(givenOrderCosts > 0 && givenOrderCosts < airdistanceOrderCosts)
+    {
+        bestCosts = givenOrderCosts;
+    }
+    else
+    {
+        bestCosts = airdistanceOrderCosts;
+        //the old order is the "optimal" one, since the new one didn't have a gain<0
+        line = oldAirdistanceOrder;
+        fillSubPts(line);
+    }
+
+    SGisLine lastWorkingOrder = line;
+    qreal lastWorkingOrderCosts = bestCosts;
+    int numOfRestarts = 0;
+    // The number of needed starting permutations is somewhat arbitrary,
+    // but you'd likely need more to find the global optimum if there are more possibilities
+    while(numOfRestarts < line.length())
+    {
+        SGisLine newWorkingOrder;
+        qreal bestInsertionGain = createNextBestOrder(lastWorkingOrder, newWorkingOrder);
+
+        if(bestInsertionGain < 0)
+        {
+            qreal newWorkingOrderCosts = getRealRouteCosts(newWorkingOrder, lastWorkingOrderCosts);
+
+            if(newWorkingOrderCosts > 0 && newWorkingOrderCosts < lastWorkingOrderCosts)
+            {
+                lastWorkingOrder = newWorkingOrder;
+                lastWorkingOrderCosts = newWorkingOrderCosts;
+
+                if(newWorkingOrderCosts < bestCosts)
+                {
+                    bestCosts = newWorkingOrderCosts;
+                    line = newWorkingOrder;
+
+                    // Do this every time, since changes to the line are displayed and the data is available anyways.
+                    // Gives a nice animation on screen if the subpoints are displayed aswell.
+                    fillSubPts(line);
+                }
+            }
+        }
+        else
+        {
+            numOfRestarts += 1;
+            //We accept any order that is produced, as we want to escape from the local optimum
+            twoOptStep(lastWorkingOrder, newWorkingOrder);
+            lastWorkingOrder = newWorkingOrder;
+            lastWorkingOrderCosts = getRealRouteCosts(lastWorkingOrder);
+        }
+    }
+
+    //Do this a last time, since it happens that the route is already optimal.
+    //Return the return value as this is the last point the code may fail for some odd reason
+    return fillSubPts(line);
+}
+
+qreal CRouterOptimization::createNextBestOrder(const SGisLine &oldOrder, SGisLine &newOrder)
+{
+    qreal bestInsertionGain = 0;
+    int bestBaseIndex = -1;
+    int bestInsertedItemIndex = -1;
+
+    // lastWorkingOrder.length()-2, since we can't use the last two items as base
+    for(int baseIndex = 0; baseIndex < oldOrder.length() -2; baseIndex++)
+    {
+        // Keep start and end fixed
+        for(int insertedItemIndex = 1; insertedItemIndex < oldOrder.length() -1; insertedItemIndex++)
+        {
+            if(baseIndex == insertedItemIndex || baseIndex == insertedItemIndex-1)
+            {
+                continue;
+            }
+
+            qreal insertionGain = bestKnownDistance(oldOrder[baseIndex], oldOrder[insertedItemIndex])
+                                  + bestKnownDistance(oldOrder[insertedItemIndex], oldOrder[baseIndex +1])
+                                  - bestKnownDistance(oldOrder[baseIndex], oldOrder[baseIndex+1])
+                                  + bestKnownDistance(oldOrder[insertedItemIndex-1], oldOrder[insertedItemIndex+1])
+                                  - bestKnownDistance(oldOrder[insertedItemIndex-1], oldOrder[insertedItemIndex])
+                                  - bestKnownDistance(oldOrder[insertedItemIndex], oldOrder[insertedItemIndex+1]);
+
+            if(insertionGain < bestInsertionGain)
+            {
+                bestBaseIndex = baseIndex;
+                bestInsertionGain = insertionGain;
+                bestInsertedItemIndex = insertedItemIndex;
+            }
+        }
+    }
+
+    newOrder = SGisLine(oldOrder);
+    if(bestBaseIndex >= 0 && bestInsertedItemIndex >= 0)
+    {
+        // If the index of the inserted item was smaller than that of the base item,
+        // moving it will cause the index of the base to decrease. Thus, we don't add 1 to place it after the base
+        if(bestInsertedItemIndex < bestBaseIndex)
+        {
+            newOrder.move(bestInsertedItemIndex, bestBaseIndex);
+        }
+        else
+        {
+            newOrder.move(bestInsertedItemIndex, bestBaseIndex+1);
+        }
+    }
+    return bestInsertionGain;
+}
+
+qreal CRouterOptimization::twoOptStep(const SGisLine &oldOrder, SGisLine &newOrder)
+{
+    //NOINT and not 0, since we also want to take orders that don't seem to be improving the situation
+    qreal bestTwoOptGain = NOINT;
+    //Begin and End of the section that is inverted
+    int bestBeginIndex = -1;
+    int bestEndIndex = -1;
+
+    // lastWorkingOrder.length()-2, since the end of the inverted section can't be the end of the line
+    for(int beginIndex = 1; beginIndex < oldOrder.length() - 2; beginIndex++)
+    {
+        for(int endIndex = beginIndex + 1; endIndex < oldOrder.length() - 1; endIndex++)
+        {
+            qreal oldRangeCosts = bestKnownDistance(oldOrder[beginIndex-1], oldOrder[beginIndex])
+                                  + bestKnownDistance(oldOrder[endIndex], oldOrder[endIndex+1]);
+
+            qreal newRangeCosts = bestKnownDistance(oldOrder[beginIndex-1], oldOrder[endIndex])
+                                  +bestKnownDistance(oldOrder[beginIndex], oldOrder[endIndex+1]);
+            for(int i = beginIndex; i < endIndex; i++)
+            {
+                oldRangeCosts+=bestKnownDistance(oldOrder[i], oldOrder[i+1]);
+                newRangeCosts+=bestKnownDistance(oldOrder[i+1], oldOrder[i]);
+            }
+
+            if(newRangeCosts-oldRangeCosts < bestTwoOptGain)
+            {
+                bestBeginIndex = beginIndex;
+                bestEndIndex = endIndex;
+                bestTwoOptGain = newRangeCosts-oldRangeCosts;
+            }
+        }
+    }
+
+    newOrder = SGisLine(oldOrder);
+    if(bestEndIndex >= 0 && bestBeginIndex >= 0)
+    {
+        std::reverse(newOrder.begin()+bestBeginIndex, newOrder.begin()+bestEndIndex);
+    }
+    return bestTwoOptGain;
+}
+
+qreal CRouterOptimization::getRealRouteCosts(const SGisLine &line, qreal costCutoff)
+{
+    qreal costs = 0;
+    for(int i = 0; i < line.length()-1; i++)
+    {
+        const routing_cache_item_t* route = getRoute(line[i].coord, line[i+1].coord);
+        if(route == nullptr)
+        {
+            return -1;
+        }
+        costs += route->costs;
+
+        if(costCutoff > 0 && costs > costCutoff)
+        {
+            return -1;
+        }
+    }
+    return costs;
+}
+
+qreal CRouterOptimization::bestKnownDistance(const IGisLine::point_t& start, const IGisLine::point_t& end)
+{
+    //10 digits after the decimal point in exponential format should be by far enough
+    QString start_key=QString::number(start.coord.x(), 'e', 10) + QString::number(start.coord.y(), 'e', 10);
+    QString end_key=QString::number(end.coord.x(), 'e', 10) + QString::number(end.coord.y(), 'e', 10);
+
+    if(!routingCache.contains(start_key))
+    {
+        routingCache[start_key] = {};
+    }
+
+    if(routingCache[start_key].contains(end_key))
+    {
+        return routingCache[start_key][end_key].costs;
+    }
+    else
+    {
+        //Multiply it with the average of the minimum occuring factor and the average factor
+        // to get a reasonable compromise of optimization speed and optimality of results
+        if(totalNumOfRoutes > 0 && minAirToCostFactor > 0)
+        {
+            return GPS_Math_DistanceQuick(start.coord.x(), start.coord.y(),
+                                          end.coord.x(), end.coord.y())
+                   * (totalAirToCosts/totalNumOfRoutes + minAirToCostFactor)/2;
+        }
+        else
+        {
+            return GPS_Math_DistanceQuick(start.coord.x(), start.coord.y(),
+                                          end.coord.x(), end.coord.y());
+        }
+    }
+}
+
+const CRouterOptimization::routing_cache_item_t* CRouterOptimization::getRoute(const QPointF& start, const QPointF& end)
+{
+    QString start_key=QString::number(start.x(), 'e', 10) + QString::number(start.y(), 'e', 10);
+    QString end_key=QString::number(end.x(), 'e', 10) + QString::number(end.y(), 'e', 10);
+
+    if(!routingCache.contains(start_key))
+    {
+        routingCache[start_key] = {};
+    }
+
+    if(!routingCache[start_key].contains(end_key))
+    {
+        routing_cache_item_t cacheItem;
+        int response = CRouterSetup::self().calcRoute(start, end, cacheItem.route, &cacheItem.costs);
+        if(response < 0)
+        {
+            return nullptr;
+        }
+        routingCache[start_key][end_key] = cacheItem;
+
+        qreal airToCostFactor = cacheItem.costs/GPS_Math_DistanceQuick(start.x(), start.y(), end.x(), end.y());
+        if( airToCostFactor < minAirToCostFactor || minAirToCostFactor < 0)
+        {
+            minAirToCostFactor = airToCostFactor;
+        }
+        totalAirToCosts += airToCostFactor;
+        totalNumOfRoutes++;
+    }
+    return &routingCache[start_key][end_key];
+}
+
+int CRouterOptimization::fillSubPts(SGisLine &line)
+{
+    for(int i = 0; i < line.length()-1; i++)
+    {
+        line[i].subpts.clear();
+        const routing_cache_item_t* route= getRoute(line[i].coord, line[i+1].coord);
+        if(route == nullptr)
+        {
+            return -1;
+        }
+        for(const QPointF& point : route->route)
+        {
+            line[i].subpts<<IGisLine::subpt_t(point);
+        }
+    }
+    return 0;
+}
+
+void CRouterOptimization::checkRouter()
+{
+    const QString& options = CRouterSetup::self().getOptions();
+    if(routerOptions != options)
+    {
+        routingCache.clear();
+        routerOptions = options;
+    }
+}

--- a/src/qmapshack/gis/rte/router/CRouterOptimization.h
+++ b/src/qmapshack/gis/rte/router/CRouterOptimization.h
@@ -1,0 +1,57 @@
+/**********************************************************************************************
+    Copyright (C) 2020 Henri Hornburg hrnbg@t-online.de
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CROUTEROPTIMIZATION_H
+#define CROUTEROPTIMIZATION_H
+#include <gis/IGisLine.h>
+#include <QMap>
+#include <QPolygonF>
+
+class CRouterOptimization
+{
+public:
+    CRouterOptimization();
+    int optimize(SGisLine & line);
+
+private:
+
+    struct routing_cache_item_t
+    {
+        QPolygonF route;
+        qreal costs;
+    };
+
+    /// returns value by which the costs were changed
+    qreal createNextBestOrder(const SGisLine& oldOrder, SGisLine& newOrder);
+    qreal twoOptStep(const SGisLine &oldOrder, SGisLine &newOrder);
+
+    qreal getRealRouteCosts(const SGisLine& line, qreal costCutoff = -1);
+    qreal bestKnownDistance(const IGisLine::point_t &start, const IGisLine::point_t &end);
+    const routing_cache_item_t *getRoute(const QPointF& from, const QPointF& to);
+    int fillSubPts(SGisLine& line);
+    /// checks if router settings were changed and if yes, discards the routingCache
+    void checkRouter();
+
+    QMap<QString, QMap<QString, routing_cache_item_t> > routingCache;
+    qreal minAirToCostFactor = -1;
+    qreal totalAirToCosts = 0;
+    qreal totalNumOfRoutes = 0;
+    QString routerOptions = "";
+};
+
+#endif // CROUTEROPTIMIZATION_H

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -40,7 +40,7 @@ int ProgressFunc(double complete)
         return true;
     }
 
-    CRouterRoutino::progress->setValue(complete*100);
+    CRouterRoutino::progress->setValue(complete * 100);
 
     return !CRouterRoutino::progress->wasCanceled();
 }
@@ -236,7 +236,7 @@ void CRouterRoutino::buildDatabaseList()
     for(const QString &path : dbPaths)
     {
         QDir dir(path);
-        for(const QString &filename : dir.entryList(QStringList("*segments.mem"), QDir::Files|QDir::Readable, QDir::Name))
+        for(const QString &filename : dir.entryList(QStringList("*segments.mem"), QDir::Files | QDir::Readable, QDir::Name))
         {
             QString prefix;
             if(re.exactMatch(filename))
@@ -338,7 +338,7 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key)
         QVector<Routino_Waypoint*> waypoints(line.size(), nullptr);
         for(const IGisLine::point_t &pt : line)
         {
-            waypoints[idx] = Routino_FindWaypoint(data, profile, pt.coord.y()*RAD_TO_DEG, pt.coord.x()*RAD_TO_DEG);
+            waypoints[idx] = Routino_FindWaypoint(data, profile, pt.coord.y() * RAD_TO_DEG, pt.coord.x() * RAD_TO_DEG);
             if(waypoints[idx] == nullptr)
             {
                 throw xlateRoutinoError(Routino_errno);
@@ -354,7 +354,7 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key)
 
         if(nullptr != route)
         {
-            rte->setResult(route, getOptions() + tr("<br/>Calculation time: %1s").arg(time.elapsed()/1000.0, 0, 'f', 2));
+            rte->setResult(route, getOptions() + tr("<br/>Calculation time: %1s").arg(time.elapsed() / 1000.0, 0, 'f', 2));
             Routino_DeleteRoute(route);
         }
         else
@@ -379,7 +379,7 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key)
 }
 
 
-int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords)
+int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr)
 {
     if(!mutex.tryLock())
     {
@@ -417,13 +417,13 @@ int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
         }
 
         Routino_Waypoint* waypoints[2] = {0};
-        waypoints[0] = Routino_FindWaypoint(data, profile, p1.y()*RAD_TO_DEG, p1.x()*RAD_TO_DEG);
+        waypoints[0] = Routino_FindWaypoint(data, profile, p1.y() * RAD_TO_DEG, p1.x() * RAD_TO_DEG);
         if(waypoints[0] == nullptr)
         {
             throw xlateRoutinoError(Routino_errno);
         }
 
-        waypoints[1] = Routino_FindWaypoint(data, profile, p2.y()*RAD_TO_DEG, p2.x()*RAD_TO_DEG);
+        waypoints[1] = Routino_FindWaypoint(data, profile, p2.y() * RAD_TO_DEG, p2.x() * RAD_TO_DEG);
         if(waypoints[1] == nullptr)
         {
             throw xlateRoutinoError(Routino_errno);
@@ -443,6 +443,20 @@ int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
                 if(next->type != ROUTINO_POINT_WAYPOINT)
                 {
                     coords << QPointF(next->lon, next->lat);
+                }
+                if(costs != nullptr)
+                {
+                    if(comboMode->currentIndex() == 1)
+                    {
+                        // ROUTINO_ROUTE_QUICKEST
+                        // This works, since CRouteOptimization adapts it's weights according to the data it gets
+                        *costs = next->time;
+                    }
+                    else
+                    {
+                        // ROUTINO_ROUTE_SHORTEST
+                        *costs = next->dist;
+                    }
                 }
                 next = next->next;
             }

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.h
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.h
@@ -39,7 +39,7 @@ public:
 
 
     void calcRoute(const IGisItem::key_t& key) override;
-    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords) override;
+    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal *costs) override;
 
     bool hasFastRouting() override;
 

--- a/src/qmapshack/gis/rte/router/CRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterSetup.cpp
@@ -84,15 +84,26 @@ void CRouterSetup::calcRoute(const IGisItem::key_t& key)
     }
 }
 
-int CRouterSetup::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords)
+int CRouterSetup::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs)
 {
     IRouter * router = dynamic_cast<IRouter*>(stackedWidget->currentWidget());
     if(router)
     {
-        return router->calcRoute(p1, p2, coords);
+        return router->calcRoute(p1, p2, coords, costs);
     }
 
     return false;
+}
+
+QString CRouterSetup::getOptions()
+{
+    IRouter * router = dynamic_cast<IRouter*>(stackedWidget->currentWidget());
+    if(router)
+    {
+        return router->getOptions();
+    }
+
+    return "";
 }
 
 void CRouterSetup::setRouterTitle(const router_e router, const QString title)

--- a/src/qmapshack/gis/rte/router/CRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/CRouterSetup.h
@@ -34,7 +34,8 @@ public:
     virtual ~CRouterSetup();
 
     void calcRoute(const IGisItem::key_t &key);
-    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords);
+    int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal *costs = nullptr);
+    QString getOptions();
 
     bool hasFastRouting();
 

--- a/src/qmapshack/gis/rte/router/IRouter.h
+++ b/src/qmapshack/gis/rte/router/IRouter.h
@@ -30,7 +30,7 @@ public:
     virtual ~IRouter();
 
     virtual void calcRoute(const IGisItem::key_t& key) = 0;
-    virtual int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords) = 0;
+    virtual int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr) = 0;
     virtual bool hasFastRouting()
     {
         return fastRouting;

--- a/src/qmapshack/helpers/CProgressDialog.cpp
+++ b/src/qmapshack/helpers/CProgressDialog.cpp
@@ -30,14 +30,11 @@ QStack<CProgressDialog*> CProgressDialog::stackSelf;
 CProgressDialog::CProgressDialog(const QString text, int min, int max, QWidget *parent)
     : QDialog(parent)
 {
-    if(!stackSelf.isEmpty())
-    {
-        stackSelf.top()->pause();
-    }
     stackSelf.push(this);
+    int oldTopIndex = stackSelf.length()-2;
 
     setupUi(this);
-    setWindowModality(Qt::WindowModal);
+    setWindowModality(Qt::ApplicationModal);
 
     label->setText(text);
     progressBar->setMinimum(min);
@@ -61,7 +58,11 @@ CProgressDialog::CProgressDialog(const QString text, int min, int max, QWidget *
     QDialog::hide();
     timer = new QTimer(this);
     timer->setSingleShot(true);
-    connect(timer, &QTimer::timeout, this, [this] {
+    connect(timer, &QTimer::timeout, this, [this, oldTopIndex] {
+        if(oldTopIndex > 0)
+        {
+            stackSelf[oldTopIndex]->pause();
+        }
         show();
     });
     timer->start(DELAY);
@@ -94,6 +95,12 @@ void CProgressDialog::pause()
 
 void CProgressDialog::goOn()
 {
+    //if goOn() is called from the dtor of another progress bar this progress bar was not necessarily paused.
+    //Also, it the second of waiting might not have elapsed. Thus, if the timer is still running, we do nothing
+    if(timer->isActive())
+    {
+        return;
+    }
     if(timeElapsed <= DELAY)
     {
         timer->start(DELAY - timeElapsed);

--- a/src/qmapshack/mouse/line/ILineOp.h
+++ b/src/qmapshack/mouse/line/ILineOp.h
@@ -69,6 +69,7 @@ public:
     }
 
     void updateStatus();
+    void showRoutingErrorMessage(const QString &msg) const;
 
 protected slots:
     void slotTimeoutRouting();
@@ -116,7 +117,6 @@ protected:
     QPolygonF subLinePixel2;
 
 private:
-    void showRoutingErrorMessage(const QString &msg) const;
     void tryRouting(IGisLine::point_t& pt1, IGisLine::point_t& pt2) const;
 
     QTimer * timerRouting;

--- a/src/qmapshack/mouse/line/IMouseEditLine.h
+++ b/src/qmapshack/mouse/line/IMouseEditLine.h
@@ -22,6 +22,7 @@
 
 #include "gis/IGisItem.h"
 #include "gis/IGisLine.h"
+#include "gis/rte/router/CRouterOptimization.h"
 #include "mouse/IMouse.h"
 #include <QDebug>
 #include <QPointer>
@@ -102,6 +103,7 @@ protected slots:
     void slotVectorRouting();
     void slotTrackRouting();
 
+    void slotOptimize();
 
     virtual void slotAbort() = 0;
     void slotAbortEx(bool showMB);
@@ -153,6 +155,8 @@ private:
     bool enableStatus;
 
     QString type;
+
+    CRouterOptimization optimizer;
 };
 
 #endif //IMOUSEEDITLINE_H

--- a/src/qmapshack/mouse/line/IScrOptEditLine.ui
+++ b/src/qmapshack/mouse/line/IScrOptEditLine.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>653</width>
+    <width>734</width>
     <height>46</height>
    </rect>
   </property>
@@ -302,6 +302,17 @@
          </widget>
         </item>
        </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushOptimize">
+       <property name="toolTip">
+        <string>Optimizes the route by reordering the points using the router specified in the &quot;Routing&quot; tab. 
+This is known as solving the Traveling Salesman Problem, however start and end are kept fixed here</string>
+       </property>
+       <property name="text">
+        <string>Optimize</string>
+       </property>
       </widget>
      </item>
      <item>


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#68

**Describe roughly what you have done:**

Since the TSP somehow fascinated me, I decided to write my own algorithm to optimize routes using the routers already available in QMS.

I adapted the routers, so they also return the cost of the route calculated using `calcRoute`. This enables the algorithm to actually optimize on what the router is trying to minimize.

The only option left to speed up that comes to my mind would be to intercept the `calcRoute` calls for the points the user actually uses, however I didn't find a good possibility to do so.

**What steps have to be done to perform a simple smoke test:**

1. You have to have a router installed that is capable of fast routing.
2. Draw a route
3. Press the button 'optimize'
4. Wait (Brouter can take ~10-20 times longer than routino, with my heavily assymetric mountainbiking profile optimizing a route of 18 Points and 40km initial length takes ~30sec, shortest path with routino takes ~1 sec, shortest path with brouter takes ~20sec)
5. See the hopefully improved result.
6. If you are not happy with the result, press optimize again, the result should improve and come faster than the first time.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
