### PR TITLE
[QMS-151] Missing tooltip in route toolbar

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-134] Rework track range selection from scratch
 [QMS-140] Enhancements for OS X release
+[QMS-151] Missing tooltip in route toolbar
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/gis/rte/IScrOptRte.ui
+++ b/src/qmapshack/gis/rte/IScrOptRte.ui
@@ -99,6 +99,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="toolInstruction">
+       <property name="toolTip">
+        <string>Show instructions and details.</string>
+       </property>
        <property name="text">
         <string>...</string>
        </property>


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#151

**Describe roughly what you have done:**

I added the tooltip.

**What steps have to be done to perform a simple smoke test:**

Just hoover the mouse over the button.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
