### PR TITLE
[QMS-132] Do not load DEM data out of scale

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,12 @@
 V1.XX.X
 [QMS-68] Route Optimization
+[QMS-132] DEMs: Make the scale range control cut off not only rendering but also loading or requesting the data.
 [QMS-134] Rework track range selection from scratch
 [QMS-135] Improved French translation
 [QMS-140] Enhancements for OS X release
 [QMS-148] Misplaced track info window
 [QMS-151] Missing tooltip in route toolbar
+[QMS-153] Improved French translation
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -648,8 +648,8 @@ void CCanvas::mouseMoveEvent(QMouseEvent * e)
 {
     QPointF pos = e->pos();
     map->convertPx2Rad(pos);
-    qreal ele = dem->getElevationAt(pos);
-    qreal slope = dem->getSlopeAt(pos);
+    qreal ele = dem->getElevationAt(pos, true);
+    qreal slope = dem->getSlopeAt(pos, true);
     emit sigMousePosition(pos * RAD_TO_DEG, ele, slope);
 
     mouse->mouseMoveEvent(e);

--- a/src/qmapshack/dem/CDemDraw.cpp
+++ b/src/qmapshack/dem/CDemDraw.cpp
@@ -268,7 +268,7 @@ void CDemDraw::restoreActiveMapsList(const QStringList& keys, QSettings& cfg)
 }
 
 
-qreal CDemDraw::getElevationAt(const QPointF& pos)
+qreal CDemDraw::getElevationAt(const QPointF& pos, bool checkScale)
 {
     qreal ele = NOFLOAT;
     if(CDemItem::mutexActiveDems.tryLock())
@@ -287,7 +287,7 @@ qreal CDemDraw::getElevationAt(const QPointF& pos)
                     break;
                 }
 
-                ele = item->demfile->getElevationAt(pos);
+                ele = item->demfile->getElevationAt(pos, checkScale);
                 if(ele != NOFLOAT)
                 {
                     break;
@@ -299,7 +299,7 @@ qreal CDemDraw::getElevationAt(const QPointF& pos)
     return ele;
 }
 
-qreal CDemDraw::getSlopeAt(const QPointF& pos)
+qreal CDemDraw::getSlopeAt(const QPointF& pos, bool checkScale)
 {
     qreal slope = NOFLOAT;
     if(CDemItem::mutexActiveDems.tryLock())
@@ -318,7 +318,7 @@ qreal CDemDraw::getSlopeAt(const QPointF& pos)
                     break;
                 }
 
-                slope = item->demfile->getSlopeAt(pos);
+                slope = item->demfile->getSlopeAt(pos, checkScale);
                 if(slope != NOFLOAT)
                 {
                     break;

--- a/src/qmapshack/dem/CDemDraw.h
+++ b/src/qmapshack/dem/CDemDraw.h
@@ -47,11 +47,11 @@ public:
      */
     void loadConfigForDemItem(CDemItem * item);
 
-    qreal getElevationAt(const QPointF& pos);
+    qreal getElevationAt(const QPointF& pos, bool checkScale = false);
     void  getElevationAt(const QPolygonF& pos, QPolygonF& ele);
     void  getElevationAt(SGisLine& line);
 
-    qreal getSlopeAt(const QPointF& pos);
+    qreal getSlopeAt(const QPointF& pos, bool checkScale = false);
     void  getSlopeAt(const QPolygonF& pos, QPolygonF& slope);
 
     void setProjection(const QString& proj) override;

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -140,7 +140,7 @@ CDemVRT::~CDemVRT()
 
 qreal CDemVRT::getElevationAt(const QPointF& pos)
 {
-    if(pjsrc == 0)
+    if(pjsrc == 0 || outOfScale)
     {
         return NOFLOAT;
     }
@@ -185,7 +185,7 @@ qreal CDemVRT::getElevationAt(const QPointF& pos)
 
 qreal CDemVRT::getSlopeAt(const QPointF& pos)
 {
-    if(pjsrc == 0)
+    if(pjsrc == 0 || outOfScale)
     {
         return NOFLOAT;
     }
@@ -232,13 +232,14 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
         return;
     }
 
-    if(!doHillshading() && !doSlopeColor() && !doElevationLimit())
+    QPointF bufferScale = buf.scale * buf.zoomFactor;
+    outOfScale = isOutOfScale(bufferScale);
+
+    if(outOfScale || (!doHillshading() && !doSlopeColor() && !doElevationLimit()))
     {
         QThread::msleep(100);
         return;
     }
-
-    QPointF bufferScale = buf.scale * buf.zoomFactor;
 
     // get pixel offset of top left buffer corner
     QPointF pp = buf.ref1;
@@ -324,7 +325,7 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
     p.setOpacity(o1);
 
     qreal nTiles = ((right - left) * (bottom - top) / (w * h));
-    if(!isOutOfScale(bufferScale) && (nTiles < TILELIMIT))
+    if(nTiles < TILELIMIT)
     {
         for(qreal y = top - 1; y < bottom; y += h)
         {

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -138,9 +138,9 @@ CDemVRT::~CDemVRT()
     GDALClose(dataset);
 }
 
-qreal CDemVRT::getElevationAt(const QPointF& pos)
+qreal CDemVRT::getElevationAt(const QPointF& pos, bool checkScale)
 {
-    if(pjsrc == 0 || outOfScale)
+    if(pjsrc == 0 || (checkScale && outOfScale))
     {
         return NOFLOAT;
     }
@@ -183,9 +183,9 @@ qreal CDemVRT::getElevationAt(const QPointF& pos)
     return ele;
 }
 
-qreal CDemVRT::getSlopeAt(const QPointF& pos)
+qreal CDemVRT::getSlopeAt(const QPointF& pos, bool checkScale)
 {
-    if(pjsrc == 0 || outOfScale)
+    if(pjsrc == 0 || (checkScale && outOfScale))
     {
         return NOFLOAT;
     }

--- a/src/qmapshack/dem/CDemVRT.h
+++ b/src/qmapshack/dem/CDemVRT.h
@@ -57,6 +57,8 @@ private:
     bool hasOverviews = false;
 
     QRectF boundingBox;
+
+    bool outOfScale = false;
 };
 
 #endif //CDEMVRT_H

--- a/src/qmapshack/dem/CDemVRT.h
+++ b/src/qmapshack/dem/CDemVRT.h
@@ -35,8 +35,8 @@ public:
 
     void draw(IDrawContext::buffer_t& buf) override;
 
-    qreal getElevationAt(const QPointF& pos) override;
-    qreal getSlopeAt(const QPointF& pos) override;
+    qreal getElevationAt(const QPointF& pos, bool checkScale) override;
+    qreal getSlopeAt(const QPointF& pos, bool checkScale) override;
 
 private:
     QMutex mutex;

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -51,8 +51,8 @@ public:
 
     virtual void draw(IDrawContext::buffer_t& buf) = 0;
 
-    virtual qreal getElevationAt(const QPointF& pos) = 0;
-    virtual qreal getSlopeAt(const QPointF& pos) = 0;
+    virtual qreal getElevationAt(const QPointF& pos, bool checkScale) = 0;
+    virtual qreal getSlopeAt(const QPointF& pos, bool checkScale) = 0;
 
     bool activated()
     {


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#132

**Describe roughly what you have done:**

Avoid to call GDALDataset::RasterIO() if current scale is out of  valid scale. To achieve that the out of scale information derived during CDemVRT::draw() has to be stored and used in getElevationAt() getSlopeAt().


**What steps have to be done to perform a simple smoke test:**

* Load  DEM
* Set the scale bounds
* Out of the scale bounds no elevation data should be shown in the status bar

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
