### PR TITLE
[QMS-148] Misplaced track info window

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-134] Rework track range selection from scratch
 [QMS-140] Enhancements for OS X release
+[QMS-148] Misplaced track info window
 [QMS-151] Missing tooltip in route toolbar
 
 V1.14.1

--- a/src/qmapshack/gis/ovl/CScrOptOvlArea.cpp
+++ b/src/qmapshack/gis/ovl/CScrOptOvlArea.cpp
@@ -39,7 +39,7 @@ CScrOptOvlArea::CScrOptOvlArea(CGisItemOvlArea *area, const QPoint &point, IMous
     {
         anchor = point;
     }
-    move(anchor.toPoint() + QPoint(-width()/2, SCR_OPT_OFFSET));
+    moveTo(anchor.toPoint());
     toolNogo->setChecked(area->isNogo());
     show();
 

--- a/src/qmapshack/gis/rte/CScrOptRte.cpp
+++ b/src/qmapshack/gis/rte/CScrOptRte.cpp
@@ -46,7 +46,7 @@ CScrOptRte::CScrOptRte(CGisItemRte *rte, const QPoint& point, IMouse *parent)
     {
         anchor = point;
     }
-    move(anchor.toPoint() + QPoint(-width()/2, SCR_OPT_OFFSET));
+    moveTo(anchor.toPoint());
     toolNogo->setChecked(rte->isNogo());
     show();
 

--- a/src/qmapshack/gis/trk/CScrOptTrk.cpp
+++ b/src/qmapshack/gis/trk/CScrOptTrk.cpp
@@ -58,7 +58,7 @@ CScrOptTrk::CScrOptTrk(CGisItemTrk * trk, const QPoint& point, IMouse *parent)
         toolCut->setEnabled(false);
     }
 
-    move(anchor.toPoint() + QPoint(-width()/2, SCR_OPT_OFFSET));
+    moveTo(anchor.toPoint());
     show();
 
     connect(toolEditDetails, &QToolButton::clicked, this, &CScrOptTrk::slotEditDetails);

--- a/src/qmapshack/gis/wpt/CScrOptWpt.cpp
+++ b/src/qmapshack/gis/wpt/CScrOptWpt.cpp
@@ -17,8 +17,6 @@
 
 **********************************************************************************************/
 
-
-#include "canvas/CCanvas.h"
 #include "CMainWindow.h"
 #include "gis/CGisWorkspace.h"
 #include "gis/search/CGeoSearchWeb.h"
@@ -51,7 +49,7 @@ CScrOptWpt::CScrOptWpt(CGisItemWpt *wpt, const QPoint& point, IMouse *parent)
     toolDelRadius->setEnabled(radius);
 
     anchor = wpt->getPointCloseBy(point);
-    move(anchor.toPoint() + QPoint(-width()/2, SCR_OPT_OFFSET));
+    moveTo(anchor.toPoint());
     show();
 
     connect(toolDelete,           &QToolButton::clicked, this, &CScrOptWpt::slotDelete);

--- a/src/qmapshack/gis/wpt/CScrOptWptRadius.cpp
+++ b/src/qmapshack/gis/wpt/CScrOptWptRadius.cpp
@@ -53,7 +53,7 @@ CScrOptWptRadius::CScrOptWptRadius(CGisItemWpt *wpt, const QPoint& point, IMouse
     toolNogoArea->setChecked(wpt->isNogo());
 
     anchor = wpt->getPointCloseBy(point);
-    move(anchor.toPoint() + QPoint(-width()/2, SCR_OPT_OFFSET));
+    moveTo(anchor.toPoint());
     show();
 
     connect(toolDelete,   &QToolButton::clicked, this, &CScrOptWptRadius::slotDelete);

--- a/src/qmapshack/helpers/CDraw.cpp
+++ b/src/qmapshack/helpers/CDraw.cpp
@@ -204,6 +204,12 @@ void CDraw::text(const QString &str, QPainter &p, const QRect &r, const QColor &
     p.drawText(r, Qt::AlignCenter, str);
 }
 
+QPoint CDraw::bubble(QPainter &p, const QRect &contentRect, const QPoint &pointerPos, const QColor& background)
+{
+    qint32 pointerBasePos = qMax(0, pointerPos.x() - contentRect.left());
+    return CDraw::bubble(p, contentRect, pointerPos, background, 20, pointerBasePos);
+}
+
 QPoint CDraw::bubble(QPainter &p, const QRect &contentRect, const QPoint &pointerPos, const QColor& background,
                      int pointerBaseWidth, float pointerBasePos, const QPen &pen)
 {

--- a/src/qmapshack/helpers/CDraw.h
+++ b/src/qmapshack/helpers/CDraw.h
@@ -79,11 +79,30 @@ public:
        @param p                 An active QPainter
        @param contentRect       The area the actual content will be in
        @param pointerPos        The position of the pointer's head
+       @param background        The color of the background
        @param pointerBaseWidth  The width of the pointer
        @param pointerBasePos    The (relative) location of the pointer (in percent / pixels)
+       @param pen               The border color
+
+       @return Top left corner of content rectangle.
      */
     static QPoint bubble(QPainter &p, const QRect &contentRect, const QPoint &pointerPos, const QColor &background,
-                         int pointerBaseWidth = 20, float pointerBasePos = .5f, const QPen& pen = penBorderGray);
+                         int pointerBaseWidth, float pointerBasePos, const QPen& pen = penBorderGray);
+
+    /**
+       @brief Draw a cartoon bubble
+
+       Shift the pointerBasePos below pointerPos.
+
+       @param p                 An active QPainter
+       @param contentRect       The area the actual content will be in
+       @param pointerPos        The position of the pointer's head
+       @param background        The color of the background
+
+       @return Top left corner of content rectangle.
+     */
+    static QPoint bubble(QPainter &p, const QRect &contentRect, const QPoint &pointerPos, const QColor &background);
+
 
     static bool doesOverlap(const QList<QRectF>& blockedAreas, const QRectF& rect);
 

--- a/src/qmapshack/mouse/IScrOpt.cpp
+++ b/src/qmapshack/mouse/IScrOpt.cpp
@@ -42,6 +42,27 @@ IScrOpt::~IScrOpt()
     CGisWorkspace::self().slotWksItemSelectionReset();
 }
 
+void IScrOpt::moveTo(const QPoint& anchor)
+{
+    CCanvas * canvas = CMainWindow::self().getVisibleCanvas();
+    if(canvas == nullptr)
+    {
+        move(anchor + QPoint(-width()/2, SCR_OPT_OFFSET));
+        return;
+    }
+
+    qint32 xmin = 0;
+    qint32 xmax = canvas->width() - width();
+    qint32 ymax = canvas->height() - height() - SCR_OPT_OFFSET;
+
+    QPoint pt = anchor + QPoint(-width()/2, SCR_OPT_OFFSET);
+    pt.rx() = qMax(xmin, pt.x());
+    pt.rx() = qMin(xmax, pt.x());
+    pt.ry() = qMin(ymax, pt.y());
+
+    move(pt);
+}
+
 void IScrOpt::mouseMove(const QPoint& pos)
 {
     mousePos = pos;

--- a/src/qmapshack/mouse/IScrOpt.h
+++ b/src/qmapshack/mouse/IScrOpt.h
@@ -71,6 +71,8 @@ protected:
         e->accept();
     }
 
+    void moveTo(const QPoint& anchor);
+
     QPoint origin;
     QPoint mousePos;
 

--- a/src/qmapshack/mouse/line/CScrOptRangeLine.cpp
+++ b/src/qmapshack/mouse/line/CScrOptRangeLine.cpp
@@ -34,7 +34,7 @@ CScrOptRangeLine::CScrOptRangeLine(const QPointF &point, IMouse *mouse, QWidget 
 
     setOrigin(point.toPoint());
 
-    move(point.toPoint() + QPoint(-width()/2, SCR_OPT_OFFSET));
+    moveTo(point.toPoint());
     show();
 }
 

--- a/src/qmapshack/mouse/range/CScrOptRangeTrk.cpp
+++ b/src/qmapshack/mouse/range/CScrOptRangeTrk.cpp
@@ -39,8 +39,7 @@ CScrOptRangeTrk::CScrOptRangeTrk(const QPointF &point, CGisItemTrk * trk, IMouse
     adjustSize();
 
     setOrigin(point.toPoint());
-
-    move(point.toPoint() + QPoint(-width()/2, SCR_OPT_OFFSET));
+    moveTo(point.toPoint());
     show();
 
     toolCopy->setDisabled(noRange);


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#148

**Describe roughly what you have done:**

Add method `moveTo()` to `IScrOpt` to unify placement
and to take care of canvas borders.

**What steps have to be done to perform a simple smoke test:**

Click on an item close to the canvas border. It should be visible.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
