### PR TITLE
[QMS-165] Add event filter for QFileOpenEvent

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-148] Misplaced track info window
 [QMS-151] Missing tooltip in route toolbar
 [QMS-153] Improved French translation
+[QMS-165] OSX: GIS files not loaded when clicked
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -96,6 +96,8 @@ CMainWindow::CMainWindow()
     pSelf = this;
     setupUi(this);
 
+    qApp->installEventFilter(this);
+
 #ifdef DEVELOPMENT
     setWindowTitle(WHAT_STR  ".develop");
 #else
@@ -1783,7 +1785,7 @@ bool CMainWindow::nativeEvent(const QByteArray & eventType, void * message, long
         {
         case DBT_DEVICEARRIVAL:
         {
-            qDebug() << "DBT_DEVICEARRIVAL"<< pHdr->dbch_devicetype;
+            qDebug() << "DBT_DEVICEARRIVAL" << pHdr->dbch_devicetype;
             if (pHdr->dbch_devicetype == DBT_DEVTYP_VOLUME)
             {
                 PDEV_BROADCAST_VOLUME pHdrv = (PDEV_BROADCAST_VOLUME)pHdr;
@@ -1877,4 +1879,16 @@ void CMainWindow::slotHelp()
     }
 
     help->setVisible(true);
+}
+
+
+bool CMainWindow::eventFilter(QObject *obj, QEvent *event)
+{
+    if(event->type() == QEvent::FileOpen)
+    {
+        QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
+        qDebug() << "load GIS file:" << openEvent->file();
+        widgetGisWorkspace->loadGisProject(openEvent->file());
+    }
+    return QMainWindow::eventFilter(obj, event);
 }

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -151,6 +151,7 @@ public slots:
     void slotLinkActivated(const QUrl& url);
 
 protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
 #ifdef WIN32
     bool CMainWindow::nativeEvent(const QByteArray & eventType, void * message, long * result);
 #endif // WIN32

--- a/src/qmapshack/GeoMath.cpp
+++ b/src/qmapshack/GeoMath.cpp
@@ -27,7 +27,7 @@
 #include <QtWidgets>
 
 #define PI M_PI
-#define TWOPI (2*PI)
+#define TWOPI (2 * PI)
 
 pointDP::pointDP() : used(true), idx(NOIDX)
 {
@@ -90,21 +90,21 @@ qreal GPS_Math_Distance(const qreal u1, const qreal v1, const qreal u2, const qr
     qreal sinLambda  = 0.0;
     qreal cosLambda  = 0.0;
 
-    qreal a = 6378137.0, b = 6356752.3142,  f = 1.0/298.257223563;  // WGS-84 ellipsiod
+    qreal a = 6378137.0, b = 6356752.3142,  f = 1.0 / 298.257223563;  // WGS-84 ellipsiod
     qreal L = u2 - u1;
 
-    qreal U1 = qAtan((1-f) * qTan(v1));
-    qreal U2 = qAtan((1-f) * qTan(v2));
+    qreal U1 = qAtan((1 - f) * qTan(v1));
+    qreal U2 = qAtan((1 - f) * qTan(v2));
     qreal sinU1 = qSin(U1), cosU1 = qCos(U1);
     qreal sinU2 = qSin(U2), cosU2 = qCos(U2);
-    qreal lambda = L, lambdaP = 2*PI;
+    qreal lambda = L, lambdaP = 2 * PI;
     unsigned iterLimit = 20;
 
     while ((qAbs(lambda - lambdaP) > 1e-12) && (--iterLimit > 0))
     {
         sinLambda = qSin(lambda);
         cosLambda = qCos(lambda);
-        sinSigma = qSqrt((cosU2*sinLambda) * (cosU2*sinLambda) + (cosU1*sinU2-sinU1*cosU2*cosLambda) * (cosU1*sinU2-sinU1*cosU2*cosLambda));
+        sinSigma = qSqrt((cosU2 * sinLambda) * (cosU2 * sinLambda) + (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda) * (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda));
 
         if (sinSigma == 0)
         {
@@ -122,19 +122,19 @@ qreal GPS_Math_Distance(const qreal u1, const qreal v1, const qreal u2, const qr
             cos2SigmaM = 0;  // equatorial line: cosSqAlpha=0 (§6)
         }
 
-        qreal C = f/16 * cosSqAlpha * (4 + f * (4 - 3 * cosSqAlpha));
+        qreal C = f / 16 * cosSqAlpha * (4 + f * (4 - 3 * cosSqAlpha));
         lambdaP = lambda;
-        lambda = L + (1-C) * f * sinAlpha * (sigma + C*sinSigma*(cos2SigmaM + C * cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM)));
+        lambda = L + (1 - C) * f * sinAlpha * (sigma + C * sinSigma * (cos2SigmaM + C * cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM)));
     }
     if (iterLimit == 0)
     {
         return FP_NAN;                // formula failed to converge
     }
-    qreal uSq = cosSqAlpha * (a*a - b*b) / (b*b);
-    qreal A = 1 + uSq/16384*(4096+uSq*(-768+uSq*(320-175*uSq)));
-    qreal B = uSq/1024 * (256+uSq*(-128+uSq*(74-47*uSq)));
-    qreal deltaSigma = B*sinSigma*(cos2SigmaM+B/4*(cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)-B/6*cos2SigmaM*(-3+4*sinSigma*sinSigma)*(-3+4*cos2SigmaM*cos2SigmaM)));
-    qreal s = b*A*(sigma-deltaSigma);
+    qreal uSq = cosSqAlpha * (a * a - b * b) / (b * b);
+    qreal A = 1 + uSq / 16384 * (4096 + uSq * (-768 + uSq * (320 - 175 * uSq)));
+    qreal B = uSq / 1024 * (256 + uSq * (-128 + uSq * (74 - 47 * uSq)));
+    qreal deltaSigma = B * sinSigma * (cos2SigmaM + B / 4 * (cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM) - B / 6 * cos2SigmaM * (-3 + 4 * sinSigma * sinSigma) * (-3 + 4 * cos2SigmaM * cos2SigmaM)));
+    qreal s = b * A * (sigma - deltaSigma);
 
     a1 = qAtan2(cosU2 * sinLambda, cosU1 * sinU2 - sinU1 * cosU2 * cosLambda) * 360 / TWOPI;
     a2 = qAtan2(cosU1 * sinLambda, -sinU1 * cosU2 + cosU1 * sinU2 * cosLambda) * 360 / TWOPI;
@@ -152,21 +152,21 @@ qreal GPS_Math_Distance(const qreal u1, const qreal v1, const qreal u2, const qr
     qreal sinLambda  = 0.0;
     qreal cosLambda  = 0.0;
 
-    qreal a = 6378137.0, b = 6356752.3142,  f = 1.0/298.257223563;  // WGS-84 ellipsiod
+    qreal a = 6378137.0, b = 6356752.3142,  f = 1.0 / 298.257223563;  // WGS-84 ellipsiod
     qreal L = u2 - u1;
 
-    qreal U1 = qAtan((1-f) * qTan(v1));
-    qreal U2 = qAtan((1-f) * qTan(v2));
+    qreal U1 = qAtan((1 - f) * qTan(v1));
+    qreal U2 = qAtan((1 - f) * qTan(v2));
     qreal sinU1 = qSin(U1), cosU1 = qCos(U1);
     qreal sinU2 = qSin(U2), cosU2 = qCos(U2);
-    qreal lambda = L, lambdaP = 2*PI;
+    qreal lambda = L, lambdaP = 2 * PI;
     unsigned iterLimit = 20;
 
     while ((qAbs(lambda - lambdaP) > 1e-12) && (--iterLimit > 0))
     {
         sinLambda = qSin(lambda);
         cosLambda = qCos(lambda);
-        sinSigma = qSqrt((cosU2*sinLambda) * (cosU2*sinLambda) + (cosU1*sinU2-sinU1*cosU2*cosLambda) * (cosU1*sinU2-sinU1*cosU2*cosLambda));
+        sinSigma = qSqrt((cosU2 * sinLambda) * (cosU2 * sinLambda) + (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda) * (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda));
 
         if (sinSigma == 0)
         {
@@ -184,19 +184,19 @@ qreal GPS_Math_Distance(const qreal u1, const qreal v1, const qreal u2, const qr
             cos2SigmaM = 0;  // equatorial line: cosSqAlpha=0 (§6)
         }
 
-        qreal C = f/16 * cosSqAlpha * (4 + f * (4 - 3 * cosSqAlpha));
+        qreal C = f / 16 * cosSqAlpha * (4 + f * (4 - 3 * cosSqAlpha));
         lambdaP = lambda;
-        lambda = L + (1-C) * f * sinAlpha * (sigma + C*sinSigma*(cos2SigmaM + C * cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM)));
+        lambda = L + (1 - C) * f * sinAlpha * (sigma + C * sinSigma * (cos2SigmaM + C * cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM)));
     }
     if (iterLimit == 0)
     {
         return FP_NAN;                // formula failed to converge
     }
-    qreal uSq = cosSqAlpha * (a*a - b*b) / (b*b);
-    qreal A = 1 + uSq/16384*(4096+uSq*(-768+uSq*(320-175*uSq)));
-    qreal B = uSq/1024 * (256+uSq*(-128+uSq*(74-47*uSq)));
-    qreal deltaSigma = B*sinSigma*(cos2SigmaM+B/4*(cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)-B/6*cos2SigmaM*(-3+4*sinSigma*sinSigma)*(-3+4*cos2SigmaM*cos2SigmaM)));
-    qreal s = b*A*(sigma-deltaSigma);
+    qreal uSq = cosSqAlpha * (a * a - b * b) / (b * b);
+    qreal A = 1 + uSq / 16384 * (4096 + uSq * (-768 + uSq * (320 - 175 * uSq)));
+    qreal B = uSq / 1024 * (256 + uSq * (-128 + uSq * (74 - 47 * uSq)));
+    qreal deltaSigma = B * sinSigma * (cos2SigmaM + B / 4 * (cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM) - B / 6 * cos2SigmaM * (-3 + 4 * sinSigma * sinSigma) * (-3 + 4 * cos2SigmaM * cos2SigmaM)));
+    qreal s = b * A * (sigma - deltaSigma);
 
     return s;
 }
@@ -206,7 +206,7 @@ qreal GPS_Math_DistanceQuick(const qreal u1, const qreal v1, const qreal u2, con
     qreal dU = u2 - u1; // lambda
     qreal dV = v2 - v1; // roh
 
-    qreal d = 2*qAsin(qSqrt(qSin(dV/2) * qSin(dV/2) + qCos(v1) * qCos(v2) * qSin(dU/2) * qSin(dU/2)));
+    qreal d = 2 * qAsin(qSqrt(qSin(dV / 2) * qSin(dV / 2) + qCos(v1) * qCos(v2) * qSin(dU / 2) * qSin(dU / 2)));
 
     return 6371010 * d;
 }
@@ -237,16 +237,16 @@ static qreal GPS_Math_distPointLine3D(const point3D &x1, const point3D &x2, cons
     v1x2.z  = v1.x * v2.y - v1.y * v2.x;
 
     // |(x0 - x1)x(x0 - x2)|
-    qreal a1x2    = v1x2.x*v1x2.x + v1x2.y*v1x2.y + v1x2.z*v1x2.z;
+    qreal a1x2    = v1x2.x * v1x2.x + v1x2.y * v1x2.y + v1x2.z * v1x2.z;
     // |(x2 - x1)|
-    qreal a3      = v3.x*v3.x + v3.y*v3.y + v3.z*v3.z;
+    qreal a3      = v3.x * v3.x + v3.y * v3.y + v3.z * v3.z;
 
-    return qSqrt(a1x2/a3);
+    return qSqrt(a1x2 / a3);
 }
 
 static inline qreal sqr(qreal a)
 {
-    return a*a;
+    return a * a;
 }
 static inline qreal sqrlen(const QPointF &a)
 {
@@ -276,8 +276,8 @@ qreal GPS_Math_DistPointPolyline(const QPolygonF &points, const QPointF &q)
 
         const QPointF dab = a - b;
 
-        const qreal inv_sqrlen = 1./sqrlen(dab);
-        const qreal t = (dab.x()*daq.x() + dab.y()*daq.y())*inv_sqrlen;
+        const qreal inv_sqrlen = 1. / sqrlen(dab);
+        const qreal t = (dab.x() * daq.x() + dab.y() * daq.y()) * inv_sqrlen;
         if (t < 0.)
         {
             continue;
@@ -285,7 +285,7 @@ qreal GPS_Math_DistPointPolyline(const QPolygonF &points, const QPointF &q)
         qreal current_dist;
         if (t <= 1.)
         {
-            current_dist = sqr(dab.x()*dbq.y() - dab.y()*dbq.x())*inv_sqrlen;
+            current_dist = sqr(dab.x() * dbq.y() - dab.y() * dbq.x()) * inv_sqrlen;
         }
         else//t>1.
         {
@@ -305,9 +305,9 @@ qreal GPS_Math_DistPointPolyline(const QPolygonF& line, const QPointF& pt, qreal
 
     const int len = line.size();
     // see http://local.wasp.uwa.edu.au/~pbourke/geometry/pointline/
-    for(int i=1; i < len; ++i)
+    for(int i = 1; i < len; ++i)
     {
-        const QPointF &p1 = line[i-1];
+        const QPointF &p1 = line[i - 1];
         const QPointF &p2 = line[i];
 
         qreal dx = p2.x() - p1.x();
@@ -328,7 +328,7 @@ qreal GPS_Math_DistPointPolyline(const QPolygonF& line, const QPointF& pt, qreal
         qreal x = p1.x() + u * dx;
         qreal y = p1.y() + u * dy;
 
-        qreal distance = qSqrt((x - pt.x())*(x - pt.x()) + (y - pt.y())*(y - pt.y()));
+        qreal distance = qSqrt((x - pt.x()) * (x - pt.x()) + (y - pt.y()) * (y - pt.y()));
         if(distance < threshold)
         {
             d = threshold = distance;
@@ -457,7 +457,7 @@ void GPS_Math_SubPolyline(const QPointF& pt1, const QPointF& pt2, qint32 thresho
             x = p1.u + u * dx;
             y = p1.v + u * dy;
 
-            qreal distance = qSqrt((x - pt1.x())*(x - pt1.x()) + (y - pt1.y())*(y - pt1.y()));
+            qreal distance = qSqrt((x - pt1.x()) * (x - pt1.x()) + (y - pt1.y()) * (y - pt1.y()));
 
             if(distance < shortest1)
             {
@@ -478,7 +478,7 @@ void GPS_Math_SubPolyline(const QPointF& pt1, const QPointF& pt2, qint32 thresho
             x = p1.u + u * dx;
             y = p1.v + u * dy;
 
-            qreal distance = qSqrt((x - pt2.x())*(x - pt2.x()) + (y - pt2.y())*(y - pt2.y()));
+            qreal distance = qSqrt((x - pt2.x()) * (x - pt2.x()) + (y - pt2.y()) * (y - pt2.y()));
 
             if(distance < shortest2)
             {
@@ -520,7 +520,7 @@ void GPS_Math_SubPolyline(const QPointF& pt1, const QPointF& pt2, qint32 thresho
         QPointF px = pixel.first();
         qreal dist = distance(px, pt2);
 
-        if(dist < (threshold<<1))
+        if(dist < (threshold << 1))
         {
             idx21 = 0;
             pt21 = px;
@@ -529,7 +529,7 @@ void GPS_Math_SubPolyline(const QPointF& pt1, const QPointF& pt2, qint32 thresho
         {
             px = pixel.last();
             qreal dist = distance(px, pt2);
-            if(dist < (threshold<<1))
+            if(dist < (threshold << 1))
             {
                 idx21 = pixel.size() - 2;
                 pt21 = px;
@@ -591,52 +591,52 @@ QPointF GPS_Math_Wpt_Projection(const QPointF& p1, qreal distance, qreal bearing
 
     const qreal a = 6378137.0;
     const qreal b = 6356752.3142;
-    const qreal f = 1.0/298.257223563;
+    const qreal f = 1.0 / 298.257223563;
 
     qreal sinAlpha1 = qSin(Alpha1);
     qreal cosAlpha1 = qCos(Alpha1);
 
-    qreal tanU1 = (1-f) * qTan(Phi1);
-    qreal cosU1 = 1 / qSqrt((1 + tanU1*tanU1));
+    qreal tanU1 = (1 - f) * qTan(Phi1);
+    qreal cosU1 = 1 / qSqrt((1 + tanU1 * tanU1));
     qreal sinU1 = tanU1 * cosU1;
     qreal Sigma1 = qAtan2(tanU1, cosAlpha1);
     qreal sinAlpha = cosU1 * sinAlpha1;
-    qreal cosSqAlpha = 1 - sinAlpha*sinAlpha;
-    qreal uSq = cosSqAlpha * (a*a - b*b) / (b*b);
-    qreal A = 1 + uSq/16384*(4096+uSq*(-768+uSq*(320-175*uSq)));
-    qreal B = uSq/1024 * (256+uSq*(-128+uSq*(74-47*uSq)));
+    qreal cosSqAlpha = 1 - sinAlpha * sinAlpha;
+    qreal uSq = cosSqAlpha * (a * a - b * b) / (b * b);
+    qreal A = 1 + uSq / 16384 * (4096 + uSq * (-768 + uSq * (320 - 175 * uSq)));
+    qreal B = uSq / 1024 * (256 + uSq * (-128 + uSq * (74 - 47 * uSq)));
 
     qreal cos2SigmaM;
     qreal sinSigma;
     qreal cosSigma;
     qreal deltaSigma;
 
-    qreal Sigma = s / (b*A);
+    qreal Sigma = s / (b * A);
     qreal Sigma_;
     int iterations = 0;
     do
     {
-        cos2SigmaM = qCos(2*Sigma1 + Sigma);
+        cos2SigmaM = qCos(2 * Sigma1 + Sigma);
         sinSigma = qSin(Sigma);
         cosSigma = qCos(Sigma);
-        deltaSigma = B*sinSigma*(cos2SigmaM+B/4*(cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)-
-                                                 B/6*cos2SigmaM*(-3+4*sinSigma*sinSigma)*(-3+4*cos2SigmaM*cos2SigmaM)));
+        deltaSigma = B * sinSigma * (cos2SigmaM + B / 4 * (cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM) -
+                                                           B / 6 * cos2SigmaM * (-3 + 4 * sinSigma * sinSigma) * (-3 + 4 * cos2SigmaM * cos2SigmaM)));
         Sigma_ = Sigma;
-        Sigma = s / (b*A) + deltaSigma;
+        Sigma = s / (b * A) + deltaSigma;
     }
-    while (qAbs(Sigma-Sigma_) > 1e-12 && ++iterations < 100);
+    while (qAbs(Sigma - Sigma_) > 1e-12 && ++iterations < 100);
     if (iterations >= 100)
     {
         return NOPOINTF;
     }
-    qreal x = sinU1*sinSigma - cosU1*cosSigma*cosAlpha1;
-    qreal Phi2 = qAtan2(sinU1*cosSigma + cosU1*sinSigma*cosAlpha1, (1-f)*qSqrt(sinAlpha*sinAlpha + x*x));
-    qreal Lambda = qAtan2(sinSigma*sinAlpha1, cosU1*cosSigma - sinU1*sinSigma*cosAlpha1);
-    qreal C = f/16*cosSqAlpha*(4+f*(4-3*cosSqAlpha));
-    qreal L = Lambda - (1-C) * f * sinAlpha *
-              (Sigma + C*sinSigma*(cos2SigmaM+C*cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)));
+    qreal x = sinU1 * sinSigma - cosU1 * cosSigma * cosAlpha1;
+    qreal Phi2 = qAtan2(sinU1 * cosSigma + cosU1 * sinSigma * cosAlpha1, (1 - f) * qSqrt(sinAlpha * sinAlpha + x * x));
+    qreal Lambda = qAtan2(sinSigma * sinAlpha1, cosU1 * cosSigma - sinU1 * sinSigma * cosAlpha1);
+    qreal C = f / 16 * cosSqAlpha * (4 + f * (4 - 3 * cosSqAlpha));
+    qreal L = Lambda - (1 - C) * f * sinAlpha *
+              (Sigma + C * sinSigma * (cos2SigmaM + C * cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM)));
 
-    qreal Lambda2 = Lambda1+L;
+    qreal Lambda2 = Lambda1 + L;
     if(Lambda2 > PI)
     {
         Lambda2 = -Lambda2 + PI;

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -554,10 +554,10 @@ void CCanvas::resizeEvent(QResizeEvent * e)
     const QRect& r = rect();
 
     // move map loading indicator to new center of canvas
-    QPoint p1(mapLoadIndicator->width()>>1, mapLoadIndicator->height()>>1);
+    QPoint p1(mapLoadIndicator->width() >> 1, mapLoadIndicator->height() >> 1);
     mapLoadIndicator->move(r.center() - p1);
 
-    QPoint p2(demLoadIndicator->width()>>1, demLoadIndicator->height()>>1);
+    QPoint p2(demLoadIndicator->width() >> 1, demLoadIndicator->height() >> 1);
     demLoadIndicator->move(r.center() - p2);
 
     textStatusMessages->move(X_OFF_STATUS, Y_OFF_STATUS);
@@ -619,7 +619,7 @@ void CCanvas::paintEvent(QPaintEvent*)
     mouse->draw(p, needsRedraw, rect());
 
     drawStatusMessages(p);
-    drawTrackStatistic(p);    
+    drawTrackStatistic(p);
 
     p.end();
     needsRedraw = eRedrawNone;
@@ -747,19 +747,19 @@ void CCanvas::keyPressEvent(QKeyEvent * e)
 
     /* move the map with keys up, down, left and right */
     case Qt::Key_Up:
-        moveMap(QPointF(0,  height()/4));
+        moveMap(QPointF(0,  height() / 4));
         break;
 
     case Qt::Key_Down:
-        moveMap(QPointF(0, -height()/4));
+        moveMap(QPointF(0, -height() / 4));
         break;
 
     case Qt::Key_Left:
-        moveMap(QPointF( width()/4, 0));
+        moveMap(QPointF( width() / 4, 0));
         break;
 
     case Qt::Key_Right:
-        moveMap(QPointF(-width()/4, 0));
+        moveMap(QPointF(-width() / 4, 0));
         break;
 
     case Qt::Key_Escape:
@@ -873,7 +873,7 @@ void CCanvas::drawScale(QPainter& p, QRectF drawRect)
     p.drawLine(pt1, pt2 + QPoint(9, 0));
 
 
-    QPoint pt3(pt2.x() + (pt1.x() - pt2.x())/2, pt2.y());
+    QPoint pt3(pt2.x() + (pt1.x() - pt2.x()) / 2, pt2.y());
 
     QString val, unit;
     IUnit::self().meter2distance(d, val, unit);
@@ -962,7 +962,7 @@ void CCanvas::slotUpdateTrackInfo(bool updateVisuals)
         QString text;
         if(isShowTrackSummary())
         {
-            text += trk->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowActivity);
+            text += trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity);
         }
 
         if(isShowMinMaxSummary())

--- a/src/qmapshack/canvas/IDrawContext.cpp
+++ b/src/qmapshack/canvas/IDrawContext.cpp
@@ -106,7 +106,7 @@ bool IDrawContext::resize(const QSize& size)
     viewWidth  = size.width();
     viewHeight = size.height();
 
-    center     = QPointF(viewWidth/2.0, viewHeight/2.0);
+    center     = QPointF(viewWidth / 2.0, viewHeight / 2.0);
     bufWidth   = viewWidth  + 2 * BUFFER_BORDER;
     bufHeight  = viewHeight + 2 * BUFFER_BORDER;
 
@@ -246,8 +246,8 @@ void IDrawContext::convertRad2M(QPointF &p) const
         turnaround. It exceeds the values. We have to
         apply fixes in that case.
      */
-    bool fixWest = p.x() < (-180*DEG_TO_RAD);
-    bool fixEast = p.x() > ( 180*DEG_TO_RAD);
+    bool fixWest = p.x() < (-180 * DEG_TO_RAD);
+    bool fixEast = p.x() > ( 180 * DEG_TO_RAD);
 
     pj_transform(pjtar, pjsrc, 1, 0, &p.rx(), &p.ry(), 0);
 
@@ -258,16 +258,16 @@ void IDrawContext::convertRad2M(QPointF &p) const
      */
     if(fixWest)
     {
-        QPointF o(-180*DEG_TO_RAD, y);
+        QPointF o(-180 * DEG_TO_RAD, y);
         convertRad2M(o);
-        p.rx() = 2*o.x() + p.x();
+        p.rx() = 2 * o.x() + p.x();
     }
 
     if(fixEast)
     {
-        QPointF o(180*DEG_TO_RAD, y);
+        QPointF o(180 * DEG_TO_RAD, y);
         convertRad2M(o);
-        p.rx() = 2*o.x() + p.x();
+        p.rx() = 2 * o.x() + p.x();
     }
 }
 
@@ -342,11 +342,11 @@ void IDrawContext::convertRad2Px(QPolygonF& poly) const
      */
     for(int i = 0; i < N; ++i, ++pFix, pY += 2)
     {
-        if(*pY < (-180*DEG_TO_RAD))
+        if(*pY < (-180 * DEG_TO_RAD))
         {
             pFix->fixWest = *pY;
         }
-        if(*pY > ( 180*DEG_TO_RAD))
+        if(*pY > ( 180 * DEG_TO_RAD))
         {
             pFix->fixEast = *pY;
         }
@@ -366,15 +366,15 @@ void IDrawContext::convertRad2Px(QPolygonF& poly) const
          */
         if(pFix->fixWest != NOFLOAT)
         {
-            QPointF o(-180*DEG_TO_RAD, pFix->fixWest);
+            QPointF o(-180 * DEG_TO_RAD, pFix->fixWest);
             convertRad2M(o);
-            pPt->rx() = 2*o.x() + pPt->x();
+            pPt->rx() = 2 * o.x() + pPt->x();
         }
         if(pFix->fixEast != NOFLOAT)
         {
-            QPointF o(180*DEG_TO_RAD, pFix->fixEast);
+            QPointF o(180 * DEG_TO_RAD, pFix->fixEast);
             convertRad2M(o);
-            pPt->rx() = 2*o.x() + pPt->x();
+            pPt->rx() = 2 * o.x() + pPt->x();
         }
 
         *pPt = (*pPt - f) / (scale * zoomFactor) + center;
@@ -402,10 +402,10 @@ void IDrawContext::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QPoint
     mutex.lock(); // --------- start serialize with thread
 
     // derive references for all corners coordinate of map buffer
-    ref1 = f1 + QPointF(-bufWidth/2, -bufHeight/2) * bufferScale;
-    ref2 = f1 + QPointF( bufWidth/2, -bufHeight/2) * bufferScale;
-    ref3 = f1 + QPointF( bufWidth/2,  bufHeight/2) * bufferScale;
-    ref4 = f1 + QPointF(-bufWidth/2,  bufHeight/2) * bufferScale;
+    ref1 = f1 + QPointF(-bufWidth / 2, -bufHeight / 2) * bufferScale;
+    ref2 = f1 + QPointF( bufWidth / 2, -bufHeight / 2) * bufferScale;
+    ref3 = f1 + QPointF( bufWidth / 2,  bufHeight / 2) * bufferScale;
+    ref4 = f1 + QPointF(-bufWidth / 2,  bufHeight / 2) * bufferScale;
     convertM2Rad(ref1);
     convertM2Rad(ref2);
     convertM2Rad(ref3);
@@ -416,20 +416,20 @@ void IDrawContext::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QPoint
     {
         if(qAbs(ref1.x()) > qAbs(ref2.x()))
         {
-            ref1.rx() = -2*(180*DEG_TO_RAD) + ref1.rx();
+            ref1.rx() = -2 * (180 * DEG_TO_RAD) + ref1.rx();
         }
         if(qAbs(ref4.x()) > qAbs(ref3.x()))
         {
-            ref4.rx() = -2*(180*DEG_TO_RAD) + ref4.rx();
+            ref4.rx() = -2 * (180 * DEG_TO_RAD) + ref4.rx();
         }
 
         if(qAbs(ref1.x()) < qAbs(ref2.x()))
         {
-            ref2.rx() = 2*(180*DEG_TO_RAD) + ref2.rx();
+            ref2.rx() = 2 * (180 * DEG_TO_RAD) + ref2.rx();
         }
         if(qAbs(ref4.x()) < qAbs(ref3.x()))
         {
-            ref3.rx() = 2*(180*DEG_TO_RAD) + ref3.rx();
+            ref3.rx() = 2 * (180 * DEG_TO_RAD) + ref3.rx();
         }
     }
 
@@ -449,7 +449,7 @@ void IDrawContext::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QPoint
 
     p.save();
     // scale image if current zoomfactor does not match buffer's zoomfactor
-    p.scale(currentBuffer.zoomFactor.x()/zoomFactor.x(), currentBuffer.zoomFactor.y()/zoomFactor.y());
+    p.scale(currentBuffer.zoomFactor.x() / zoomFactor.x(), currentBuffer.zoomFactor.y() / zoomFactor.y());
     // add offset
     p.translate(off);
     // draw buffer to painter

--- a/src/qmapshack/canvas/IDrawObject.cpp
+++ b/src/qmapshack/canvas/IDrawObject.cpp
@@ -101,8 +101,8 @@ void IDrawObject::drawTileLQ(const QImage& img, QPolygonF& l, QPainter& p, IDraw
     qreal dy1 = l[0].y() - l[1].y();
     qreal dx2 = l[0].x() - l[3].x();
     qreal dy2 = l[0].y() - l[3].y();
-    qreal w   = qCeil( qSqrt(dx1*dx1 + dy1*dy1));
-    qreal h   = qCeil( qSqrt(dx2*dx2 + dy2*dy2));
+    qreal w   = qCeil( qSqrt(dx1 * dx1 + dy1 * dy1));
+    qreal h   = qCeil( qSqrt(dx2 * dx2 + dy2 * dy2));
 
 
     // switch to HQ if the gaps get visible
@@ -116,12 +116,12 @@ void IDrawObject::drawTileLQ(const QImage& img, QPolygonF& l, QPainter& p, IDraw
     }
 
     // calculate rotation. This is not really a reprojection but might be good enough for close zoom levels
-    qreal a = qAtan(dy1/dx1) * RAD_TO_DEG;
+    qreal a = qAtan(dy1 / dx1) * RAD_TO_DEG;
 
     // finally translate, scale, rotate and draw tile
     p.save();
     p.translate(l[0]);
-    p.scale(w/img.width(), h/img.height());
+    p.scale(w / img.width(), h / img.height());
     p.rotate(a);
     p.drawImage(0, 0, img);
     p.restore();
@@ -135,11 +135,11 @@ void IDrawObject::drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDraw
     // rounding effects.
     qint32 nStepsX = 8;
     qint32 nStepsY = 8;
-    if(img.width()/nStepsX < 32)
+    if(img.width() / nStepsX < 32)
     {
         nStepsX = 4;
     }
-    if(img.height()/nStepsY < 32)
+    if(img.height() / nStepsY < 32)
     {
         nStepsY = 4;
     }
@@ -189,7 +189,7 @@ void IDrawObject::drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDraw
     // canvas using the view's projection
     context.convertRad2Px(quads);
 
-    QRectF rect(0, 0, img.width()/nStepsX, img.height() / nStepsY);
+    QRectF rect(0, 0, img.width() / nStepsX, img.height() / nStepsY);
     const qreal rw = rect.width();
     const qreal rh = rect.height();
 
@@ -206,11 +206,11 @@ void IDrawObject::drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDraw
             qreal dy1 = pPt[0].y() - pPt[1].y();
             qreal dx2 = pPt[0].x() - pPt[3].x();
             qreal dy2 = pPt[0].y() - pPt[3].y();
-            qreal w   = /*qRound*/ ( qSqrt(dx1*dx1 + dy1*dy1));
-            qreal h   = /*qRound*/ ( qSqrt(dx2*dx2 + dy2*dy2));
+            qreal w   = /*qRound*/ ( qSqrt(dx1 * dx1 + dy1 * dy1));
+            qreal h   = /*qRound*/ ( qSqrt(dx2 * dx2 + dy2 * dy2));
 
             // calculate rotation. This is not really a reprojection but might be good enough for close zoom levels
-            qreal a = qAtan(dy1/dx1) * RAD_TO_DEG;
+            qreal a = qAtan(dy1 / dx1) * RAD_TO_DEG;
 
             // move rect to select the part of the tile to draw.
             rect.moveLeft(x * rw);
@@ -218,7 +218,7 @@ void IDrawObject::drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDraw
             // finally translate, scale, rotate and draw tile
             p.save();
             p.translate(pPt[0]);
-            p.scale(w/rw, h/rh);
+            p.scale(w / rw, h / rh);
             p.rotate(a);
             p.drawImage(QPoint(0, 0), img, rect);
             p.restore();

--- a/src/qmapshack/dem/CDemDraw.cpp
+++ b/src/qmapshack/dem/CDemDraw.cpp
@@ -153,7 +153,7 @@ void CDemDraw::buildMapList()
     {
         QDir dir(path);
         // find available maps
-        for(const QString &filename : dir.entryList(supportedFormats, QDir::Files|QDir::Readable, QDir::Name))
+        for(const QString &filename : dir.entryList(supportedFormats, QDir::Files | QDir::Readable, QDir::Name))
         {
             QFileInfo fi(filename);
 

--- a/src/qmapshack/dem/CDemList.cpp
+++ b/src/qmapshack/dem/CDemList.cpp
@@ -177,7 +177,7 @@ void CDemList::slotMoveUp()
 
     item->showChildren(false);
     treeWidget->takeTopLevelItem(index);
-    treeWidget->insertTopLevelItem(index-1, item);
+    treeWidget->insertTopLevelItem(index - 1, item);
     item->showChildren(true);
     treeWidget->setCurrentItem(0);
     emit treeWidget->sigChanged();
@@ -199,7 +199,7 @@ void CDemList::slotMoveDown()
 
     item->showChildren(false);
     treeWidget->takeTopLevelItem(index);
-    treeWidget->insertTopLevelItem(index+1, item);
+    treeWidget->insertTopLevelItem(index + 1, item);
     item->showChildren(true);
     treeWidget->setCurrentItem(0);
     emit treeWidget->sigChanged();

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -106,7 +106,7 @@ CDemVRT::CDemVRT(const QString &filename, CDemDraw *parent)
 
     if(adfGeoTransform[4] != 0.0)
     {
-        trFwd.rotate(qAtan(adfGeoTransform[2]/adfGeoTransform[4]));
+        trFwd.rotate(qAtan(adfGeoTransform[2] / adfGeoTransform[4]));
     }
 
     if(pj_is_latlong(pjsrc))
@@ -206,13 +206,13 @@ qreal CDemVRT::getSlopeAt(const QPointF& pos, bool checkScale)
 
     qint16 win[eWinsize4x4];
     mutex.lock();
-    CPLErr err = dataset->RasterIO(GF_Read, qFloor(pt.x())-1, qFloor(pt.y())-1, 4, 4, &win, 4, 4, GDT_Int16, 1, 0, 0, 0, 0);
+    CPLErr err = dataset->RasterIO(GF_Read, qFloor(pt.x()) - 1, qFloor(pt.y()) - 1, 4, 4, &win, 4, 4, GDT_Int16, 1, 0, 0, 0, 0);
     mutex.unlock();
     if(err == CE_Failure)
     {
         return NOFLOAT;
     }
-    for(int i=0; i < eWinsize4x4; i++)
+    for(int i = 0; i < eWinsize4x4; i++)
     {
         if(hasNoData && win[i] == noData)
         {
@@ -320,7 +320,7 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
     USE_ANTI_ALIASING(p, true);
     p.translate(-pp);
 
-    qreal o1 = getOpacity()/100.0;
+    qreal o1 = getOpacity() / 100.0;
     qreal o2 = ((o1 + 0.4) >= 1.0) ? o1 : (o1 + 0.4);
     p.setOpacity(o1);
 

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -165,7 +165,7 @@ void IDem::slotSetFactorHillshade(int f)
     }
     else if(f < 0)
     {
-        factorHillshading = -1.0/f;
+        factorHillshading = -1.0 / f;
     }
     else
     {
@@ -209,7 +209,7 @@ int IDem::getFactorHillshading()
     }
     else if(factorHillshading < 1)
     {
-        return -1.0/factorHillshading;
+        return -1.0 / factorHillshading;
     }
     else
     {
@@ -222,9 +222,9 @@ void IDem::hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img)
     int wp2 = w + 2;
 
 #define ZFACT           0.125
-#define ZFACT_BY_ZFACT  (ZFACT*ZFACT)
-#define SIN_ALT         (qSin(45*DEG_TO_RAD))
-#define ZFACT_COS_ALT   (ZFACT*qCos(45*DEG_TO_RAD))
+#define ZFACT_BY_ZFACT  (ZFACT * ZFACT)
+#define SIN_ALT         (qSin(45 * DEG_TO_RAD))
+#define ZFACT_COS_ALT   (ZFACT * qCos(45 * DEG_TO_RAD))
 #define AZ              (315 * DEG_TO_RAD)
     for(unsigned int m = 1; m <= h; m++)
     {
@@ -240,11 +240,11 @@ void IDem::hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img)
                 continue;
             }
 
-            qreal dx         = ((win[0] + win[3] + win[3] + win[6]) - (win[2] + win[5] + win[5] + win[8])) / (xscale*factorHillshading);
-            qreal dy         = ((win[6] + win[7] + win[7] + win[8]) - (win[0] + win[1] + win[1] + win[2])) / (yscale*factorHillshading);
+            qreal dx         = ((win[0] + win[3] + win[3] + win[6]) - (win[2] + win[5] + win[5] + win[8])) / (xscale * factorHillshading);
+            qreal dy         = ((win[6] + win[7] + win[7] + win[8]) - (win[0] + win[1] + win[1] + win[2])) / (yscale * factorHillshading);
             qreal aspect     = qAtan2(dy, dx);
             qreal xx_plus_yy = dx * dx + dy * dy;
-            qreal cang       = (SIN_ALT - ZFACT_COS_ALT * qSqrt(xx_plus_yy) * qSin(aspect - AZ)) / qSqrt(1+ZFACT_BY_ZFACT*xx_plus_yy);
+            qreal cang       = (SIN_ALT - ZFACT_COS_ALT * qSqrt(xx_plus_yy) * qSin(aspect - AZ)) / qSqrt(1 + ZFACT_BY_ZFACT * xx_plus_yy);
 
             if (cang <= 0.0)
             {
@@ -281,17 +281,17 @@ qreal IDem::slopeOfWindowInterp(qint16* win2, winsize_e size, qreal x, qreal y)
         break;
 
     case eWinsize4x4:
-        win[0] = win2[0] + x * (win2[1]-win2[0]) + y * (win2[4]-win2[0]) + x*y*(win2[0]-win2[1]-win2[4]+win2[5]);
-        win[1] = win2[1] + x * (win2[2]-win2[1]) + y * (win2[5]-win2[1]) + x*y*(win2[1]-win2[2]-win2[5]+win2[6]);
-        win[2] = win2[2] + x * (win2[3]-win2[2]) + y * (win2[6]-win2[2]) + x*y*(win2[2]-win2[3]-win2[6]+win2[7]);
+        win[0] = win2[0] + x * (win2[1] - win2[0]) + y * (win2[4] - win2[0]) + x * y * (win2[0] - win2[1] - win2[4] + win2[5]);
+        win[1] = win2[1] + x * (win2[2] - win2[1]) + y * (win2[5] - win2[1]) + x * y * (win2[1] - win2[2] - win2[5] + win2[6]);
+        win[2] = win2[2] + x * (win2[3] - win2[2]) + y * (win2[6] - win2[2]) + x * y * (win2[2] - win2[3] - win2[6] + win2[7]);
 
-        win[3] = win2[4] + x * (win2[5]-win2[4]) + y * (win2[8]-win2[4]) + x*y*(win2[4]-win2[5]-win2[8]+win2[9]);
-        win[4] = win2[5] + x * (win2[6]-win2[5]) + y * (win2[9]-win2[5]) + x*y*(win2[5]-win2[6]-win2[9]+win2[10]);
-        win[5] = win2[6] + x * (win2[7]-win2[6]) + y * (win2[10]-win2[6]) + x*y*(win2[6]-win2[7]-win2[10]+win2[11]);
+        win[3] = win2[4] + x * (win2[5] - win2[4]) + y * (win2[8] - win2[4]) + x * y * (win2[4] - win2[5] - win2[8] + win2[9]);
+        win[4] = win2[5] + x * (win2[6] - win2[5]) + y * (win2[9] - win2[5]) + x * y * (win2[5] - win2[6] - win2[9] + win2[10]);
+        win[5] = win2[6] + x * (win2[7] - win2[6]) + y * (win2[10] - win2[6]) + x * y * (win2[6] - win2[7] - win2[10] + win2[11]);
 
-        win[6] = win2[8] + x * (win2[9]-win2[8]) + y * (win2[12]-win2[8]) + x*y*(win2[8]-win2[9]-win2[12]+win2[13]);
-        win[7] = win2[9] + x * (win2[10]-win2[9]) + y * (win2[13]-win2[9]) + x*y*(win2[9]-win2[10]-win2[13]+win2[14]);
-        win[8] = win2[10] + x * (win2[11]-win2[10]) + y * (win2[14]-win2[10]) + x*y*(win2[10]-win2[11]-win2[14]+win2[15]);
+        win[6] = win2[8] + x * (win2[9] - win2[8]) + y * (win2[12] - win2[8]) + x * y * (win2[8] - win2[9] - win2[12] + win2[13]);
+        win[7] = win2[9] + x * (win2[10] - win2[9]) + y * (win2[13] - win2[9]) + x * y * (win2[9] - win2[10] - win2[13] + win2[14]);
+        win[8] = win2[10] + x * (win2[11] - win2[10]) + y * (win2[14] - win2[10]) + x * y * (win2[10] - win2[11] - win2[14] + win2[15]);
         break;
 
     default:

--- a/src/qmapshack/dem/IDemProp.h
+++ b/src/qmapshack/dem/IDemProp.h
@@ -32,7 +32,7 @@ public:
     virtual ~IDemProp();
 
 protected slots:
-    virtual void slotPropertiesChanged()= 0;
+    virtual void slotPropertiesChanged() = 0;
 
 protected:
     IDem * demfile;

--- a/src/qmapshack/device/CDeviceGarmin.cpp
+++ b/src/qmapshack/device/CDeviceGarmin.cpp
@@ -303,7 +303,7 @@ void CDeviceGarmin::saveImages(CGisItemWpt& wpt)
     {
         QString name = wpt.getName();
         quint32 size = name.size();
-        QString path = QString("%1/%2/%3").arg(name.at(size-1)).arg(name.at(size -2)).arg(name);
+        QString path = QString("%1/%2/%3").arg(name.at(size - 1)).arg(name.at(size - 2)).arg(name);
 
         const QDir dirSpoilers(dir.absoluteFilePath(pathSpoilers));
         const QDir dirCache(dirSpoilers.absoluteFilePath(path));
@@ -360,7 +360,7 @@ void CDeviceGarmin::loadImages(CGisItemWpt& wpt)
     {
         QString name = wpt.getName();
         quint32 size = name.size();
-        QString path = QString("%1/%2/%3").arg(name.at(size-1)).arg(name.at(size -2)).arg(name);
+        QString path = QString("%1/%2/%3").arg(name.at(size - 1)).arg(name.at(size - 2)).arg(name);
 
         const QDir dirSpoilers(dir.absoluteFilePath(pathSpoilers));
         const QDir dirCache(dirSpoilers.absoluteFilePath(path));
@@ -442,7 +442,7 @@ void CDeviceGarmin::aboutToRemoveProject(IGisProject * project)
         {
             QString name = wpt->getName();
             quint32 size = name.size();
-            QString path = QString("%1/%2/%3").arg(name.at(size-1)).arg(name.at(size -2)).arg(name);
+            QString path = QString("%1/%2/%3").arg(name.at(size - 1)).arg(name.at(size - 2)).arg(name);
 
             QDir dirSpoilers(dir.absoluteFilePath(pathSpoilers));
             QDir dirCache(dirSpoilers.absoluteFilePath(path));

--- a/src/qmapshack/device/CDeviceTwoNav.cpp
+++ b/src/qmapshack/device/CDeviceTwoNav.cpp
@@ -65,7 +65,7 @@ CDeviceTwoNav::CDeviceTwoNav(const QString &path, const QString &key, const QStr
         }
     }
 
-    entries = dirData.entryList(QDir::NoDotAndDotDot|QDir::Dirs);
+    entries = dirData.entryList(QDir::NoDotAndDotDot | QDir::Dirs);
     for(const QString &entry : entries)
     {
         IGisProject * project =  new CTwoNavProject(dirData.absoluteFilePath(entry), this);

--- a/src/qmapshack/device/IDevice.cpp
+++ b/src/qmapshack/device/IDevice.cpp
@@ -316,7 +316,7 @@ bool IDevice::testForExternalProject(const QString& filename)
     {
         CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
         QString msg = tr("There is another project with the same name. If you press 'ok' it will be removed and replaced.");
-        int res = QMessageBox::warning(CMainWindow::getBestWidgetForParent(), getName(), msg, QMessageBox::Ok|QMessageBox::Abort, QMessageBox::Ok);
+        int res = QMessageBox::warning(CMainWindow::getBestWidgetForParent(), getName(), msg, QMessageBox::Ok | QMessageBox::Abort, QMessageBox::Ok);
         if(res != QMessageBox::Ok)
         {
             return true;

--- a/src/qmapshack/gis/CGisItemRate.cpp
+++ b/src/qmapshack/gis/CGisItemRate.cpp
@@ -84,17 +84,17 @@ QSet<QString> CGisItemRate::getRemovedKeywords() const
 
 void CGisItemRate::ratingLabelClicked(int labelNumber)
 {
-    ratingChanged=true;
+    ratingChanged = true;
 
     //Comparing like this since one is a floating point and one an integer
     if(rating > labelNumber || rating < labelNumber)
     {
-        rating=labelNumber;
+        rating = labelNumber;
     }
     else
     {
         //The icon is already a star, if you click it again, the star goes away
-        rating=labelNumber-1;
+        rating = labelNumber - 1;
     }
     updateStars();
 }

--- a/src/qmapshack/gis/CGisListDB.cpp
+++ b/src/qmapshack/gis/CGisListDB.cpp
@@ -459,7 +459,7 @@ void CGisListDB::slotDelDatabase()
         return;
     }
 
-    int res = QMessageBox::question(this, tr("Remove database..."), tr("Do you really want to remove '%1' from the list?").arg(folder->text(CGisListDB::eColumnName)), QMessageBox::Ok|QMessageBox::Abort, QMessageBox::Ok);
+    int res = QMessageBox::question(this, tr("Remove database..."), tr("Do you really want to remove '%1' from the list?").arg(folder->text(CGisListDB::eColumnName)), QMessageBox::Ok | QMessageBox::Abort, QMessageBox::Ok);
     if(res != QMessageBox::Ok)
     {
         return;
@@ -523,7 +523,7 @@ void CGisListDB::slotDelFolder()
         return;
     }
 
-    int res = QMessageBox::question(this, tr("Delete database folder..."), tr("Are you sure you want to delete selected folders and all subfolders from the database?"), QMessageBox::Ok|QMessageBox::No);
+    int res = QMessageBox::question(this, tr("Delete database folder..."), tr("Are you sure you want to delete selected folders and all subfolders from the database?"), QMessageBox::Ok | QMessageBox::No);
     if(res != QMessageBox::Ok)
     {
         return;
@@ -773,7 +773,7 @@ void CGisListDB::slotDelLostFound()
         return;
     }
 
-    int res = QMessageBox::question(this, tr("Remove items..."), tr("Are you sure you want to delete all items from Lost&Found? This will remove them permanently."), QMessageBox::Ok|QMessageBox::No);
+    int res = QMessageBox::question(this, tr("Remove items..."), tr("Are you sure you want to delete all items from Lost&Found? This will remove them permanently."), QMessageBox::Ok | QMessageBox::No);
     if(res != QMessageBox::Ok)
     {
         return;
@@ -793,7 +793,7 @@ void CGisListDB::slotDelLostFoundItem()
 {
     CGisListDBEditLock lock(false, this, "slotDelLostFoundItem");
 
-    int res = QMessageBox::question(this, tr("Remove items..."), tr("Are you sure you want to delete all selected items from Lost&Found? This will remove them permanently."), QMessageBox::Ok|QMessageBox::No);
+    int res = QMessageBox::question(this, tr("Remove items..."), tr("Are you sure you want to delete all selected items from Lost&Found? This will remove them permanently."), QMessageBox::Ok | QMessageBox::No);
     if(res != QMessageBox::Ok)
     {
         return;
@@ -880,7 +880,7 @@ void CGisListDB::slotDelItem()
         if(last != QMessageBox::YesToAll)
         {
             QString msg = tr("Are you sure you want to delete '%1' from folder '%2'?").arg(dbItem->text(CGisListDB::eColumnName)).arg(folder->text(CGisListDB::eColumnName));
-            last = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete..."), msg, QMessageBox::YesToAll|QMessageBox::Cancel|QMessageBox::Ok|QMessageBox::No, QMessageBox::Ok);
+            last = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete..."), msg, QMessageBox::YesToAll | QMessageBox::Cancel | QMessageBox::Ok | QMessageBox::No, QMessageBox::Ok);
         }
         if(last == QMessageBox::No)
         {

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -178,7 +178,7 @@ CGisListWks::CGisListWks(QWidget *parent)
 
     // several GIS items related actions
     actionRteFromWpt    = addAction(QIcon("://icons/32x32/Route.png"), tr("Create Route..."), this, SLOT(slotRteFromWpt()));
-    actionEditPrxWpt=  addAction(QIcon("://icons/32x32/WptEditProx.png"), tr("Change Proximity..."), this, SLOT(slotEditPrxWpt()));
+    actionEditPrxWpt =  addAction(QIcon("://icons/32x32/WptEditProx.png"), tr("Change Proximity..."), this, SLOT(slotEditPrxWpt()));
 
     connect(qApp, &QApplication::aboutToQuit, this, &CGisListWks::slotSaveWorkspace);
     connect(this, &CGisListWks::customContextMenuRequested, this, &CGisListWks::slotContextMenu);
@@ -532,7 +532,7 @@ void CGisListWks::dropEvent( QDropEvent  * e )
     {
         // calc. index offset (below/above item)
         QRect r = visualItemRect(itemAt(e->pos()));
-        int y1 = r.top() + r.height()/2;
+        int y1 = r.top() + r.height() / 2;
         int y2 = e->pos().y();
         int off = y2 > y1 ? 1 : 0;
 
@@ -1241,7 +1241,7 @@ void CGisListWks::slotContextMenu(const QPoint& point)
             actionRteFromWpt->setEnabled(keysWpt.count() > 1);
             actionEditPrxWpt->setEnabled(hasWpts);
             actionCombineTrk->setEnabled(keysTrk.count() > 1);
-            actionEleWptTrk->setEnabled(hasWpts|hasTrks);
+            actionEleWptTrk->setEnabled(hasWpts | hasTrks);
             showMenuItem(p, keysTrk, keysWpt);
             return;
         }
@@ -1436,7 +1436,7 @@ void CGisListWks::slotCloseProject()
 
 void CGisListWks::slotCloseAllProjects()
 {
-    int res = QMessageBox::question(this, tr("Close all projects..."), tr("This will remove all projects from the workspace."), QMessageBox::Ok|QMessageBox::Abort, QMessageBox::Ok);
+    int res = QMessageBox::question(this, tr("Close all projects..."), tr("This will remove all projects from the workspace."), QMessageBox::Ok | QMessageBox::Abort, QMessageBox::Ok);
     if(res != QMessageBox::Ok)
     {
         return;
@@ -1463,7 +1463,7 @@ void CGisListWks::slotDeleteProject()
         {
             {
                 CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
-                int res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete project..."), tr("Do you really want to delete %1?").arg(project->getFilename()), QMessageBox::Ok|QMessageBox::No, QMessageBox::Ok);
+                int res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete project..."), tr("Do you really want to delete %1?").arg(project->getFilename()), QMessageBox::Ok | QMessageBox::No, QMessageBox::Ok);
 
                 if(res != QMessageBox::Ok)
                 {

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -151,7 +151,7 @@ void CGisWorkspace::loadGisProject(const QString& filename)
 
 void CGisWorkspace::slotSetGisLayerOpacity(int val)
 {
-    CCanvas::gisLayerOpacity = qreal(val)/100;
+    CCanvas::gisLayerOpacity = qreal(val) / 100;
     CCanvas * canvas = CMainWindow::self().getVisibleCanvas();
     if(canvas != nullptr)
     {
@@ -351,7 +351,7 @@ IGisProject * CGisWorkspace::selectProject(bool forceSelect)
             CDBProject * p = nullptr;
             while(nullptr == p)
             {
-                QApplication::processEvents(QEventLoop::WaitForMoreEvents|QEventLoop::ExcludeUserInputEvents, 100);
+                QApplication::processEvents(QEventLoop::WaitForMoreEvents | QEventLoop::ExcludeUserInputEvents, 100);
                 p = dynamic_cast<CDBProject*>(treeWks->getProjectById(evt.idChild, db));
             }
             /*
@@ -961,7 +961,7 @@ void CGisWorkspace::cutTrkByKey(const IGisItem::key_t& key)
     CGisItemTrk * trk = dynamic_cast<CGisItemTrk*>(getItemByKey(key));
     if(nullptr != trk && trk->cut())
     {
-        int res = QMessageBox::question(this, tr("Cut Track..."), tr("Do you want to delete the original track?"), QMessageBox::Ok|QMessageBox::No, QMessageBox::Ok);
+        int res = QMessageBox::question(this, tr("Cut Track..."), tr("Do you want to delete the original track?"), QMessageBox::Ok | QMessageBox::No, QMessageBox::Ok);
         if(res == QMessageBox::Ok)
         {
             delete trk;
@@ -1237,7 +1237,7 @@ void CGisWorkspace::editPrxWpt(const QList<IGisItem::key_t>& keys)
         return;
     }
 
-    qreal proximity = var.toDouble()/IUnit::self().baseFactor;
+    qreal proximity = var.toDouble() / IUnit::self().baseFactor;
     bool isNoGo = dlg.optionIsChecked();
     for(const IGisItem::key_t& key : keys)
     {
@@ -1389,7 +1389,7 @@ void CGisWorkspace::tagItemsByKey(const QList<IGisItem::key_t>& keys)
             {
                 commonKeywords = gisItem->getKeywords();
                 rating = gisItem->getRating();
-                firstItem=false;
+                firstItem = false;
             }
             else
             {

--- a/src/qmapshack/gis/IGisItem.cpp
+++ b/src/qmapshack/gis/IGisItem.cpp
@@ -81,7 +81,7 @@ IGisItem::IGisItem(IGisProject *parent, type_e typ, int idx)
                 if(childType == eTypeTrk)
                 {
                     parent->removeChild(this);
-                    parent->insertChild(n+1, this);
+                    parent->insertChild(n + 1, this);
                     break;
                 }
             }
@@ -97,7 +97,7 @@ IGisItem::IGisItem(IGisProject *parent, type_e typ, int idx)
                 if( childType == eTypeRte || childType == eTypeTrk)
                 {
                     parent->removeChild(this);
-                    parent->insertChild(n+1, this);
+                    parent->insertChild(n + 1, this);
                     break;
                 }
             }
@@ -113,7 +113,7 @@ IGisItem::IGisItem(IGisProject *parent, type_e typ, int idx)
                 if(childType == eTypeWpt || childType == eTypeRte || childType == eTypeTrk)
                 {
                     parent->removeChild(this);
-                    parent->insertChild(n+1, this);
+                    parent->insertChild(n + 1, this);
                     break;
                 }
             }
@@ -129,7 +129,7 @@ IGisItem::IGisItem(IGisProject *parent, type_e typ, int idx)
                 if(childType == eTypeOvl || childType == eTypeWpt || childType == eTypeRte || childType == eTypeTrk)
                 {
                     parent->removeChild(this);
-                    parent->insertChild(n+1, this);
+                    parent->insertChild(n + 1, this);
                     break;
                 }
             }
@@ -338,7 +338,7 @@ void IGisItem::updateDecoration(quint32 enable, quint32 disable)
 
     // update project if necessary
     IGisProject * project = getParentProject();
-    if(project && (enable & (eMarkChanged|eMarkNotPart|eMarkNotInDB)))
+    if(project && (enable & (eMarkChanged | eMarkNotPart | eMarkNotInDB)))
     {
         project->setChanged();
     }
@@ -613,7 +613,7 @@ bool IGisItem::setReadOnlyMode(bool readOnly)
     }
 
     // warn if item is external and read only
-    if(!(flags & (eFlagCreatedInQms|eFlagTainted)))
+    if(!(flags & (eFlagCreatedInQms | eFlagTainted)))
     {
         SETTINGS;
         bool doNotAsk = cfg.value("Dialog/Items/ReadOnly/doNotAsk", false).toBool();
@@ -624,7 +624,7 @@ bool IGisItem::setReadOnlyMode(bool readOnly)
 
             QCheckBox * checkBox = new QCheckBox(tr("Never ask again."), 0);
             QString msg = tr("<h3>%1</h3> This element is probably read-only because it was not created within QMapShack. Usually you should not want to change imported data. But if you think that is ok press 'Ok'.").arg(getName());
-            QMessageBox box(QMessageBox::Warning, tr("Read Only Mode..."), msg, QMessageBox::Ok|QMessageBox::Abort, CMainWindow::getBestWidgetForParent());
+            QMessageBox box(QMessageBox::Warning, tr("Read Only Mode..."), msg, QMessageBox::Ok | QMessageBox::Abort, CMainWindow::getBestWidgetForParent());
             box.setDefaultButton(QMessageBox::Ok);
             box.setCheckBox(checkBox);
             int res = box.exec();
@@ -704,7 +704,7 @@ void IGisItem::showIcon()
         displayIcon.fill(Qt::transparent);
         QPainter painter(&displayIcon);
         painter.drawPixmap(0, 0, icon);
-        painter.drawPixmap(width*0.4, height*0.4, QPixmap("://icons/48x48/NoGo.png").scaled(width*0.6, height*0.6, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        painter.drawPixmap(width * 0.4, height * 0.4, QPixmap("://icons/48x48/NoGo.png").scaled(width * 0.6, height * 0.6, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     }
     else
     {
@@ -1066,7 +1066,7 @@ qreal IGisItem::getRating() const
 
 void IGisItem::setRating(qreal rating)
 {
-    this->rating=rating;
+    this->rating = rating;
     updateHistory();
 }
 

--- a/src/qmapshack/gis/db/CDBFolderLostFound.cpp
+++ b/src/qmapshack/gis/db/CDBFolderLostFound.cpp
@@ -87,7 +87,7 @@ bool CDBFolderLostFound::update()
 void CDBFolderLostFound::expanding()
 {
     const int N = childCount();
-    for(int i=0; i < N; i++)
+    for(int i = 0; i < N; i++)
     {
         CDBItem * item = dynamic_cast<CDBItem*>(child(i));
         if(item)

--- a/src/qmapshack/gis/db/CDBItem.cpp
+++ b/src/qmapshack/gis/db/CDBItem.cpp
@@ -91,17 +91,17 @@ void CDBItem::updateAge()
         if(timestamp.isValid())
         {
             quint64 diff = QDateTime::currentDateTimeUtc().toTime_t() - timestamp.toTime_t();
-            if(diff < (60*60))
+            if(diff < (60 * 60))
             {
-                setText(CGisListDB::eColumnTime, tr("%1 min.").arg(diff/60));
+                setText(CGisListDB::eColumnTime, tr("%1 min.").arg(diff / 60));
             }
-            else if(diff < (60*60*24))
+            else if(diff < (60 * 60 * 24))
             {
-                setText(CGisListDB::eColumnTime, tr("%1 h").arg(diff/(60*60)));
+                setText(CGisListDB::eColumnTime, tr("%1 h").arg(diff / (60 * 60)));
             }
             else
             {
-                setText(CGisListDB::eColumnTime, tr("%1 days").arg(diff/(60*60*24)));
+                setText(CGisListDB::eColumnTime, tr("%1 days").arg(diff / (60 * 60 * 24)));
             }
         }
     }

--- a/src/qmapshack/gis/db/CDBProject.cpp
+++ b/src/qmapshack/gis/db/CDBProject.cpp
@@ -356,7 +356,7 @@ void CDBProject::updateItem(IGisItem *&item, quint64 idItem, QSqlQuery &query)
     query.bindValue(":icon",    buffer.data());
     query.bindValue(":name",    item->getName());
     query.bindValue(":date",    item->getTimestamp());
-    query.bindValue(":comment", item->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText));
+    query.bindValue(":comment", item->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText));
     query.bindValue(":data",    data);
     query.bindValue(":hash",    item->getHash());
     query.bindValue(":id",      idItem);
@@ -404,7 +404,7 @@ void CDBProject::updateItem(IGisItem *&item, quint64 idItem, QSqlQuery &query)
             query.bindValue(":icon",    buffer.data());
             query.bindValue(":name",    item->getName());
             query.bindValue(":date",    item->getTimestamp());
-            query.bindValue(":comment", item->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText));
+            query.bindValue(":comment", item->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText));
             query.bindValue(":data",    data);
             query.bindValue(":hash",    item->getHash());
             query.bindValue(":id",      idItem);
@@ -457,7 +457,7 @@ quint64 CDBProject::insertItem(IGisItem * item, QSqlQuery &query)
     query.bindValue(":icon",    buffer.data());
     query.bindValue(":name",    item->getName());
     query.bindValue(":date",    item->getTimestamp());
-    query.bindValue(":comment", item->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText));
+    query.bindValue(":comment", item->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText));
     query.bindValue(":data",    data);
     query.bindValue(":hash",    item->getHash());
     QUERY_EXEC(throw eReasonQueryFail);
@@ -563,7 +563,7 @@ int CDBProject::checkForAction1(IGisItem * item, quint64& itemId, int& lastResul
     }
     else
     {
-        action = eActionInsert|eActionLink;
+        action = eActionInsert | eActionLink;
     }
 
     return action;
@@ -651,7 +651,7 @@ bool CDBProject::save(int lastResult)
                 query.bindValue(":child", idItem);
                 QUERY_EXEC(throw eReasonQueryFail);
             }
-            item->updateDecoration(IGisItem::eMarkNone, IGisItem::eMarkChanged|IGisItem::eMarkNotPart|IGisItem::eMarkNotInDB);
+            item->updateDecoration(IGisItem::eMarkNone, IGisItem::eMarkChanged | IGisItem::eMarkNotPart | IGisItem::eMarkNotInDB);
         }
         catch(reasons_e reason)
         {
@@ -776,7 +776,7 @@ void CDBProject::update()
     if(isChanged())
     {
         QString msg = tr("The project '%1' is about to update itself from the database. However there are changes not saved.").arg(getName());
-        int res = QMessageBox::question(CMainWindow::self().getBestWidgetForParent(), tr("Save changes?"), msg, QMessageBox::Save|QMessageBox::Ignore|QMessageBox::Abort, QMessageBox::Save);
+        int res = QMessageBox::question(CMainWindow::self().getBestWidgetForParent(), tr("Save changes?"), msg, QMessageBox::Save | QMessageBox::Ignore | QMessageBox::Abort, QMessageBox::Save);
 
         if(res == QMessageBox::Abort)
         {
@@ -875,13 +875,13 @@ void CDBProject::update()
                 {
                     // item is not connected to this project
                     item->updateFromDB(idItem, db);
-                    item->updateDecoration(IGisItem::eMarkNotPart|IGisItem::eMarkChanged, IGisItem::eMarkNone);
+                    item->updateDecoration(IGisItem::eMarkNotPart | IGisItem::eMarkChanged, IGisItem::eMarkNone);
                 }
             }
             else
             {
                 // item is not in the database at all.
-                item->updateDecoration(IGisItem::eMarkNotInDB|IGisItem::eMarkChanged, IGisItem::eMarkNone);
+                item->updateDecoration(IGisItem::eMarkNotInDB | IGisItem::eMarkChanged, IGisItem::eMarkNone);
             }
         }
 

--- a/src/qmapshack/gis/db/IDB.cpp
+++ b/src/qmapshack/gis/db/IDB.cpp
@@ -63,7 +63,7 @@ bool IDB::setupDB(QString &error)
             int res = QMessageBox::warning(CMainWindow::self().getBestWidgetForParent(),
                                            tr("Migrate database..."),
                                            msg,
-                                           QMessageBox::Ok|QMessageBox::Abort);
+                                           QMessageBox::Ok | QMessageBox::Abort);
             if(res != QMessageBox::Ok)
             {
                 error = tr("Migration aborted by user");

--- a/src/qmapshack/gis/db/IDBMysql.cpp
+++ b/src/qmapshack/gis/db/IDBMysql.cpp
@@ -242,7 +242,7 @@ bool IDBMysql::migrateDB4to5()
         }
 
         // get full size info text
-        QString comment = item->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText);
+        QString comment = item->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText);
 
         // replace comment with full size info text in items table
         QSqlQuery query2(db);
@@ -293,7 +293,7 @@ bool IDBMysql::migrateDB5to6()
         }
 
         // get full size info text
-        QString comment = item->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText);
+        QString comment = item->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText);
         QDateTime date  = item->getTimestamp();
 
         // replace comment with full size info text in items table

--- a/src/qmapshack/gis/db/IDBSqlite.cpp
+++ b/src/qmapshack/gis/db/IDBSqlite.cpp
@@ -392,7 +392,7 @@ bool IDBSqlite::migrateDB4to5()
         }
 
         // get full size info text
-        QString comment = item->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText);
+        QString comment = item->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText);
 
         // replace comment with full size info text in items table
         QSqlQuery query2(db);
@@ -465,7 +465,7 @@ bool IDBSqlite::migrateDB5to6()
         }
 
         // get full size info text
-        QString comment = item->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText);
+        QString comment = item->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText);
         QDateTime date  = item->getTimestamp();
 
         // replace comment with full size info text in items table

--- a/src/qmapshack/gis/fit/CFitStream.cpp
+++ b/src/qmapshack/gis/fit/CFitStream.cpp
@@ -38,7 +38,7 @@ const CFitMessage& CFitStream::nextMesg()
 
 const CFitMessage& CFitStream::lastMesg() const
 {
-    int pos = readPos-1;
+    int pos = readPos - 1;
     if(pos < 0)
     {
         pos = 0;

--- a/src/qmapshack/gis/fit/decoder/CFitDefinitionMessage.cpp
+++ b/src/qmapshack/gis/fit/decoder/CFitDefinitionMessage.cpp
@@ -85,7 +85,7 @@ void CFitDefinitionMessage::addDevField(CFitFieldDefinition fieldDef)
 
 bool CFitDefinitionMessage::hasField(const quint8 fieldNum) const
 {
-    for (int i=0; i < fields.size(); i++)
+    for (int i = 0; i < fields.size(); i++)
     {
         if (fieldNum == fields[i].getDefNr())
         {
@@ -97,7 +97,7 @@ bool CFitDefinitionMessage::hasField(const quint8 fieldNum) const
 
 const CFitFieldDefinition& CFitDefinitionMessage::getField(const quint8 fieldNum) const
 {
-    for (int i=0; i < fields.size(); i++)
+    for (int i = 0; i < fields.size(); i++)
     {
         if (fieldNum == fields[i].getDefNr())
         {

--- a/src/qmapshack/gis/fit/decoder/CFitField.cpp
+++ b/src/qmapshack/gis/fit/decoder/CFitField.cpp
@@ -56,11 +56,11 @@ void CFitField::applyScaleAndOffset()
         // scale and offset is only for int / sint types
         if(baseType->isUnsignedInt())
         {
-            value = QVariant(rawValue.toUInt()/ profile().getScale() - profile().getOffset());
+            value = QVariant(rawValue.toUInt() / profile().getScale() - profile().getOffset());
         }
         if(baseType->isSignedInt())
         {
-            value = QVariant(rawValue.toInt()/ profile().getScale() - profile().getOffset());
+            value = QVariant(rawValue.toInt() / profile().getScale() - profile().getOffset());
         }
     }
     else

--- a/src/qmapshack/gis/fit/decoder/CFitFieldDataState.cpp
+++ b/src/qmapshack/gis/fit/decoder/CFitFieldDataState.cpp
@@ -239,11 +239,11 @@ CFitFieldProfile CFitFieldDataState::buildDevFieldProfile(CFitMessage& mesg)
         const CFitFieldProfile* nativeFieldProfile = CFitProfileLookup::getFieldForProfile(natvieMesgNum, nativeFieldNum);
         if (nativeFieldProfile->getBaseType().nr() == eBaseTypeNrInvalid)
         {
-            qWarning() << "DEV field"<< fieldName <<" field profile for mesg num"<< natvieMesgNum << "and field num" << nativeFieldNum << "does not exist.";
+            qWarning() << "DEV field" << fieldName << " field profile for mesg num" << natvieMesgNum << "and field num" << nativeFieldNum << "does not exist.";
         }
         if (nativeFieldProfile->getUnits() != units)
         {
-            qWarning() << "DEV field" << fieldName << "units" << units <<" do not match existing profile units" << nativeFieldProfile->getUnits();
+            qWarning() << "DEV field" << fieldName << "units" << units << " do not match existing profile units" << nativeFieldProfile->getUnits();
         }
         // scale and offset not allowed if a fit field is overwritten.
         scale = 0;

--- a/src/qmapshack/gis/fit/decoder/CFitFieldDataState.h
+++ b/src/qmapshack/gis/fit/decoder/CFitFieldDataState.h
@@ -21,7 +21,7 @@
 
 #include "gis/fit/decoder/IFitDecoderState.h"
 
-static const int fitMaxFieldSize =255;
+static const int fitMaxFieldSize = 255;
 
 class CFitFieldDataState final : public IFitDecoderState
 {

--- a/src/qmapshack/gis/fit/decoder/IFitDecoderState.cpp
+++ b/src/qmapshack/gis/fit/decoder/IFitDecoderState.cpp
@@ -129,7 +129,7 @@ void IFitDecoderState::addDevFieldProfile(const CFitFieldProfile &fieldProfile)
 
 CFitFieldProfile* IFitDecoderState::devFieldProfile(quint32 fieldNr)
 {
-    for (int i=0; i < data.devFieldProfiles.size(); i++)
+    for (int i = 0; i < data.devFieldProfiles.size(); i++)
     {
         if (fieldNr == data.devFieldProfiles[i].getFieldDefNum())
         {

--- a/src/qmapshack/gis/fit/defs/CFitBaseType.h
+++ b/src/qmapshack/gis/fit/defs/CFitBaseType.h
@@ -65,7 +65,7 @@ public:
 
 private:
     // fixed size to 8, which is enough for float64
-    quint8 invalidBytes[8] {0,0,0,0,0,0,0,0};
+    quint8 invalidBytes[8] {0, 0, 0, 0, 0, 0, 0, 0};
     quint8 typeSize;
     fit_base_type_nr_e baseTypeNr;
     QString namestr;
@@ -98,7 +98,7 @@ static const CFitBaseType fitInvalidType = CFitBaseType(eBaseTypeNrInvalid, "Inv
 class CFitBaseTypeMap
 {
 public:
-    static const quint8 fitBaseTypeNumMask =0x1F; // 0000 0000 0001 1111
+    static const quint8 fitBaseTypeNumMask = 0x1F; // 0000 0000 0001 1111
 
     /**
      * param nr: either the "real" base type number (0 -13) or the masked base type byte.

--- a/src/qmapshack/gis/fit/defs/CFitProfile.cpp
+++ b/src/qmapshack/gis/fit/defs/CFitProfile.cpp
@@ -52,7 +52,7 @@ const CFitFieldProfile* CFitProfile::getField(quint8 fieldDefNr) const
 
 void CFitProfile::addField(QString name, const CFitBaseType& baseType, quint8 fieldDefNr, qreal scale, qint16 offset, QString units)
 {
-    CFitFieldProfile* field= new CFitFieldProfile(this, name, baseType, fieldDefNr, scale, offset, units);
+    CFitFieldProfile* field = new CFitFieldProfile(this, name, baseType, fieldDefNr, scale, offset, units);
     fields.insert(fieldDefNr, field);
 }
 void CFitProfile::addSubfield(QString name, const CFitBaseType& baseType, quint8 fieldDefNr, qreal

--- a/src/qmapshack/gis/gpx/CGpxProject.cpp
+++ b/src/qmapshack/gis/gpx/CGpxProject.cpp
@@ -278,7 +278,7 @@ bool CGpxProject::saveAs(const QString& fn, IGisProject& project, bool strictGpx
                                                 "QMapShack might not be able to load and store all elements of this file.  "
                                                 "Those elements will be lost. I recommend to use another file. "
                                                 "<b>Do you really want to overwrite the file?</b>")
-                                           , QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
+                                           , QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
             if(res == QMessageBox::No)
             {
                 return false;

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -39,7 +39,7 @@ const QString IGisProject::rmc_ns    = "urn:net:trekbuddy:1.0:nmea:rmc";
 const QString IGisProject::ql_ns     = "http://www.qlandkarte.org/xmlschemas/v1.1";
 const QString IGisProject::gs_ns     = "http://www.groundspeak.com/cache/1/0";
 const QString IGisProject::tp1_ns    = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1";
-const QString IGisProject::gpxdata_ns= "http://www.cluetrust.com/XML/GPXDATA/1/0";
+const QString IGisProject::gpxdata_ns = "http://www.cluetrust.com/XML/GPXDATA/1/0";
 
 
 static void readXml(const QDomNode& xml, const QString& tag, qint32& value)
@@ -489,7 +489,7 @@ QDomNode IGisProject::writeMetadata(QDomDocument& doc, bool strictGpx11)
                          + gpxtpx_ns + " http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd "
                          + wptx1_ns  + " http://www.garmin.com/xmlschemas/WaypointExtensionv1.xsd "
                          + ql_ns     + " http://www.qlandkarte.org/xmlschemas/v1.1/ql-extensions.xsd "
-                         + gpxdata_ns+ " http://www.cluetrust.com/Schemas/gpxdata10.xsd";
+                         + gpxdata_ns + " http://www.cluetrust.com/Schemas/gpxdata10.xsd";
     }
     else
     {
@@ -648,7 +648,7 @@ void CGisItemWpt::readGcExt(const QDomNode& xmlCache)
     geocache.archived   = attr.namedItem("archived").nodeValue().toLocal8Bit() == "True";
     geocache.available  = attr.namedItem("available").nodeValue().toLocal8Bit() == "True";
 
-    for(QDomNode xmlAttribute = geocacheAttributes.firstChild(); !xmlAttribute.isNull(); xmlAttribute=xmlAttribute.nextSibling())
+    for(QDomNode xmlAttribute = geocacheAttributes.firstChild(); !xmlAttribute.isNull(); xmlAttribute = xmlAttribute.nextSibling())
     {
         quint8 id = xmlAttribute.attributes().namedItem("id").nodeValue().toUInt();
         if(id >= geocache.attributeMeanings.size())
@@ -658,7 +658,7 @@ void CGisItemWpt::readGcExt(const QDomNode& xmlCache)
         }
 
         qint8 intvalue = xmlAttribute.attributes().namedItem("inc").nodeValue().toUInt();
-        geocache.attributes[id]=(intvalue == 1);
+        geocache.attributes[id] = (intvalue == 1);
         if(id == 42) //42 is the code for 'Needs maintenance' and it only appears, when there attribute is set
         {
             geocache.needsMaintenance = true;

--- a/src/qmapshack/gis/ovl/CGisItemOvlArea.cpp
+++ b/src/qmapshack/gis/ovl/CGisItemOvlArea.cpp
@@ -41,7 +41,7 @@ CGisItemOvlArea::CGisItemOvlArea(const SGisLine &line, const QString &name, IGis
     area.name = name;
     readAreaDataFromGisLine(line);
 
-    flags |=  eFlagCreatedInQms|eFlagWriteAllowed;
+    flags |=  eFlagCreatedInQms | eFlagWriteAllowed;
 
     setColor(str2color(""));
     setupHistory();
@@ -253,11 +253,11 @@ void CGisItemOvlArea::deriveSecondaryData()
     int j = line.size() - 1;
     for(int i = 0; i < line.size(); i++)
     {
-        area.area += (line[j].x() + line[i].x())*(line[j].y() - line[i].y());
+        area.area += (line[j].x() + line[i].x()) * (line[j].y() - line[i].y());
         j = i;
     }
 
-    area.area = qAbs(area.area/2);
+    area.area = qAbs(area.area / 2);
 }
 
 void CGisItemOvlArea::drawItem(QPainter& p, const QPolygonF& viewport, QList<QRectF>& blockedAreas, CGisDraw * gis)
@@ -579,7 +579,7 @@ QMap<searchProperty_e, CGisItemOvlArea::fSearch> CGisItemOvlArea::initKeywordLam
     });
     map.insert(eSearchPropertyGeneralFullText, [](CGisItemOvlArea* item){
         searchValue_t searchValue;
-        searchValue.str1 = item->getInfo(eFeatureShowFullText|eFeatureShowName);
+        searchValue.str1 = item->getInfo(eFeatureShowFullText | eFeatureShowName);
         return searchValue;
     });
     map.insert(eSearchPropertyGeneralComment, [](CGisItemOvlArea* item){

--- a/src/qmapshack/gis/ovl/CScrOptOvlArea.cpp
+++ b/src/qmapshack/gis/ovl/CScrOptOvlArea.cpp
@@ -31,7 +31,7 @@ CScrOptOvlArea::CScrOptOvlArea(CGisItemOvlArea *area, const QPoint &point, IMous
     setupUi(this);
     setOrigin(point);
     label->setFont(CMainWindow::self().getMapFont());
-    label->setText(area->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowLinks));
+    label->setText(area->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowLinks));
     adjustSize();
 
     anchor = area->getPointCloseBy(point);

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -130,7 +130,7 @@ void CDetailsPrj::slotSetupGui()
         X_____________UnBlockAllSignals_____________X(this);
 
         QString msg = tr("You want to sort waypoints along a track, but you switched off track and waypoint correlation. Do you want to switch it on again?");
-        int res = QMessageBox::question(this, tr("Correlation..."), msg, QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+        int res = QMessageBox::question(this, tr("Correlation..."), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
         if(res == QMessageBox::Yes)
         {
             prj.switchOnCorrelation();
@@ -348,7 +348,7 @@ void CDetailsPrj::draw(QTextDocument& doc, bool printable)
     }
 
 
-    int n=1;
+    int n = 1;
     PROGRESS_SETUP(tr("Build diary..."), 0, nItems, this);
 
     IGisProject::sorting_roadbook_e sorting = IGisProject::sorting_roadbook_e(comboSort->currentIndex());
@@ -435,7 +435,7 @@ void CDetailsPrj::drawWaypointSummary(QTextCursor& cursor, const QList<CGisItemW
             summary[iconName]++;
         }
 
-        const CGisItemWpt::geocache_t& gc =wpt->getGeoCache();
+        const CGisItemWpt::geocache_t& gc = wpt->getGeoCache();
         if(gc.hasData)
         {
             GCsummary[gc.type]++;
@@ -454,19 +454,19 @@ void CDetailsPrj::drawWaypointSummary(QTextCursor& cursor, const QList<CGisItemW
 
     if(summary["Geocache"] != 0)
     {
-        str+= QString::number(summary["Geocache"]) + tr(" x Geocache, consisting of: <br/>");
-        str+="<ul>";
+        str += QString::number(summary["Geocache"]) + tr(" x Geocache, consisting of: <br/>");
+        str += "<ul>";
         for(auto key:GCsummary.keys())
         {
-            str+= "<li>" + QString::number(GCsummary[key]) + " x " + key+ "</li>";
+            str += "<li>" + QString::number(GCsummary[key]) + " x " + key + "</li>";
         }
-        str+="</ul>";
+        str += "</ul>";
     }
     for(auto key: summary.keys())
     {
         if(key != "Geocache")
         {
-            str+= QString::number(summary[key]) + " x " + key+ "<br/>";
+            str += QString::number(summary[key]) + " x " + key + "<br/>";
         }
     }
 
@@ -495,7 +495,7 @@ void CDetailsPrj::drawByGroup(QTextCursor &cursor,
     if(!wpts.isEmpty())
     {
         cursor.insertHtml(tr("<h2>Waypoints</h2>"));
-        QTextTable * table = cursor.insertTable(wpts.count()+1, eMax1, fmtTableStandard);
+        QTextTable * table = cursor.insertTable(wpts.count() + 1, eMax1, fmtTableStandard);
 
         table->cellAt(0, eSym1).setFormat(fmtCharHeader);
         table->cellAt(0, eInfo1).setFormat(fmtCharHeader);
@@ -521,7 +521,7 @@ void CDetailsPrj::drawByGroup(QTextCursor &cursor,
     if(!trks.isEmpty())
     {
         cursor.insertHtml(tr("<h2>Tracks</h2>"));
-        QTextTable * table = cursor.insertTable(trks.count()+1, eMax1, fmtTableStandard);
+        QTextTable * table = cursor.insertTable(trks.count() + 1, eMax1, fmtTableStandard);
 
         table->cellAt(0, eSym1).setFormat(fmtCharHeader);
         table->cellAt(0, eInfo1).setFormat(fmtCharHeader);
@@ -538,12 +538,12 @@ void CDetailsPrj::drawByGroup(QTextCursor &cursor,
 
             addIcon(table, eSym1, cnt, trk->getDisplayIcon(), trk->getKey().item, trk->isReadOnly(), printable);
 
-            int w1 = qRound(w/3.5 > 300 ? 300 : w/3.5);
-            int h1 = qRound(w1/2.0);
+            int w1 = qRound(w / 3.5 > 300 ? 300 : w / 3.5);
+            int h1 = qRound(w1 / 2.0);
 
             if(w1 < 300)
             {
-                table->cellAt(cnt, eInfo1).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowActivity));
+                table->cellAt(cnt, eInfo1).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
 
                 QTextTable * table1 = table->cellAt(cnt, eInfo1).lastCursorPosition().insertTable(1, 2, fmtTableInfo);
 
@@ -559,7 +559,7 @@ void CDetailsPrj::drawByGroup(QTextCursor &cursor,
             {
                 QTextTable * table1 = table->cellAt(cnt, eInfo1).firstCursorPosition().insertTable(1, 3, fmtTableInfo);
 
-                table1->cellAt(0, 0).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowActivity));
+                table1->cellAt(0, 0).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
 
                 QImage profile(w1, h1, QImage::Format_ARGB32);
                 getTrackProfile(trk, nullptr, profile);
@@ -669,7 +669,7 @@ QList<wpt_info_t> CDetailsPrj::getWptInfo(const CGisItemTrk& trk) const
 
             if(!hasValidTime && trkpt.time.isValid())
             {
-                info.info += "<br/>" + tr("Created: %1").arg(IUnit::datetime2string(trkpt.time, false, QPointF(trkpt.lon*DEG_TO_RAD, trkpt.lat*DEG_TO_RAD)));
+                info.info += "<br/>" + tr("Created: %1").arg(IUnit::datetime2string(trkpt.time, false, QPointF(trkpt.lon * DEG_TO_RAD, trkpt.lat * DEG_TO_RAD)));
             }
 
             CWptIconManager& wptMgr = CWptIconManager::self();
@@ -731,41 +731,41 @@ QString CDetailsPrj::getStatistics(const wpt_info_t &info) const
     text += "<tr>";
     text += "<td>" + tr("Distance: ") + "</td>";
     IUnit::self().meter2distance(info.distance1, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     IUnit::self().meter2distance(info.distance2, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     IUnit::self().meter2distance(info.distance3, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     text += "</tr>";
 
     text += "<tr>";
     text += "<td>" + tr("Time: ") + "</td>";
     IUnit::self().seconds2time(info.elapsedSeconds1, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "&nbsp;</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "&nbsp;</td>";
     IUnit::self().seconds2time(info.elapsedSeconds2, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "&nbsp;</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "&nbsp;</td>";
     IUnit::self().seconds2time(info.elapsedSeconds3, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "&nbsp;</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "&nbsp;</td>";
     text += "</tr>";
 
     text += "<tr>";
     text += "<td>" + tr("Ascent: ") + "</td>";
     IUnit::self().meter2elevation(info.ascent1, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     IUnit::self().meter2elevation(info.ascent2, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     IUnit::self().meter2elevation(info.ascent3, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     text += "</tr>";
 
     text += "<tr>";
     text += "<td>" + tr("Descent: ") + "</td>";
     IUnit::self().meter2elevation(info.descent1, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     IUnit::self().meter2elevation(info.descent2, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     IUnit::self().meter2elevation(info.descent3, val, unit);
-    text += "<td>"+ QString("%1%2").arg(val).arg(unit) + "</td>";
+    text += "<td>" + QString("%1%2").arg(val).arg(unit) + "</td>";
     text += "</tr>";
 
     text += "</table>";
@@ -802,15 +802,15 @@ void CDetailsPrj::drawByTrack(QTextCursor& cursor,
 {
     int w = cursor.document()->textWidth();
 
-    const qreal w1 = qRound(w/3.5 > 300 ? 300 : w/3.5);
-    const qreal h1 = qRound(w1/2.0);
+    const qreal w1 = qRound(w / 3.5 > 300 ? 300 : w / 3.5);
+    const qreal h1 = qRound(w1 / 2.0);
 
     for(CGisItemTrk * trk : trks)
     {
         const QList<wpt_info_t>& wptInfo = getWptInfo(*trk);
 
         cursor.insertHtml(QString("<h2>%1</h2>").arg(trk->getName()));
-        QTextTable * table = cursor.insertTable(wptInfo.count()+2, eMax2, fmtTableStandard);
+        QTextTable * table = cursor.insertTable(wptInfo.count() + 2, eMax2, fmtTableStandard);
 
         table->cellAt(0, eSym2).setFormat(fmtCharHeader);
         table->cellAt(0, eInfo2).setFormat(fmtCharHeader);
@@ -843,7 +843,7 @@ void CDetailsPrj::drawByTrack(QTextCursor& cursor,
         }
 
         addIcon(table, eSym1, cnt, trk->getDisplayIcon(), trk->getKey().item, trk->isReadOnly(), printable);
-        table->cellAt(cnt, eInfo2).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowActivity));
+        table->cellAt(cnt, eInfo2).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
 
         QTextTable * table1 = table->cellAt(cnt, eData2).lastCursorPosition().insertTable(1, 2, fmtTableInfo);
 
@@ -869,15 +869,15 @@ void CDetailsPrj::drawByDetails(QTextCursor& cursor,
 {
     int w = cursor.document()->textWidth();
 
-    const qreal w1 = qRound(w/3.5 > 300 ? 300 : w/3.5);
-    const qreal h1 = qRound(w1/2.0);
+    const qreal w1 = qRound(w / 3.5 > 300 ? 300 : w / 3.5);
+    const qreal h1 = qRound(w1 / 2.0);
 
     for(CGisItemTrk * trk : trks)
     {
         const QList<wpt_info_t>& wptInfo = getWptInfo(*trk);
 
         cursor.insertHtml(QString("<h2>%1</h2>").arg(trk->getName()));
-        QTextTable * table = cursor.insertTable(wptInfo.count()+2, eMax2, fmtTableStandard);
+        QTextTable * table = cursor.insertTable(wptInfo.count() + 2, eMax2, fmtTableStandard);
 
         table->cellAt(0, eSym2).setFormat(fmtCharHeader);
         table->cellAt(0, eInfo2).setFormat(fmtCharHeader);
@@ -920,7 +920,7 @@ void CDetailsPrj::drawByDetails(QTextCursor& cursor,
         }
 
         addIcon(table, eSym1, cnt, trk->getDisplayIcon(), trk->getKey().item, trk->isReadOnly(), printable);
-        table->cellAt(cnt, eInfo2).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowActivity));
+        table->cellAt(cnt, eInfo2).firstCursorPosition().insertHtml(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
 
         table->mergeCells(cnt, eData2, 1, 2);
         table->cellAt(cnt, eData2).firstCursorPosition().insertHtml(IGisItem::createText(trk->isReadOnly() || printable, trk->getComment(), trk->getDescription(), trk->getLinks(), trk->getKey().item));
@@ -936,7 +936,7 @@ void CDetailsPrj::drawArea(QTextCursor& cursor, QList<CGisItemOvlArea *> &areas,
         return;
     }
     cursor.insertHtml(tr("<h2>Areas</h2>"));
-    QTextTable * table = cursor.insertTable(areas.count()+1, eMax1, fmtTableStandard);
+    QTextTable * table = cursor.insertTable(areas.count() + 1, eMax1, fmtTableStandard);
 
     table->cellAt(0, eSym1).setFormat(fmtCharHeader);
     table->cellAt(0, eInfo1).setFormat(fmtCharHeader);
@@ -966,7 +966,7 @@ void CDetailsPrj::drawRoute(QTextCursor& cursor, QList<CGisItemRte *> &rtes, CPr
         return;
     }
     cursor.insertHtml(tr("<h2>Routes</h2>"));
-    QTextTable * table = cursor.insertTable(rtes.count()+1, eMax1, fmtTableStandard);
+    QTextTable * table = cursor.insertTable(rtes.count() + 1, eMax1, fmtTableStandard);
 
     table->cellAt(0, eSym1).setFormat(fmtCharHeader);
     table->cellAt(0, eInfo1).setFormat(fmtCharHeader);

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -178,7 +178,7 @@ bool IGisProject::askBeforClose()
     {
         {
             CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
-            res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Save project?"), tr("<h3>%1</h3>The project was changed. Save before closing it?").arg(getName()), QMessageBox::Save|QMessageBox::No|QMessageBox::Abort, QMessageBox::No);
+            res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Save project?"), tr("<h3>%1</h3>The project was changed. Save before closing it?").arg(getName()), QMessageBox::Save | QMessageBox::No | QMessageBox::Abort, QMessageBox::No);
         }
 
         if(res == QMessageBox::Save)
@@ -389,7 +389,7 @@ void IGisProject::updateItems()
             if(progress.wasCanceled())
             {
                 QString msg = tr("<h3>%1</h3>Did that take too long for you? Do you want to skip correlation of tracks and waypoints for this project in the future?").arg(getNameEx());
-                int res = QMessageBox::question(&progress, tr("Canceled correlation..."), msg, QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+                int res = QMessageBox::question(&progress, tr("Canceled correlation..."), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
                 noCorrelation = res == QMessageBox::Yes;
                 break;
             }
@@ -721,7 +721,7 @@ bool IGisProject::delItemByKey(const IGisItem::key_t& key, QMessageBox::Standard
 {
     for(int i = childCount(); i > 0; i--)
     {
-        IGisItem * item = dynamic_cast<IGisItem*>(child(i-1));
+        IGisItem * item = dynamic_cast<IGisItem*>(child(i - 1));
         if(nullptr == item )
         {
             continue;
@@ -732,7 +732,7 @@ bool IGisProject::delItemByKey(const IGisItem::key_t& key, QMessageBox::Standard
             if(last != QMessageBox::YesToAll)
             {
                 QString msg = tr("Are you sure you want to delete '%1' from project '%2'?").arg(item->getName()).arg(text(CGisListWks::eColumnName));
-                last = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete..."), msg, QMessageBox::YesToAll|QMessageBox::Cancel|QMessageBox::Ok|QMessageBox::No, QMessageBox::Ok);
+                last = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete..."), msg, QMessageBox::YesToAll | QMessageBox::Cancel | QMessageBox::Ok | QMessageBox::No, QMessageBox::Ok);
                 if((last == QMessageBox::No) || (last == QMessageBox::Cancel))
                 {
                     // as each item in the project has to be unique, we can stop searching.
@@ -761,7 +761,7 @@ void IGisProject::editItemByKey(const IGisItem::key_t& key)
 {
     for(int i = childCount(); i > 0; i--)
     {
-        IGisItem * item = dynamic_cast<IGisItem*>(child(i-1));
+        IGisItem * item = dynamic_cast<IGisItem*>(child(i - 1));
         if(nullptr == item)
         {
             continue;
@@ -1117,7 +1117,7 @@ void IGisProject::sortItems()
             continue;
         }
 
-        others<<item;
+        others << item;
     }
 
     sortItems(trks);
@@ -1126,7 +1126,7 @@ void IGisProject::sortItems()
     sortItems(ovls);
 
     items.clear();
-    items<<others;
+    items << others;
     for(IGisItem * item : trks)
     {
         items << item;
@@ -1187,7 +1187,7 @@ void IGisProject::sortItems(QList<IGisItem *> &items) const
 
 void IGisProject::setProjectFilter(const CSearch& search)
 {
-    projectSearch=search;
+    projectSearch = search;
     applyFilters();
 }
 

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -622,8 +622,8 @@ protected:
 
     QString hashTrkWpt[2];
 
-    CSearch projectSearch= CSearch("");
-    CSearch workspaceSearch= CSearch("");
+    CSearch projectSearch = CSearch("");
+    CSearch workspaceSearch = CSearch("");
 
     CProjectFilterItem* projectFilter = nullptr;
 };

--- a/src/qmapshack/gis/qms/serialization.cpp
+++ b/src/qmapshack/gis/qms/serialization.cpp
@@ -298,7 +298,7 @@ QDataStream& operator>>(QDataStream& stream, CGisItemWpt::geocache_t& geocache)
         stream >> geocache.container;
         if(version > 2)
         {
-            stream>>geocache.attributes;
+            stream >> geocache.attributes;
         }
         stream >> tmp8;
         geocache.shortDescIsHtml = tmp8;
@@ -727,7 +727,7 @@ QDataStream& CGisItemWpt::operator<<(QDataStream& stream)
     if(version <= 2 && geocache.hasData)
     {
         //If the geocache was saved with an old Version of QMS recalculate it's key to make sure geocaches with the same id are treated as being the same
-        key.item="";
+        key.item = "";
         genKey();
     }
     //Also sets icon, tooltip and text

--- a/src/qmapshack/gis/rte/CCreateRouteFromWpt.cpp
+++ b/src/qmapshack/gis/rte/CCreateRouteFromWpt.cpp
@@ -46,7 +46,7 @@ CCreateRouteFromWpt::CCreateRouteFromWpt(const QList<IGisItem::key_t> &keys, QWi
         item->setText(wpt->getName());
         item->setIcon(wpt->getIcon());
         item->setToolTip(wpt->getInfo(IGisItem::eFeatureShowName));
-        item->setData(Qt::UserRole + 0, QPointF(wpt->getPosition()*DEG_TO_RAD));
+        item->setData(Qt::UserRole + 0, QPointF(wpt->getPosition() * DEG_TO_RAD));
     }
 
     connect(listWidget, &QListWidget::itemSelectionChanged, this, &CCreateRouteFromWpt::slotSelectionChanged);

--- a/src/qmapshack/gis/rte/CGisItemRte.cpp
+++ b/src/qmapshack/gis/rte/CGisItemRte.cpp
@@ -127,7 +127,7 @@ CGisItemRte::CGisItemRte(const SGisLine &l, const QString &name, IGisProject *pr
     rte.name = name;
     readRouteDataFromGisLine(l);
 
-    flags |=  eFlagCreatedInQms|eFlagWriteAllowed;
+    flags |=  eFlagCreatedInQms | eFlagWriteAllowed;
 
     setupHistory();
     updateDecoration(eMarkChanged, eMarkNone);
@@ -684,7 +684,7 @@ void CGisItemRte::drawItem(QPainter& p, const QRectF& viewport, CGisDraw * gis)
         const CMainWindow& w = CMainWindow::self();
         QFont f = w.getMapFont();
         QFontMetrics fm(f);
-        QRect rectText = fm.boundingRect(QRect(0, 0, 500, 0), Qt::AlignLeft|Qt::AlignTop|Qt::TextWordWrap, str);
+        QRect rectText = fm.boundingRect(QRect(0, 0, 500, 0), Qt::AlignLeft | Qt::AlignTop | Qt::TextWordWrap, str);
         rectText.adjust(-5, -5, 5, 5);
         rectText.moveBottomLeft(anchor.toPoint() + QPoint(-50, -50));
 
@@ -720,19 +720,19 @@ void CGisItemRte::drawLabel(QPainter& p, const QPolygonF& viewport, QList<QRectF
         rect.adjust(-2, -2, 2, 2);
 
         // place label on top
-        rect.moveCenter(pt + QPointF(rtept.icon.width()/2, -fm.height()));
+        rect.moveCenter(pt + QPointF(rtept.icon.width() / 2, -fm.height()));
         if(CDraw::doesOverlap(blockedAreas, rect))
         {
             // place label on bottom
-            rect.moveCenter(pt + QPointF( rtept.icon.width()/2, +fm.height() + rtept.icon.height()));
+            rect.moveCenter(pt + QPointF( rtept.icon.width() / 2, +fm.height() + rtept.icon.height()));
             if(CDraw::doesOverlap(blockedAreas, rect))
             {
                 // place label on right
-                rect.moveCenter(pt + QPointF( rtept.icon.width() + rect.width()/2, +fm.height()));
+                rect.moveCenter(pt + QPointF( rtept.icon.width() + rect.width() / 2, +fm.height()));
                 if(CDraw::doesOverlap(blockedAreas, rect))
                 {
                     // place label on left
-                    rect.moveCenter(pt + QPointF( -rect.width()/2, +fm.height()));
+                    rect.moveCenter(pt + QPointF( -rect.width() / 2, +fm.height()));
                     if(CDraw::doesOverlap(blockedAreas, rect))
                     {
                         // failed to place label anywhere
@@ -1134,7 +1134,7 @@ void CGisItemRte::setResult(const QDomDocument& xml, const QString &options)
     for(int i = 0; i < rte.pts.size() - 1; i++ )
     {
         quint32 idx1 = idxLegs[i];
-        quint32 idx2 = idxLegs[i+1];
+        quint32 idx2 = idxLegs[i + 1];
 
         rtept_t& rtept      = rte.pts[i];
         rtept.subpts        = shape.mid(idx1, idx2 - idx1 + 1);
@@ -1262,10 +1262,10 @@ void CGisItemRte::setResultFromBRouter(const QDomDocument &xml, const QString &o
     for(qint32 rtIdx = 0; rtIdx < rte.pts.size() - 1; rtIdx++)
     {
         rtept_t &routePoint = rte.pts[rtIdx];
-        const rtept_t &nextRoutePoint = rte.pts[rtIdx+1];
+        const rtept_t &nextRoutePoint = rte.pts[rtIdx + 1];
 
         qreal minDist = std::pow(nextRoutePoint.lon - shape[minDistIdx].lon, 2) + std::pow(nextRoutePoint.lat - shape[minDistIdx].lat, 2);
-        for (qint32 idx = startIdx+1; idx < shape.size(); idx++)
+        for (qint32 idx = startIdx + 1; idx < shape.size(); idx++)
         {
             qreal dist = std::pow(nextRoutePoint.lon - shape[idx].lon, 2) + std::pow(nextRoutePoint.lat - shape[idx].lat, 2);
             if (dist < minDist)
@@ -1275,7 +1275,7 @@ void CGisItemRte::setResultFromBRouter(const QDomDocument &xml, const QString &o
             }
         }
         routePoint.ele = shape[startIdx].ele;
-        routePoint.subpts = shape.mid(startIdx, minDistIdx-startIdx);
+        routePoint.subpts = shape.mid(startIdx, minDistIdx - startIdx);
         routePoint.fakeSubpt.lon = routePoint.lon;
         routePoint.fakeSubpt.lat = routePoint.lat;
         routePoint.fakeSubpt.ele = routePoint.ele;
@@ -1326,7 +1326,7 @@ QMap<searchProperty_e, CGisItemRte::fSearch> CGisItemRte::initKeywordLambdaMap()
     });
     map.insert(eSearchPropertyGeneralFullText, [](CGisItemRte* item){
         searchValue_t searchValue;
-        searchValue.str1 = item->getInfo(eFeatureShowFullText|eFeatureShowName);
+        searchValue.str1 = item->getInfo(eFeatureShowFullText | eFeatureShowName);
         return searchValue;
     });
     map.insert(eSearchPropertyGeneralElevation, [](CGisItemRte* item){
@@ -1383,8 +1383,8 @@ QMap<searchProperty_e, CGisItemRte::fSearch> CGisItemRte::initKeywordLambdaMap()
     });
     map.insert(eSearchPropertyRteTrkTotalTime, [](CGisItemRte* item){
         searchValue_t searchValue;
-        searchValue.value1=item->rte.maxElevation;
-        searchValue.str1="s";
+        searchValue.value1 = item->rte.maxElevation;
+        searchValue.str1 = "s";
         return searchValue;
     });
     return map;

--- a/src/qmapshack/gis/rte/CScrOptRte.cpp
+++ b/src/qmapshack/gis/rte/CScrOptRte.cpp
@@ -32,7 +32,7 @@ CScrOptRte::CScrOptRte(CGisItemRte *rte, const QPoint& point, IMouse *parent)
     setupUi(this);
     setOrigin(point);
     label->setFont(CMainWindow::self().getMapFont());
-    label->setText(rte->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowLinks));
+    label->setText(rte->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowLinks));
     adjustSize();
 
     toolInstruction->setEnabled(rte->isCalculated());

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -206,7 +206,7 @@ QString CRouterBRouter::getOptions()
 {
     return QString(tr("profile: %1, alternative: %2")
                    .arg(comboProfile->currentData().toString())
-                   .arg(comboAlternative->currentData().toInt()+1));
+                   .arg(comboAlternative->currentData().toInt() + 1));
 }
 
 void CRouterBRouter::routerSelected()
@@ -330,7 +330,7 @@ int CRouterBRouter::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
         return -1;
     }
 
-    const QVector<QPointF> points = {p1*RAD_TO_DEG, p2*RAD_TO_DEG};
+    const QVector<QPointF> points = {p1*RAD_TO_DEG, p2 * RAD_TO_DEG};
 
     QList<IGisItem*> nogos;
     CGisWorkspace::self().getNogoAreas(nogos);
@@ -405,8 +405,8 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF> &points, const QLi
             const QDomElement &elem   = xmlLatLng.item(n).toElement();
             coords << QPointF();
             QPointF &point = coords.last();
-            point.setX(elem.attribute("lon").toFloat()*DEG_TO_RAD);
-            point.setY(elem.attribute("lat").toFloat()*DEG_TO_RAD);
+            point.setX(elem.attribute("lon").toFloat() * DEG_TO_RAD);
+            point.setY(elem.attribute("lat").toFloat() * DEG_TO_RAD);
         }
 
         //find costs of route (copied and adapted from CGisItemRte::setResultFromBrouter)
@@ -553,7 +553,7 @@ void CRouterBRouter::slotRequestFinished(QNetworkReply* reply)
         CGisItemRte * rte = dynamic_cast<CGisItemRte*>(CGisWorkspace::self().getItemByKey(key));
         if(rte != nullptr)
         {
-            rte->setResultFromBRouter(xml, reply->property("options").toString() + tr("<br/>Calculation time: %1s").arg(time/1000.0, 0, 'f', 2));
+            rte->setResultFromBRouter(xml, reply->property("options").toString() + tr("<br/>Calculation time: %1s").arg(time / 1000.0, 0, 'f', 2));
         }
     }
     catch(const QString& msg)

--- a/src/qmapshack/gis/rte/router/CRouterMapQuest.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterMapQuest.cpp
@@ -180,7 +180,7 @@ void CRouterMapQuest::addMapQuestLocations(QDomDocument& xml, QDomElement& locat
     for(const IGisLine::point_t &pt : line)
     {
         QDomElement location = xml.createElement("location");
-        location.appendChild(xml.createTextNode(QString("%1,%2").arg(pt.coord.y()*RAD_TO_DEG).arg(pt.coord.x()*RAD_TO_DEG)));
+        location.appendChild(xml.createTextNode(QString("%1,%2").arg(pt.coord.y() * RAD_TO_DEG).arg(pt.coord.x() * RAD_TO_DEG)));
         locations.appendChild(location);
     }
 }
@@ -360,7 +360,7 @@ void CRouterMapQuest::slotRequestFinished(QNetworkReply* reply)
     CGisItemRte * rte = dynamic_cast<CGisItemRte*>(CGisWorkspace::self().getItemByKey(key));
     if(rte != nullptr)
     {
-        rte->setResult(xml, reply->property("options").toString() + tr("<br/>Calculation time: %1s").arg(time/1000.0, 0, 'f', 2));
+        rte->setResult(xml, reply->property("options").toString() + tr("<br/>Calculation time: %1s").arg(time / 1000.0, 0, 'f', 2));
     }
 
     slotCloseStatusMsg();

--- a/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
@@ -38,7 +38,7 @@ int CRouterOptimization::optimize(SGisLine &line)
         return 0; //There is nothing to optimize
     }
 
-    CProgressDialog progress(CProgressDialog::tr("Optimizing route"), 0, line.length()+2, nullptr);
+    CProgressDialog progress(CProgressDialog::tr("Optimizing route"), 0, line.length() + 2, nullptr);
 
     //Optimize using air distance and known distances, since this is much faster than routing, especially brouter
     SGisLine newAirdistanceOrder;
@@ -84,7 +84,7 @@ int CRouterOptimization::optimize(SGisLine &line)
     // but you'd likely need more to find the global optimum if there are more possibilities
     while(numOfRestarts < line.length())
     {
-        progress.setValue(numOfRestarts+2);
+        progress.setValue(numOfRestarts + 2);
         if(progress.wasCanceled())
         {
             return -1;
@@ -135,22 +135,22 @@ qreal CRouterOptimization::createNextBestOrder(const SGisLine &oldOrder, SGisLin
     int bestInsertedItemIndex = -1;
 
     // lastWorkingOrder.length()-2, since we can't use the last two items as base
-    for(int baseIndex = 0; baseIndex < oldOrder.length() -2; baseIndex++)
+    for(int baseIndex = 0; baseIndex < oldOrder.length() - 2; baseIndex++)
     {
         // Keep start and end fixed
-        for(int insertedItemIndex = 1; insertedItemIndex < oldOrder.length() -1; insertedItemIndex++)
+        for(int insertedItemIndex = 1; insertedItemIndex < oldOrder.length() - 1; insertedItemIndex++)
         {
-            if(baseIndex == insertedItemIndex || baseIndex == insertedItemIndex-1)
+            if(baseIndex == insertedItemIndex || baseIndex == insertedItemIndex - 1)
             {
                 continue;
             }
 
             qreal insertionGain = bestKnownDistance(oldOrder[baseIndex], oldOrder[insertedItemIndex])
-                                  + bestKnownDistance(oldOrder[insertedItemIndex], oldOrder[baseIndex +1])
-                                  - bestKnownDistance(oldOrder[baseIndex], oldOrder[baseIndex+1])
-                                  + bestKnownDistance(oldOrder[insertedItemIndex-1], oldOrder[insertedItemIndex+1])
-                                  - bestKnownDistance(oldOrder[insertedItemIndex-1], oldOrder[insertedItemIndex])
-                                  - bestKnownDistance(oldOrder[insertedItemIndex], oldOrder[insertedItemIndex+1]);
+                                  + bestKnownDistance(oldOrder[insertedItemIndex], oldOrder[baseIndex + 1])
+                                  - bestKnownDistance(oldOrder[baseIndex], oldOrder[baseIndex + 1])
+                                  + bestKnownDistance(oldOrder[insertedItemIndex - 1], oldOrder[insertedItemIndex + 1])
+                                  - bestKnownDistance(oldOrder[insertedItemIndex - 1], oldOrder[insertedItemIndex])
+                                  - bestKnownDistance(oldOrder[insertedItemIndex], oldOrder[insertedItemIndex + 1]);
 
             if(insertionGain < bestInsertionGain)
             {
@@ -172,7 +172,7 @@ qreal CRouterOptimization::createNextBestOrder(const SGisLine &oldOrder, SGisLin
         }
         else
         {
-            newOrder.move(bestInsertedItemIndex, bestBaseIndex+1);
+            newOrder.move(bestInsertedItemIndex, bestBaseIndex + 1);
         }
     }
     return bestInsertionGain;
@@ -191,22 +191,22 @@ qreal CRouterOptimization::twoOptStep(const SGisLine &oldOrder, SGisLine &newOrd
     {
         for(int endIndex = beginIndex + 1; endIndex < oldOrder.length() - 1; endIndex++)
         {
-            qreal oldRangeCosts = bestKnownDistance(oldOrder[beginIndex-1], oldOrder[beginIndex])
-                                  + bestKnownDistance(oldOrder[endIndex], oldOrder[endIndex+1]);
+            qreal oldRangeCosts = bestKnownDistance(oldOrder[beginIndex - 1], oldOrder[beginIndex])
+                                  + bestKnownDistance(oldOrder[endIndex], oldOrder[endIndex + 1]);
 
-            qreal newRangeCosts = bestKnownDistance(oldOrder[beginIndex-1], oldOrder[endIndex])
-                                  +bestKnownDistance(oldOrder[beginIndex], oldOrder[endIndex+1]);
+            qreal newRangeCosts = bestKnownDistance(oldOrder[beginIndex - 1], oldOrder[endIndex])
+                                  + bestKnownDistance(oldOrder[beginIndex], oldOrder[endIndex + 1]);
             for(int i = beginIndex; i < endIndex; i++)
             {
-                oldRangeCosts+=bestKnownDistance(oldOrder[i], oldOrder[i+1]);
-                newRangeCosts+=bestKnownDistance(oldOrder[i+1], oldOrder[i]);
+                oldRangeCosts += bestKnownDistance(oldOrder[i], oldOrder[i + 1]);
+                newRangeCosts += bestKnownDistance(oldOrder[i + 1], oldOrder[i]);
             }
 
-            if(newRangeCosts-oldRangeCosts < bestTwoOptGain)
+            if(newRangeCosts - oldRangeCosts < bestTwoOptGain)
             {
                 bestBeginIndex = beginIndex;
                 bestEndIndex = endIndex;
-                bestTwoOptGain = newRangeCosts-oldRangeCosts;
+                bestTwoOptGain = newRangeCosts - oldRangeCosts;
             }
         }
     }
@@ -214,7 +214,7 @@ qreal CRouterOptimization::twoOptStep(const SGisLine &oldOrder, SGisLine &newOrd
     newOrder = SGisLine(oldOrder);
     if(bestEndIndex >= 0 && bestBeginIndex >= 0)
     {
-        std::reverse(newOrder.begin()+bestBeginIndex, newOrder.begin()+bestEndIndex);
+        std::reverse(newOrder.begin() + bestBeginIndex, newOrder.begin() + bestEndIndex);
     }
     return bestTwoOptGain;
 }
@@ -222,9 +222,9 @@ qreal CRouterOptimization::twoOptStep(const SGisLine &oldOrder, SGisLine &newOrd
 qreal CRouterOptimization::getRealRouteCosts(const SGisLine &line, qreal costCutoff)
 {
     qreal costs = 0;
-    for(int i = 0; i < line.length()-1; i++)
+    for(int i = 0; i < line.length() - 1; i++)
     {
-        const routing_cache_item_t* route = getRoute(line[i].coord, line[i+1].coord);
+        const routing_cache_item_t* route = getRoute(line[i].coord, line[i + 1].coord);
         if(route == nullptr)
         {
             return -1;
@@ -242,8 +242,8 @@ qreal CRouterOptimization::getRealRouteCosts(const SGisLine &line, qreal costCut
 qreal CRouterOptimization::bestKnownDistance(const IGisLine::point_t& start, const IGisLine::point_t& end)
 {
     //10 digits after the decimal point in exponential format should be by far enough
-    QString start_key=QString::number(start.coord.x(), 'e', 10) + QString::number(start.coord.y(), 'e', 10);
-    QString end_key=QString::number(end.coord.x(), 'e', 10) + QString::number(end.coord.y(), 'e', 10);
+    QString start_key = QString::number(start.coord.x(), 'e', 10) + QString::number(start.coord.y(), 'e', 10);
+    QString end_key = QString::number(end.coord.x(), 'e', 10) + QString::number(end.coord.y(), 'e', 10);
 
     if(!routingCache.contains(start_key))
     {
@@ -262,7 +262,7 @@ qreal CRouterOptimization::bestKnownDistance(const IGisLine::point_t& start, con
         {
             return GPS_Math_DistanceQuick(start.coord.x(), start.coord.y(),
                                           end.coord.x(), end.coord.y())
-                   * (totalAirToCosts/totalNumOfRoutes + minAirToCostFactor)/2;
+                   * (totalAirToCosts / totalNumOfRoutes + minAirToCostFactor) / 2;
         }
         else
         {
@@ -274,8 +274,8 @@ qreal CRouterOptimization::bestKnownDistance(const IGisLine::point_t& start, con
 
 const CRouterOptimization::routing_cache_item_t* CRouterOptimization::getRoute(const QPointF& start, const QPointF& end)
 {
-    QString start_key=QString::number(start.x(), 'e', 10) + QString::number(start.y(), 'e', 10);
-    QString end_key=QString::number(end.x(), 'e', 10) + QString::number(end.y(), 'e', 10);
+    QString start_key = QString::number(start.x(), 'e', 10) + QString::number(start.y(), 'e', 10);
+    QString end_key = QString::number(end.x(), 'e', 10) + QString::number(end.y(), 'e', 10);
 
     if(!routingCache.contains(start_key))
     {
@@ -292,7 +292,7 @@ const CRouterOptimization::routing_cache_item_t* CRouterOptimization::getRoute(c
         }
         routingCache[start_key][end_key] = cacheItem;
 
-        qreal airToCostFactor = cacheItem.costs/GPS_Math_DistanceQuick(start.x(), start.y(), end.x(), end.y());
+        qreal airToCostFactor = cacheItem.costs / GPS_Math_DistanceQuick(start.x(), start.y(), end.x(), end.y());
         if( airToCostFactor < minAirToCostFactor || minAirToCostFactor < 0)
         {
             minAirToCostFactor = airToCostFactor;
@@ -305,17 +305,17 @@ const CRouterOptimization::routing_cache_item_t* CRouterOptimization::getRoute(c
 
 int CRouterOptimization::fillSubPts(SGisLine &line)
 {
-    for(int i = 0; i < line.length()-1; i++)
+    for(int i = 0; i < line.length() - 1; i++)
     {
         line[i].subpts.clear();
-        const routing_cache_item_t* route= getRoute(line[i].coord, line[i+1].coord);
+        const routing_cache_item_t* route = getRoute(line[i].coord, line[i + 1].coord);
         if(route == nullptr)
         {
             return -1;
         }
         for(const QPointF& point : route->route)
         {
-            line[i].subpts<<IGisLine::subpt_t(point);
+            line[i].subpts << IGisLine::subpt_t(point);
         }
     }
     return 0;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -62,7 +62,7 @@ void CRouterBRouterSetup::load()
     expertSegmentsUrl = cfg.value("expertSegmentsUrl", defaultSegmentsUrl).toString();
     onlineProfiles.clear();
     int size = cfg.beginReadArray("online");
-    for (int i=0; i < size; i++)
+    for (int i = 0; i < size; i++)
     {
         cfg.setArrayIndex(i);
         onlineProfiles << cfg.value("profile").toString();
@@ -70,7 +70,7 @@ void CRouterBRouterSetup::load()
     cfg.endArray();
     localProfiles.clear();
     size = cfg.beginReadArray("local");
-    for (int i=0; i < size; i++)
+    for (int i = 0; i < size; i++)
     {
         cfg.setArrayIndex(i);
         localProfiles << cfg.value("profile").toString();
@@ -118,14 +118,14 @@ void CRouterBRouterSetup::save()
     cfg.setValue("expertBinariesUrl", expertBinariesUrl);
     cfg.setValue("expertSegmentsUrl", expertSegmentsUrl);
     cfg.beginWriteArray("online");
-    for (int i=0; i < onlineProfiles.size(); i++)
+    for (int i = 0; i < onlineProfiles.size(); i++)
     {
         cfg.setArrayIndex(i);
         cfg.setValue("profile", onlineProfiles.at(i));
     }
     cfg.endArray();
     cfg.beginWriteArray("local");
-    for (int i=0; i < localProfiles.size(); i++)
+    for (int i = 0; i < localProfiles.size(); i++)
     {
         cfg.setArrayIndex(i);
         cfg.setValue("profile", localProfiles.at(i));
@@ -231,7 +231,7 @@ void CRouterBRouterSetup::profileUp(const QString &profile)
         if (index > 0)
         {
             localProfiles.removeAt(index);
-            localProfiles.insert(index-1, profile);
+            localProfiles.insert(index - 1, profile);
             emit sigProfilesChanged();
         }
     }
@@ -242,7 +242,7 @@ void CRouterBRouterSetup::profileUp(const QString &profile)
         if (index > 0)
         {
             onlineProfiles.removeAt(index);
-            onlineProfiles.insert(index-1, profile);
+            onlineProfiles.insert(index - 1, profile);
             emit sigProfilesChanged();
         }
     }
@@ -253,10 +253,10 @@ void CRouterBRouterSetup::profileDown(const QString &profile)
     if (installMode == eModeLocal)
     {
         int index = localProfiles.indexOf(profile);
-        if (index > -1 && index < localProfiles.size()-1)
+        if (index > -1 && index < localProfiles.size() - 1)
         {
             localProfiles.removeAt(index);
-            localProfiles.insert(index+1, profile);
+            localProfiles.insert(index + 1, profile);
             emit sigProfilesChanged();
         }
     }
@@ -264,10 +264,10 @@ void CRouterBRouterSetup::profileDown(const QString &profile)
     {
         Q_ASSERT(installMode == eModeOnline);
         int index = onlineProfiles.indexOf(profile);
-        if (index > -1 && index < onlineProfiles.size()-1)
+        if (index > -1 && index < onlineProfiles.size() - 1)
         {
             onlineProfiles.removeAt(index);
-            onlineProfiles.insert(index+1, profile);
+            onlineProfiles.insert(index + 1, profile);
             emit sigProfilesChanged();
         }
     }
@@ -284,7 +284,7 @@ void CRouterBRouterSetup::readLocalProfiles()
         {
             if (profile.endsWith(".brf"))
             {
-                installedProfiles << profile.left(profile.length()-4);
+                installedProfiles << profile.left(profile.length() - 4);
             }
         }
     }
@@ -503,7 +503,7 @@ void CRouterBRouterSetup::loadOnlineConfigFinished(QNetworkReply *reply)
             const qint32 len = profiles.property("length").toInt();
 
             QStringList onlineProfilesLoaded;
-            for(qint32 i=0; i < len; i++)
+            for(qint32 i = 0; i < len; i++)
             {
                 const QJSValue &profile = profiles.property(i);
                 if (!profile.isString() || profile.isError())

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
@@ -509,7 +509,7 @@ void CRouterBRouterSetupWizard::slotLocalDownloadButtonClicked()
         QMessageBox mbox;
         mbox.setWindowTitle(tr("Warning..."));
         mbox.setIcon(QMessageBox::Warning);
-        mbox.setStandardButtons(QMessageBox::Ok|QMessageBox::Abort);
+        mbox.setStandardButtons(QMessageBox::Ok | QMessageBox::Abort);
         mbox.setDefaultButton(QMessageBox::Abort);
 
         QString msg = tr("Download: %1<br/>"
@@ -691,12 +691,12 @@ void CRouterBRouterSetupWizard::updateProfiles() const
     qSort(selected.begin(), selected.end());
     toolDeleteProfile->setEnabled(!selected.isEmpty());
     toolProfileUp->setEnabled(!selected.isEmpty() && selected.first() > 0);
-    toolProfileDown->setEnabled(!selected.isEmpty() && selected.last() < profiles.size()-1);
+    toolProfileDown->setEnabled(!selected.isEmpty() && selected.last() < profiles.size() - 1);
     if (isError)
     {
         toolAddProfile->setEnabled(false);
         labelProfileContent->setText(tr("Error:"));
-        textProfileContent->setText(error + ": "+ errorDetails);
+        textProfileContent->setText(error + ": " + errorDetails);
     }
     else
     {
@@ -784,7 +784,7 @@ void CRouterBRouterSetupWizard::updateOnlineDetails() const
     }
     if (isError)
     {
-        textOnlineDetails->setText(error + ": "+ errorDetails);
+        textOnlineDetails->setText(error + ": " + errorDetails);
     }
 }
 

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelect.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelect.cpp
@@ -423,27 +423,27 @@ QString CRouterBRouterTilesSelect::formatSize(const qint64 size)
 {
     if (size >= 2147483648)
     {
-        return QString("%1G").arg(size/1073741824);
+        return QString("%1G").arg(size / 1073741824);
     }
     else if (size >= 1073741824)
     {
-        return QString("%1G").arg(qreal(size/107374182)/10);
+        return QString("%1G").arg(qreal(size / 107374182) / 10);
     }
     else if (size >= 2097152)
     {
-        return QString("%1M").arg(size/1048576);
+        return QString("%1M").arg(size / 1048576);
     }
     else if (size >= 1048576)
     {
-        return QString("%1M").arg(qreal(size/104858)/10);
+        return QString("%1M").arg(qreal(size / 104858) / 10);
     }
     else if (size >= 2048)
     {
-        return QString("%1K").arg(size/1024);
+        return QString("%1K").arg(size / 1024);
     }
     else if (size >= 1000)
     {
-        return QString("%1K").arg(qreal(size/102)/10);
+        return QString("%1K").arg(qreal(size / 102) / 10);
     }
     else
     {
@@ -500,7 +500,7 @@ void CRouterBRouterTilesSelect::slotDownload()
             status->isSelected = false;
             changed = true;
 
-            status->file = new QFile(dir.absoluteFilePath(fileName+".tmp"));
+            status->file = new QFile(dir.absoluteFilePath(fileName + ".tmp"));
             if (!status->file->open(QIODevice::WriteOnly))
             {
                 const QString tmpName = status->file->fileName();
@@ -602,7 +602,7 @@ void CRouterBRouterTilesSelect::slotDownloadFinished(QNetworkReply* reply)
         {
             if(reply->error() != QNetworkReply::NoError)
             {
-                error(fileName + ": "+reply->errorString());
+                error(fileName + ": " + reply->errorString());
             }
             else if (status->file->write(reply->readAll()) < 0)
             {

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelectArea.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelectArea.cpp
@@ -79,7 +79,7 @@ void CRouterBRouterTilesSelectArea::mouseMoveEvent(QMouseEvent * event)
 {
     if (event->buttons() == Qt::LeftButton)
     {
-        canvas->moveMap(QPointF(event->pos()-mousePos));
+        canvas->moveMap(QPointF(event->pos() - mousePos));
         mousePos = event->pos();
     }
 }
@@ -98,7 +98,7 @@ void CRouterBRouterTilesSelectArea::mouseReleaseEvent(QMouseEvent * event)
     if (button == Qt::LeftButton)
     {
         const QPoint &pos = event->pos();
-        canvas->moveMap(QPointF(pos-mousePos));
+        canvas->moveMap(QPointF(pos - mousePos));
         if (pos == startPos)
         {
             emit sigTileClicked(tileUnderMouse(pos));
@@ -134,17 +134,17 @@ QPoint CRouterBRouterTilesSelectArea::tileUnderMouse(const QPointF & mousePos) c
     QPointF pos(mousePos);
     canvas->convertPx2Rad(pos);
     QPointF posDegF = pos * RAD_TO_DEG;
-    QPoint tile(posDegF.x() > 0 ? posDegF.x()/CRouterBRouterTilesSelect::tileSize : posDegF.x()/CRouterBRouterTilesSelect::tileSize - 1
-                , posDegF.y() > 0 ? posDegF.y()/CRouterBRouterTilesSelect::tileSize : posDegF.y()/CRouterBRouterTilesSelect::tileSize - 1);
+    QPoint tile(posDegF.x() > 0 ? posDegF.x() / CRouterBRouterTilesSelect::tileSize : posDegF.x() / CRouterBRouterTilesSelect::tileSize - 1
+                , posDegF.y() > 0 ? posDegF.y() / CRouterBRouterTilesSelect::tileSize : posDegF.y() / CRouterBRouterTilesSelect::tileSize - 1);
     return tile * CRouterBRouterTilesSelect::tileSize;
 }
 
 QPolygonF CRouterBRouterTilesSelectArea::tilePolygon(const QPoint & tile) const
 {
     QPointF p0(tile.x(), tile.y());
-    QPointF p1(tile.x()+CRouterBRouterTilesSelect::tileSize, tile.y());
-    QPointF p2(tile.x()+CRouterBRouterTilesSelect::tileSize, tile.y()+CRouterBRouterTilesSelect::tileSize);
-    QPointF p3(tile.x(), tile.y()+CRouterBRouterTilesSelect::tileSize);
+    QPointF p1(tile.x() + CRouterBRouterTilesSelect::tileSize, tile.y());
+    QPointF p2(tile.x() + CRouterBRouterTilesSelect::tileSize, tile.y() + CRouterBRouterTilesSelect::tileSize);
+    QPointF p3(tile.x(), tile.y() + CRouterBRouterTilesSelect::tileSize);
 
     p0 *= DEG_TO_RAD;
     p1 *= DEG_TO_RAD;
@@ -168,8 +168,8 @@ QPolygonF CRouterBRouterTilesSelectArea::tilePolygon(const QPoint & tile) const
 QPolygonF CRouterBRouterTilesSelectArea::gridPolygon(const QPoint & tile) const
 {
     QPointF p0(tile.x(), tile.y());
-    QPointF p1(tile.x()+CRouterBRouterTilesSelect::tileSize, tile.y());
-    QPointF p2(tile.x()+CRouterBRouterTilesSelect::tileSize, tile.y()+CRouterBRouterTilesSelect::tileSize);
+    QPointF p1(tile.x() + CRouterBRouterTilesSelect::tileSize, tile.y());
+    QPointF p2(tile.x() + CRouterBRouterTilesSelect::tileSize, tile.y() + CRouterBRouterTilesSelect::tileSize);
 
     p0 *= DEG_TO_RAD;
     p1 *= DEG_TO_RAD;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterToolShell.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterToolShell.cpp
@@ -41,7 +41,7 @@ void CRouterBRouterToolShell::start(const QString &dir, const QString &command, 
     isBeingKilled = false;
     isStarting = true;
     stdOut("cd " + dir);
-    stdOut(command+" " + args.join(" ") + "\n");
+    stdOut(command + " " + args.join(" ") + "\n");
     cmd.setWorkingDirectory(dir);
     startupTimer->start(200);
     cmd.start(command, args);

--- a/src/qmapshack/gis/search/CGeoSearchWebConfigDialog.cpp
+++ b/src/qmapshack/gis/search/CGeoSearchWebConfigDialog.cpp
@@ -64,7 +64,7 @@ void CGeoSearchWebConfigDialog::setupTreeWidget()
         item->setIcon(0, QIcon(service.icon));
         item->setData(0, Qt::UserRole, service.icon);
         item->setText(1, service.url);
-        item->setFlags(item->flags()|Qt::ItemIsEditable);
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
     }
 
     treeServices->header()->resizeSections(QHeaderView::ResizeToContents);
@@ -103,14 +103,14 @@ void CGeoSearchWebConfigDialog::slotAddNew()
     item->setText(0, tr("enter name and URL"));
     item->setIcon(0, QIcon(CGeoSearchWeb::defaultIcon));
     item->setData(0, Qt::UserRole, CGeoSearchWeb::defaultIcon);
-    item->setFlags(item->flags()|Qt::ItemIsEditable);
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
 
     treeServices->scrollToItem(item, QAbstractItemView::PositionAtCenter);
 }
 
 void CGeoSearchWebConfigDialog::slotDelSelected()
 {
-    int res = QMessageBox::question(this, tr("Remove..."), tr("Remove all selected services?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+    int res = QMessageBox::question(this, tr("Remove..."), tr("Remove all selected services?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if(res != QMessageBox::Yes)
     {
         return;
@@ -121,7 +121,7 @@ void CGeoSearchWebConfigDialog::slotDelSelected()
 
 void CGeoSearchWebConfigDialog::slotReset()
 {
-    int res = QMessageBox::question(this, tr("Restore default..."), tr("Remove all services and restore default list?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+    int res = QMessageBox::question(this, tr("Restore default..."), tr("Remove all services and restore default list?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if(res != QMessageBox::Yes)
     {
         return;

--- a/src/qmapshack/gis/search/CProjectFilterItem.h
+++ b/src/qmapshack/gis/search/CProjectFilterItem.h
@@ -29,7 +29,7 @@ class CProjectFilterItem : public QTreeWidgetItem
 public:
     CProjectFilterItem(IGisProject *parent);
     virtual ~CProjectFilterItem();
-    void showLineEdit(CSearch* search=nullptr);
+    void showLineEdit(CSearch* search = nullptr);
     const CSearchLineEdit* getLineEdit()
     {
         return lineEdit;

--- a/src/qmapshack/gis/search/CSearch.cpp
+++ b/src/qmapshack/gis/search/CSearch.cpp
@@ -48,7 +48,7 @@ CSearch::CSearch(QString searchstring)
         //Make spaces around so for example with is not detected inside without
         if(searchstring.contains(" " + key + " ", Qt::CaseInsensitive))
         {
-            searchTypeKeyword=key;
+            searchTypeKeyword = key;
             break;
         }
     }
@@ -56,29 +56,29 @@ CSearch::CSearch(QString searchstring)
     if(searchTypeKeyword.isEmpty())
     {
         //Default to search for what the user typed in the name or the full text
-        search.searchType=eSearchTypeWith;
+        search.searchType = eSearchTypeWith;
         if(searchMode == eSearchModeText)
         {
-            search.property=searchProperty_e::eSearchPropertyGeneralFullText;
+            search.property = searchProperty_e::eSearchPropertyGeneralFullText;
         }
         else
         {
-            search.property=searchProperty_e::eSearchPropertyGeneralName;
+            search.property = searchProperty_e::eSearchPropertyGeneralName;
         }
         search.searchValue.str1 = searchstring.simplified();
         syntaxError = true;
     }
     else
     {
-        search.searchType=keywordSearchTypeMap.value(searchTypeKeyword);
+        search.searchType = keywordSearchTypeMap.value(searchTypeKeyword);
         //Everything before the Search Type keyword is the property, i.e. "date after 2019" would result in "date"
-        search.property=eSearchPropertyNoMatch;
-        QString propertyString=searchstring.section(searchTypeKeyword, 0, 0, QString::SectionCaseInsensitiveSeps).simplified();
+        search.property = eSearchPropertyNoMatch;
+        QString propertyString = searchstring.section(searchTypeKeyword, 0, 0, QString::SectionCaseInsensitiveSeps).simplified();
         for(const QString& key:searchPropertyEnumMap.keys())
         {
             if(propertyString.compare(key, Qt::CaseInsensitive) == 0)
             {
-                search.property=searchPropertyEnumMap[key];
+                search.property = searchPropertyEnumMap[key];
                 break;
             }
         }
@@ -103,15 +103,15 @@ CSearch::CSearch(QString searchstring)
             QTime time1a = QLocale::system().toTime(filterValueStringFirstPart, tf);
             if(time1a.isValid())
             {
-                filterValue.value1=time1a.msecsSinceStartOfDay()/1000;
-                filterValue.str1="SsE";
+                filterValue.value1 = time1a.msecsSinceStartOfDay() / 1000;
+                filterValue.str1 = "SsE";
             }
 
-            QTime time1b=QLocale::c().toTime(filterValueStringFirstPart, tf);
+            QTime time1b = QLocale::c().toTime(filterValueStringFirstPart, tf);
             if(time1b.isValid())
             {
-                filterValue.value1=time1b.msecsSinceStartOfDay()/1000;
-                filterValue.str1="SsE";
+                filterValue.value1 = time1b.msecsSinceStartOfDay() / 1000;
+                filterValue.str1 = "SsE";
             }
 
             if(time1a.isValid() || time1b.isValid())
@@ -119,15 +119,15 @@ CSearch::CSearch(QString searchstring)
                 QTime time2a = QLocale::system().toTime(filterValueStringSecondPart, tf);
                 if(time2a.isValid())
                 {
-                    filterValue.value2=time2a.msecsSinceStartOfDay()/1000;
-                    filterValue.str2="SsE";
+                    filterValue.value2 = time2a.msecsSinceStartOfDay() / 1000;
+                    filterValue.str2 = "SsE";
                 }
 
-                QTime time2b=QLocale::c().toTime(filterValueStringSecondPart, tf);
+                QTime time2b = QLocale::c().toTime(filterValueStringSecondPart, tf);
                 if(time2b.isValid())
                 {
-                    filterValue.value2=time2b.msecsSinceStartOfDay()/1000;
-                    filterValue.str2="SsE";
+                    filterValue.value2 = time2b.msecsSinceStartOfDay() / 1000;
+                    filterValue.str2 = "SsE";
                 }
                 break;
             }
@@ -152,15 +152,15 @@ CSearch::CSearch(QString searchstring)
                 QDateTime time1a = QLocale::system().toDateTime(filterValueStringFirstPart, df);
                 if(time1a.isValid())
                 {
-                    filterValue.value1=time1a.toSecsSinceEpoch();
-                    filterValue.str1="SsE";
+                    filterValue.value1 = time1a.toSecsSinceEpoch();
+                    filterValue.str1 = "SsE";
                 }
 
-                QDateTime time1b=QLocale::c().toDateTime(filterValueStringFirstPart, df);
+                QDateTime time1b = QLocale::c().toDateTime(filterValueStringFirstPart, df);
                 if(time1b.isValid())
                 {
-                    filterValue.value1=time1b.toSecsSinceEpoch();
-                    filterValue.str1="SsE";
+                    filterValue.value1 = time1b.toSecsSinceEpoch();
+                    filterValue.str1 = "SsE";
                 }
 
                 if(time1a.isValid() || time1b.isValid())
@@ -168,15 +168,15 @@ CSearch::CSearch(QString searchstring)
                     QDateTime time2a = QLocale::system().toDateTime(filterValueStringSecondPart, df);
                     if(time2a.isValid())
                     {
-                        filterValue.value2=time2a.toSecsSinceEpoch();
-                        filterValue.str2="SsE";
+                        filterValue.value2 = time2a.toSecsSinceEpoch();
+                        filterValue.str2 = "SsE";
                     }
 
-                    QDateTime time2b=QLocale::c().toDateTime(filterValueStringSecondPart, df);
+                    QDateTime time2b = QLocale::c().toDateTime(filterValueStringSecondPart, df);
                     if(time2b.isValid())
                     {
-                        filterValue.value2=time2b.toSecsSinceEpoch();
-                        filterValue.str2="SsE";
+                        filterValue.value2 = time2b.toSecsSinceEpoch();
+                        filterValue.str2 = "SsE";
                     }
                     break;
                 }
@@ -200,29 +200,29 @@ CSearch::CSearch(QString searchstring)
             {
                 if(numericArguments.cap(1) != "")     //to avoid removal of NOFLOAT
                 {
-                    filterValue.value1=numericArguments.cap(1).toFloat();
+                    filterValue.value1 = numericArguments.cap(1).toFloat();
                 }
 
-                filterValue.str1=numericArguments.cap(2);
+                filterValue.str1 = numericArguments.cap(2);
 
                 if(numericArguments.cap(3) != "")     //to avoid removal of NOFLOAT
                 {
-                    filterValue.value2=numericArguments.cap(3).toFloat();
+                    filterValue.value2 = numericArguments.cap(3).toFloat();
                 }
 
-                filterValue.str2=numericArguments.cap(4);
+                filterValue.str2 = numericArguments.cap(4);
             }
         }
         if(filterValue.toString().isEmpty())
         {
             filterValue.str1 = filterValueString;
         }
-        search.searchValue=filterValue;
+        search.searchValue = filterValue;
     }
     improveQuery();
     if(search.property == eSearchPropertyNoMatch)
     {
-        syntaxError=true;
+        syntaxError = true;
     }
 }
 
@@ -294,11 +294,11 @@ void CSearch::improveQuery()
     //If the user entered a number with a unit and another number, assume they have the same unit
     if(search.searchValue.str1 != "" && search.searchValue.str2 == "" && search.searchValue.value1 != NOFLOAT && search.searchValue.value2 != NOFLOAT)
     {
-        search.searchValue.str2=search.searchValue.str1;
+        search.searchValue.str2 = search.searchValue.str1;
     }
     if(search.searchValue.str1 == "" && search.searchValue.str2 != "" && search.searchValue.value1 != NOFLOAT && search.searchValue.value2 != NOFLOAT)
     {
-        search.searchValue.str1=search.searchValue.str2;
+        search.searchValue.str1 = search.searchValue.str2;
     }
 
     //Try to guess what property the user meant when there is no match. I.e. make "shorter than 5km" work
@@ -344,14 +344,14 @@ void CSearch::improveQuery()
             //Try to catch if user only entered a year. Not done in regular detecting as it could be a speed or so.
             if(search.searchValue.str1.isEmpty())
             {
-                search.searchValue.value1=QDateTime(QDate(search.searchValue.value1, 1, 1)).toSecsSinceEpoch();
-                search.searchValue.str1="SsE";
+                search.searchValue.value1 = QDateTime(QDate(search.searchValue.value1, 1, 1)).toSecsSinceEpoch();
+                search.searchValue.str1 = "SsE";
             }
             //Assume you want 2012 and not 1912 (qt defaults to 19xx)
             else if(QDateTime::fromSecsSinceEpoch(search.searchValue.value1).addYears(100) <=  QDateTime::currentDateTime())
             {
-                search.searchValue.value1=QDateTime::fromSecsSinceEpoch(search.searchValue.value1).addYears(100).toSecsSinceEpoch();
-                search.searchValue.str1="SsE";
+                search.searchValue.value1 = QDateTime::fromSecsSinceEpoch(search.searchValue.value1).addYears(100).toSecsSinceEpoch();
+                search.searchValue.str1 = "SsE";
             }
         }
         if(search.searchValue.value2 != NOFLOAT)
@@ -359,23 +359,23 @@ void CSearch::improveQuery()
             //Try to catch if user only entered a year. Not done in regular detecting as it could be a speed or so.
             if(search.searchValue.str2.isEmpty())
             {
-                search.searchValue.value2=QDateTime(QDate(search.searchValue.value2, 1, 1)).toSecsSinceEpoch();
-                search.searchValue.str2="SsE";
+                search.searchValue.value2 = QDateTime(QDate(search.searchValue.value2, 1, 1)).toSecsSinceEpoch();
+                search.searchValue.str2 = "SsE";
             }
             //Assume you want 2012 and not 1912 (qt defaults to 19xx)
             else if(QDateTime::fromSecsSinceEpoch(search.searchValue.value2).addYears(100) <=  QDateTime::currentDateTime())
             {
-                search.searchValue.value2=QDateTime::fromSecsSinceEpoch(search.searchValue.value2).addYears(100).toSecsSinceEpoch();
-                search.searchValue.str2="SsE";
+                search.searchValue.value2 = QDateTime::fromSecsSinceEpoch(search.searchValue.value2).addYears(100).toSecsSinceEpoch();
+                search.searchValue.str2 = "SsE";
             }
         }
 
         //If the user searched for 'date equals' change it to 'between 0h and 24h of the day queried'
         if(search.searchType == eSearchTypeEquals)
         {
-            search.searchType=eSearchTypeBetween;
-            search.searchValue.str2="SsE";
-            search.searchValue.value2=search.searchValue.value1 + 24*60*60;
+            search.searchType = eSearchTypeBetween;
+            search.searchValue.str2 = "SsE";
+            search.searchValue.value2 = search.searchValue.value1 + 24 * 60 * 60;
         }
     }
 }

--- a/src/qmapshack/gis/search/CSearch.h
+++ b/src/qmapshack/gis/search/CSearch.h
@@ -183,7 +183,7 @@ public:
     }
     static void setCaseSensitivity(const Qt::CaseSensitivity &value)
     {
-        caseSensitivity=value;
+        caseSensitivity = value;
     }
 
     static search_mode_e getSearchMode()

--- a/src/qmapshack/gis/search/CSearchExplanationDialog.cpp
+++ b/src/qmapshack/gis/search/CSearchExplanationDialog.cpp
@@ -68,7 +68,7 @@ CSearchExplanationDialog::CSearchExplanationDialog(QWidget *parent)
     explanation += "<li>" + QLocale::c().dateTimeFormat(QLocale::ShortFormat) + "</li>";
     explanation += "</ul>";
     explanation += tr("<p>The search can only convert following units:</p>");
-    explanation += "<p>"+IUnit::getUnits().join(", ") + "</p>";
+    explanation += "<p>" + IUnit::getUnits().join(", ") + "</p>";
     explanation += tr("<p>The regex search uses this syntax: https://perldoc.perl.org/perlre.html</p>");
     textBrowserExplanation->setText(explanation);
     for(QString property : CSearch::getSearchTypeKeywords())

--- a/src/qmapshack/gis/search/CSearchLineEdit.cpp
+++ b/src/qmapshack/gis/search/CSearchLineEdit.cpp
@@ -58,7 +58,7 @@ CSearchLineEdit::CSearchLineEdit(QWidget *parent)
 
 CSearchLineEdit::CSearchLineEdit(QWidget *parent, IGisProject* project, CSearch* search) : CSearchLineEdit(parent)
 {
-    connectedProject=project;
+    connectedProject = project;
     if(search != nullptr)
     {
         setText(search->getSearchText());

--- a/src/qmapshack/gis/search/CSearchLineEdit.h
+++ b/src/qmapshack/gis/search/CSearchLineEdit.h
@@ -29,7 +29,7 @@ class CSearchLineEdit : public QLineEdit
     Q_OBJECT
 public:
     CSearchLineEdit(QWidget* parent);
-    CSearchLineEdit(QWidget* parent, IGisProject* project, CSearch *search=nullptr);
+    CSearchLineEdit(QWidget* parent, IGisProject* project, CSearch *search = nullptr);
 
 signals:
     void sigWorkspaceSearchChanged(CSearch newSearch);

--- a/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
+++ b/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
@@ -36,7 +36,7 @@ CGisSummaryDropZone::CGisSummaryDropZone(const CGisSummary::dropzone_t &dropZone
     }
 
     setToolTip(folderNames.join("\n") + "\n\n" + tr("Drag-n-drop items from the workspace into this drop zone."));
-    setAlignment(Qt::AlignHCenter|Qt::AlignVCenter);
+    setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
     setAutoFillBackground(true);
     setBackgroundRole(QPalette::Mid);
     setForegroundRole(QPalette::Text);

--- a/src/qmapshack/gis/suunto/CLogProject.cpp
+++ b/src/qmapshack/gis/suunto/CLogProject.cpp
@@ -142,7 +142,7 @@ void CLogProject::loadLog(const QString &filename, CLogProject *project)
 
             if(xmlHeader.namedItem("PeakTrainingEffect").isElement())
             {
-                trk.cmt += tr("Peak Training Effect: %1<br/>").arg(xmlHeader.namedItem("PeakTrainingEffect").toElement().text().toDouble()/10.0);
+                trk.cmt += tr("Peak Training Effect: %1<br/>").arg(xmlHeader.namedItem("PeakTrainingEffect").toElement().text().toDouble() / 10.0);
             }
 
             if(xmlHeader.namedItem("Energy").isElement())

--- a/src/qmapshack/gis/suunto/CSmlProject.cpp
+++ b/src/qmapshack/gis/suunto/CSmlProject.cpp
@@ -146,8 +146,8 @@ void CSmlProject::loadSml(const QString &filename, CSmlProject *project)
 
             {
                 trk.cmt += tr("Battery usage: %1 %/hour")
-                           .arg( 100*(xmlHeader.namedItem("BatteryChargeAtStart").toElement().text().toDouble()
-                                      - xmlHeader.namedItem("BatteryCharge").toElement().text().toDouble())
+                           .arg( 100 * (xmlHeader.namedItem("BatteryChargeAtStart").toElement().text().toDouble()
+                                        - xmlHeader.namedItem("BatteryCharge").toElement().text().toDouble())
                                  / (xmlHeader.namedItem("Duration").toElement().text().toDouble() / 3600), 0, 'f', 1);
             }
         }

--- a/src/qmapshack/gis/suunto/ISuuntoProject.cpp
+++ b/src/qmapshack/gis/suunto/ISuuntoProject.cpp
@@ -174,7 +174,7 @@ ISuuntoProject::sample_t ISuuntoProject::mergeSamples(QList<sample_t> samples, Q
 
         if(cnt != 0)
         {
-            result[ext.tag] = sum/cnt; // averaged value is assigned to the merged sample
+            result[ext.tag] = sum / cnt; // averaged value is assigned to the merged sample
         }
     }
 

--- a/src/qmapshack/gis/tnv/CTwoNavProject.cpp
+++ b/src/qmapshack/gis/tnv/CTwoNavProject.cpp
@@ -246,7 +246,7 @@ bool CTwoNavProject::load(const QString& filename)
 {
     QDir dir(filename);
 
-    QStringList entries = dir.entryList(QDir::NoDotAndDotDot|QDir::Dirs|QDir::Files);
+    QStringList entries = dir.entryList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files);
     for(const QString &entry : entries)
     {
         QFileInfo fi(entry);

--- a/src/qmapshack/gis/tnv/serialization.cpp
+++ b/src/qmapshack/gis/tnv/serialization.cpp
@@ -468,7 +468,7 @@ bool CGisItemTrk::readTwoNav(const QString& filename)
             const int N = values.size();
             if(N > 0)
             {
-                pt.extensions["gpxtpx:TrackPointExtension|gpxtpx:atemp"] = values[0].toFloat()/10;
+                pt.extensions["gpxtpx:TrackPointExtension|gpxtpx:atemp"] = values[0].toFloat() / 10;
             }
             if(N > 1)
             {

--- a/src/qmapshack/gis/trk/CActivityTrk.cpp
+++ b/src/qmapshack/gis/trk/CActivityTrk.cpp
@@ -351,19 +351,19 @@ void CActivityTrk::printSummary(const QMap<trkact_t, summary_t>& summary, const 
     for(const desc_t *desc : descs)
     {
         const summary_t& s = summary[desc->activity];
-        IUnit::self().meter2speed(s.distance/s.ellapsedSecondsMoving, val, unit);
+        IUnit::self().meter2speed(s.distance / s.ellapsedSecondsMoving, val, unit);
         str += QString("<td align='right'>&nbsp;&nbsp;%1%2</td>").arg(val).arg(unit);
         total += s.ellapsedSecondsMoving;
     }
     if(printNoAct)
     {
-        IUnit::self().meter2speed(sumActNone.distance/sumActNone.ellapsedSecondsMoving, val, unit);
+        IUnit::self().meter2speed(sumActNone.distance / sumActNone.ellapsedSecondsMoving, val, unit);
         str += QString("<td align='right'>&nbsp;&nbsp;%1%2</td>").arg(val).arg(unit);
         total += sumActNone.ellapsedSecondsMoving;
     }
     if(printTotal)
     {
-        IUnit::self().meter2speed(distance/total, val, unit);
+        IUnit::self().meter2speed(distance / total, val, unit);
         str += QString("<td align='right'>&nbsp;&nbsp;%1%2</td>").arg(val).arg(unit);
     }
     str += "</tr>";
@@ -375,19 +375,19 @@ void CActivityTrk::printSummary(const QMap<trkact_t, summary_t>& summary, const 
     for(const desc_t *desc : descs)
     {
         const summary_t& s = summary[desc->activity];
-        IUnit::self().meter2speed(s.distance/s.ellapsedSeconds, val, unit);
+        IUnit::self().meter2speed(s.distance / s.ellapsedSeconds, val, unit);
         str += QString("<td align='right'>&nbsp;&nbsp;%1%2</td>").arg(val).arg(unit);
         total += s.ellapsedSeconds;
     }
     if(printNoAct)
     {
-        IUnit::self().meter2speed(sumActNone.distance/sumActNone.ellapsedSeconds, val, unit);
+        IUnit::self().meter2speed(sumActNone.distance / sumActNone.ellapsedSeconds, val, unit);
         str += QString("<td align='right'>&nbsp;&nbsp;%1%2</td>").arg(val).arg(unit);
         total += sumActNone.ellapsedSeconds;
     }
     if(printTotal)
     {
-        IUnit::self().meter2speed(distance/total, val, unit);
+        IUnit::self().meter2speed(distance / total, val, unit);
         str += QString("<td align='right'>&nbsp;&nbsp;%1%2</td>").arg(val).arg(unit);
     }
     str += "</tr>";

--- a/src/qmapshack/gis/trk/CDetailsTrk.cpp
+++ b/src/qmapshack/gis/trk/CDetailsTrk.cpp
@@ -82,7 +82,7 @@ CDetailsTrk::CDetailsTrk(CGisItemTrk& trk)
     setupUi(this);
     QPixmap icon(14, 14);
     const int N = IGisItem::getColorMap().count();
-    for(int i=0; i < N; ++i)
+    for(int i = 0; i < N; ++i)
     {
         const IGisItem::color_t& color = IGisItem::getColorMap()[i];
         icon.fill(color.color);

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -43,8 +43,8 @@
 #define MIN_DIST_CLOSE_TO   10
 #define MIN_DIST_FOCUS      200
 
-#define WPT_FOCUS_DIST_IN   (50*50)
-#define WPT_FOCUS_DIST_OUT  (200*200)
+#define WPT_FOCUS_DIST_IN   (50 * 50)
+#define WPT_FOCUS_DIST_OUT  (200 * 200)
 
 namespace
 {
@@ -561,22 +561,22 @@ QString CGisItemTrk::getInfo(quint32 feature) const
         str += tr("Energy Use Cycling: %L1").arg(energyUseCycling, 0, 'f', 0) + "kcal<br/>";
     }
 
-    if((allValidFlags & (CTrackData::trkpt_t::eValidEle|CTrackData::trkpt_t::eInvalidEle)) == (CTrackData::trkpt_t::eValidEle|CTrackData::trkpt_t::eInvalidEle))
+    if((allValidFlags & (CTrackData::trkpt_t::eValidEle | CTrackData::trkpt_t::eInvalidEle)) == (CTrackData::trkpt_t::eValidEle | CTrackData::trkpt_t::eInvalidEle))
     {
         str += "<b style='color: red;'>" + tr("Invalid elevations!") + "</b><br/>";
     }
 
-    if((allValidFlags & (CTrackData::trkpt_t::eValidTime|CTrackData::trkpt_t::eInvalidTime)) == (CTrackData::trkpt_t::eValidTime|CTrackData::trkpt_t::eInvalidTime))
+    if((allValidFlags & (CTrackData::trkpt_t::eValidTime | CTrackData::trkpt_t::eInvalidTime)) == (CTrackData::trkpt_t::eValidTime | CTrackData::trkpt_t::eInvalidTime))
     {
         str += "<b style='color: red;'>" + tr("Invalid timestamps!") + "</b><br/>";
     }
 
-    if((allValidFlags & (CTrackData::trkpt_t::eValidPos|CTrackData::trkpt_t::eInvalidPos)) == (CTrackData::trkpt_t::eValidPos|CTrackData::trkpt_t::eInvalidPos))
+    if((allValidFlags & (CTrackData::trkpt_t::eValidPos | CTrackData::trkpt_t::eInvalidPos)) == (CTrackData::trkpt_t::eValidPos | CTrackData::trkpt_t::eInvalidPos))
     {
         str += "<b style='color: red;'>" + tr("Invalid positions!") + "</b><br/>";
     }
 
-    if((allValidFlags & (CTrackData::trkpt_t::eValidSlope|CTrackData::trkpt_t::eInvalidSlope)) == (CTrackData::trkpt_t::eValidSlope|CTrackData::trkpt_t::eInvalidSlope))
+    if((allValidFlags & (CTrackData::trkpt_t::eValidSlope | CTrackData::trkpt_t::eInvalidSlope)) == (CTrackData::trkpt_t::eValidSlope | CTrackData::trkpt_t::eInvalidSlope))
     {
         str += "<b style='color: red;'>" + tr("Invalid slopes!") + "</b><br/>";
     }
@@ -668,7 +668,7 @@ QString CGisItemTrk::getInfoRange() const
 
         str += QString("%4 %1:%2:%3").arg(hh, 2, 10, QChar('0')).arg(mm, 2, 10, QChar('0')).arg(ss, 2, 10, QChar('0')).arg(QChar(0x231a));
 
-        IUnit::self().meter2speed(distance/deltaTime, val, unit);
+        IUnit::self().meter2speed(distance / deltaTime, val, unit);
         str += QString(", %3 %1%2").arg(val).arg(unit).arg(QChar(0x21A3));
     }
     str += "\n";
@@ -686,20 +686,20 @@ QString CGisItemTrk::getInfoRange() const
     str += QString("%3 %1%2 (%4%5)").arg(val).arg(unit).arg(QChar(0x2197)).arg(val2).arg(unit2);
     if(timeIsValid)
     {
-        IUnit::self().meter2speed(deltaAscent/deltaTime, val, unit);
+        IUnit::self().meter2speed(deltaAscent / deltaTime, val, unit);
         str += QString(", %1%2").arg(val).arg(unit);
     }
     str += "\n";
 
-    tmp    = qAtan(deltaDescent/distance);
-    slope1 = qAbs(tmp * 360.0/(2 * M_PI));
+    tmp    = qAtan(deltaDescent / distance);
+    slope1 = qAbs(tmp * 360.0 / (2 * M_PI));
     IUnit::self().slope2string(slope1, val2, unit2);
 
     IUnit::self().meter2elevation(deltaDescent, val, unit);
     str += QString("%3 %1%2 (%4%5)").arg(val).arg(unit).arg(QChar(0x2198)).arg(val2).arg(unit2);
     if(timeIsValid)
     {
-        IUnit::self().meter2speed(deltaDescent/deltaTime, val, unit);
+        IUnit::self().meter2speed(deltaDescent / deltaTime, val, unit);
         str += QString(", %1%2").arg(val).arg(unit);
     }
 
@@ -753,7 +753,7 @@ QString CGisItemTrk::getInfoTrkPt(const CTrackData::trkpt_t& pt) const
         const CKnownExtension &ext = CKnownExtension::get(key);
         if(ext.known)
         {
-            str += "\n" + ext.nameLongText + ": " + QString("%1%2").arg(ext.valueFunc(pt)*ext.factor, 0, 'f', 1).arg(ext.unit);
+            str += "\n" + ext.nameLongText + ": " + QString("%1%2").arg(ext.valueFunc(pt) * ext.factor, 0, 'f', 1).arg(ext.unit);
         }
         else
         {
@@ -782,25 +782,25 @@ QString CGisItemTrk::getInfoProgress(const CTrackData::trkpt_t& pt) const
     if(pt.ascent != NOFLOAT)
     {
         IUnit::self().meter2elevation(pt.ascent, val, unit);
-        asc = tr("Ascent: %1%2 (%3%)").arg(val).arg(unit).arg(pt.ascent * 100/totalAscent, 2, 'f', 0);
+        asc = tr("Ascent: %1%2 (%3%)").arg(val).arg(unit).arg(pt.ascent * 100 / totalAscent, 2, 'f', 0);
     }
 
     if(pt.descent != NOFLOAT)
     {
         IUnit::self().meter2elevation(pt.descent, val, unit);
-        dsc = tr(", Descent: %1%2 (%3%)").arg(val).arg(unit).arg(pt.descent * 100/totalDescent, 2, 'f', 0);
+        dsc = tr(", Descent: %1%2 (%3%)").arg(val).arg(unit).arg(pt.descent * 100 / totalDescent, 2, 'f', 0);
     }
 
     if(pt.distance != NOFLOAT)
     {
         IUnit::self().meter2distance(pt.distance, val, unit);
-        dst = tr("Distance: %1%2 (%3%)").arg(val).arg(unit).arg(pt.distance * 100/totalDistance, 2, 'f', 0);
+        dst = tr("Distance: %1%2 (%3%)").arg(val).arg(unit).arg(pt.distance * 100 / totalDistance, 2, 'f', 0);
     }
 
     if(pt.elapsedSeconds != NOFLOAT)
     {
         IUnit::self().seconds2time(pt.elapsedSecondsMoving, val, unit);
-        mov = tr(", Moving: %1%2 (%3%)").arg(val).arg(unit).arg(pt.elapsedSecondsMoving * 100/totalElapsedSecondsMoving, 2, 'f', 0);
+        mov = tr(", Moving: %1%2 (%3%)").arg(val).arg(unit).arg(pt.elapsedSecondsMoving * 100 / totalElapsedSecondsMoving, 2, 'f', 0);
     }
 
     return QString("%1%2\n%3%4").arg(asc).arg(dsc).arg(dst).arg(mov);
@@ -826,7 +826,7 @@ QString CGisItemTrk::getInfoRange(const CTrackData::trkpt_t& pt1, const CTrackDa
 
         if(dt != NOFLOAT)
         {
-            IUnit::self().meter2speed((pt2.ascent - pt1.ascent)/dt, val, unit);
+            IUnit::self().meter2speed((pt2.ascent - pt1.ascent) / dt, val, unit);
             asc += tr(", %1%2").arg(val).arg(unit);
         }
     }
@@ -838,7 +838,7 @@ QString CGisItemTrk::getInfoRange(const CTrackData::trkpt_t& pt1, const CTrackDa
 
         if(dt != NOFLOAT)
         {
-            IUnit::self().meter2speed((pt2.descent - pt1.descent)/dt, val, unit);
+            IUnit::self().meter2speed((pt2.descent - pt1.descent) / dt, val, unit);
             dsc += tr(", %1%2").arg(val).arg(unit);
         }
     }
@@ -1104,7 +1104,7 @@ void CGisItemTrk::deriveSecondaryData()
         {
             trkpt.deltaDistance  = lastTrkpt->distanceTo(trkpt);
             trkpt.distance       = lastTrkpt->distance + trkpt.deltaDistance;
-            trkpt.elapsedSeconds = trkpt.time.toMSecsSinceEpoch()/1000.0 - timestampStart;
+            trkpt.elapsedSeconds = trkpt.time.toMSecsSinceEpoch() / 1000.0 - timestampStart;
 
             // ascent descent
             if(lastEle != NOINT)
@@ -1116,7 +1116,7 @@ void CGisItemTrk::deriveSecondaryData()
 
                 if(qAbs(delta) >= ASCENT_THRESHOLD)
                 {
-                    const qint32 step = (delta/ASCENT_THRESHOLD)*ASCENT_THRESHOLD;
+                    const qint32 step = (delta / ASCENT_THRESHOLD) * ASCENT_THRESHOLD;
 
                     if(delta > 0)
                     {
@@ -1141,7 +1141,7 @@ void CGisItemTrk::deriveSecondaryData()
         else
         {
             timeStart      = trkpt.time;
-            timestampStart = timeStart.toMSecsSinceEpoch()/1000.0;
+            timestampStart = timeStart.toMSecsSinceEpoch() / 1000.0;
             lastEle        = trkpt.ele;
 
             trkpt.deltaDistance        = 0;
@@ -1176,7 +1176,7 @@ void CGisItemTrk::deriveSecondaryData()
             {
                 d1 = trkpt2.distance;
                 e1 = trkpt2.ele;
-                t1 = trkpt2.time.toMSecsSinceEpoch()/1000.0;
+                t1 = trkpt2.time.toMSecsSinceEpoch() / 1000.0;
                 break;
             }
         }
@@ -1203,8 +1203,8 @@ void CGisItemTrk::deriveSecondaryData()
 
         if(d1 < d2)
         {
-            qreal a      = qAtan((e2 - e1)/(d2 - d1));
-            trkpt.slope1 = a * 360.0/(2 * M_PI);
+            qreal a      = qAtan((e2 - e1) / (d2 - d1));
+            trkpt.slope1 = a * 360.0 / (2 * M_PI);
             trkpt.slope2 = qTan(trkpt.slope1 * DEG_TO_RAD) * 100;
         }
         else
@@ -1316,7 +1316,7 @@ void CGisItemTrk::findWaypointsCloseBy(CProgressDialog& progress, quint32& curre
     // convert coordinates of all waypoints into meter coordinates relative to the first track point
     point3D pt0 = line[0];
     QList<trkwpt_t> trkwpts;
-    for(int i=0; i < project->childCount(); i++)
+    for(int i = 0; i < project->childCount(); i++)
     {
         CGisItemWpt * wpt = dynamic_cast<CGisItemWpt*>(project->child(i));
         if(wpt == nullptr)
@@ -1363,7 +1363,7 @@ void CGisItemTrk::findWaypointsCloseBy(CProgressDialog& progress, quint32& curre
         for(const pointDP &pt : line)
         {
             ++current;
-            qreal d = (trkwpt.x - pt.x)*(trkwpt.x - pt.x) + (trkwpt.y - pt.y)*(trkwpt.y - pt.y);
+            qreal d = (trkwpt.x - pt.x) * (trkwpt.x - pt.x) + (trkwpt.y - pt.y) * (trkwpt.y - pt.y);
 
             if(d < WPT_FOCUS_DIST_IN)
             {
@@ -1418,7 +1418,7 @@ void CGisItemTrk::findWaypointsCloseBy(CProgressDialog& progress, quint32& curre
     {
         deriveSecondaryData();
     }
-    updateVisuals(eVisualDetails|eVisualPlot, "findWaypointsCloseBy()");
+    updateVisuals(eVisualDetails | eVisualPlot, "findWaypointsCloseBy()");
 }
 
 bool CGisItemTrk::isCloseTo(const QPointF& pos)
@@ -1489,7 +1489,7 @@ bool CGisItemTrk::cut()
     if(askToDeleteOriginal)
     {
         // clone first part?
-        if((mode & (CCutTrk::eModeKeepBoth|CCutTrk::eModeKeepFirst)) != 0)
+        if((mode & (CCutTrk::eModeKeepBoth | CCutTrk::eModeKeepFirst)) != 0)
         {
             int idx = cutMode == CCutTrk::eCutMode1 ? idxMouse  - 1 : idxMouse;
             if(idx < 0)
@@ -1508,16 +1508,16 @@ bool CGisItemTrk::cut()
         }
 
         // clone second part?
-        if((mode & (CCutTrk::eModeKeepBoth|CCutTrk::eModeKeepSecond)) != 0)
+        if((mode & (CCutTrk::eModeKeepBoth | CCutTrk::eModeKeepSecond)) != 0)
         {
-            QString name = getName() + QString(" (%1 - %2)").arg(idxMouse).arg(cntTotalPoints-1);
+            QString name = getName() + QString(" (%1 - %2)").arg(idxMouse).arg(cntTotalPoints - 1);
             IGisProject *project = nullptr;
             if(!getNameAndProject(name, project, tr("track")))
             {
                 return false;
             }
 
-            new CGisItemTrk(name, idxMouse, cntTotalPoints-1, trk, project);
+            new CGisItemTrk(name, idxMouse, cntTotalPoints - 1, trk, project);
         }
     }
     else
@@ -2257,20 +2257,20 @@ void CGisItemTrk::setColorizeSource(QString src)
     if(src != getColorizeSource())
     {
         colorSourceLimit.setSource(src);
-        updateHistory(eVisualColorLegend|eVisualDetails);
+        updateHistory(eVisualColorLegend | eVisualDetails);
     }
 }
 
 void CGisItemTrk::setColorizeLimitLow(qreal limit)
 {
     colorSourceLimit.setMin(limit);
-    updateHistory(eVisualColorLegend|eVisualDetails);
+    updateHistory(eVisualColorLegend | eVisualDetails);
 }
 
 void CGisItemTrk::setColorizeLimitHigh(qreal limit)
 {
     colorSourceLimit.setMax(limit);
-    updateHistory(eVisualColorLegend|eVisualDetails);
+    updateHistory(eVisualColorLegend | eVisualDetails);
 }
 
 QString CGisItemTrk::getColorizeUnit() const
@@ -2314,7 +2314,7 @@ void CGisItemTrk::drawItem(QPainter& p, const QRectF& viewport, CGisDraw * gis)
         // calculate bounding box of text
         QFont f = CMainWindow::self().getMapFont();
         QFontMetrics fm(f);
-        QRect rectText = fm.boundingRect(QRect(0, 0, 500, 0), Qt::AlignLeft|Qt::AlignTop|Qt::TextWordWrap, str);
+        QRect rectText = fm.boundingRect(QRect(0, 0, 500, 0), Qt::AlignLeft | Qt::AlignTop | Qt::TextWordWrap, str);
 
         // The initial minimum size of the box will be MIN_WIDTH_INFO_BOX.
         // If a larger box is needed the minimum grows. By that the width
@@ -2369,9 +2369,9 @@ void CGisItemTrk::drawItem(QPainter& p, const QRectF& viewport, CGisDraw * gis)
         IUnit::self().meter2distance(mouseMoveFocus->distance, val1, unit1);
         IUnit::self().meter2distance(totalDistance - mouseMoveFocus->distance, val2, unit2);
         p.setPen(Qt::darkBlue);
-        p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter|Qt::AlignLeft, QString("%1%2").arg(val1).arg(unit1));
+        p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter | Qt::AlignLeft, QString("%1%2").arg(val1).arg(unit1));
         p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignCenter, QString("%1%").arg(mouseMoveFocus->distance * 100 / totalDistance, 0, 'f', 0));
-        p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter|Qt::AlignRight, QString("%1%2").arg(val2).arg(unit2));
+        p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter | Qt::AlignRight, QString("%1%2").arg(val2).arg(unit2));
 
         // draw progress bar time
         if(totalElapsedSeconds != 0)
@@ -2389,15 +2389,15 @@ void CGisItemTrk::drawItem(QPainter& p, const QRectF& viewport, CGisDraw * gis)
             IUnit::self().seconds2time(mouseMoveFocus->elapsedSecondsMoving, val1, unit1);
             IUnit::self().seconds2time(totalElapsedSecondsMoving - mouseMoveFocus->elapsedSecondsMoving, val2, unit2);
             p.setPen(Qt::darkBlue);
-            p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter|Qt::AlignLeft, QString("%1%2").arg(val1).arg(unit1));
+            p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter | Qt::AlignLeft, QString("%1%2").arg(val1).arg(unit1));
             p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignCenter, QString("%1%").arg(mouseMoveFocus->elapsedSecondsMoving * 100 / totalElapsedSecondsMoving, 0, 'f', 0));
-            p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter|Qt::AlignRight, QString("%1%2").arg(val2).arg(unit2));
+            p.drawText(QRect(0, 1, rectBar1.width(), fm.height()), Qt::AlignVCenter | Qt::AlignRight, QString("%1%2").arg(val2).arg(unit2));
         }
 
         // draw text
         p.translate(0, fm.height() + 8);
         p.setPen(colorFg);
-        p.drawText(rectText, Qt::AlignLeft|Qt::AlignTop|Qt::TextWordWrap, str);
+        p.drawText(rectText, Qt::AlignLeft | Qt::AlignTop | Qt::TextWordWrap, str);
 
         p.restore();
     }
@@ -2497,8 +2497,8 @@ void CGisItemTrk::drawRange(QPainter& p, CGisDraw* gis)
 
     if(seg.size() == 1)
     {
-        const auto r1 = qRound(penWidthHi/2.0);
-        const auto r2 = qRound(penWidthFg/2.0);
+        const auto r1 = qRound(penWidthHi / 2.0);
+        const auto r2 = qRound(penWidthFg / 2.0);
 
         p.setPen(Qt::NoPen);
         p.setBrush(Qt::darkGreen);
@@ -2521,8 +2521,8 @@ void CGisItemTrk::drawRange(QPainter& p, CGisDraw* gis)
         pt *= DEG_TO_RAD;
         gis->convertRad2Px(pt);
 
-        const auto r1 = qRound(penWidthHi/2.0) + 1;
-        const auto r2 = qRound(penWidthFg/2.0) + 1;
+        const auto r1 = qRound(penWidthHi / 2.0) + 1;
+        const auto r2 = qRound(penWidthFg / 2.0) + 1;
 
         p.setPen(Qt::NoPen);
         p.setBrush(Qt::darkGreen);
@@ -2586,7 +2586,7 @@ void CGisItemTrk::setElevation(qint32 idx, qint32 ele)
     {
         trkpt->ele = ele;
         deriveSecondaryData();
-        changed(tr("Changed elevation of point %1 to %2 %3").arg(idx).arg(ele*IUnit::self().elevationFactor).arg(IUnit::self().elevationUnit), "://icons/48x48/SetEle.png");
+        changed(tr("Changed elevation of point %1 to %2 %3").arg(idx).arg(ele * IUnit::self().elevationFactor).arg(IUnit::self().elevationUnit), "://icons/48x48/SetEle.png");
     }
 }
 
@@ -2595,7 +2595,7 @@ void CGisItemTrk::setColor(int idx)
     if(idx < IGisItem::getColorMap().count())
     {
         setColor(IGisItem::getColorMap()[idx].color);
-        updateHistory(eVisualColorLegend|eVisualDetails);
+        updateHistory(eVisualColorLegend | eVisualDetails);
     }
 }
 
@@ -3153,10 +3153,10 @@ void CGisItemTrk::setupInterpolation(bool on, qint32 q)
     }
 
     /// @todo find a better way to scale the algorithm
-    interp.m = interp.Q*50;
+    interp.m = interp.Q * 50;
     if(N < 400)
     {
-        interp.m = N / (16/interp.Q);
+        interp.m = N / (16 / interp.Q);
     }
 
     interp.m &= 0xFFFFFFFE;
@@ -3268,7 +3268,7 @@ QMap<searchProperty_e, CGisItemTrk::fSearch> CGisItemTrk::initKeywordLambdaMap()
     });
     map.insert(eSearchPropertyGeneralFullText, [](CGisItemTrk* item){
         searchValue_t searchValue;
-        searchValue.str1 = item->getInfo(eFeatureShowFullText|eFeatureShowName);
+        searchValue.str1 = item->getInfo(eFeatureShowFullText | eFeatureShowName);
         return searchValue;
     });
     map.insert(eSearchPropertyGeneralElevation, [](CGisItemTrk* item){
@@ -3355,26 +3355,26 @@ QMap<searchProperty_e, CGisItemTrk::fSearch> CGisItemTrk::initKeywordLambdaMap()
     });
     map.insert(eSearchPropertyRteTrkAvgSpeed, [](CGisItemTrk* item){
         searchValue_t searchValue;
-        IUnit::self().meter2speed(item->totalDistance/item->totalElapsedSecondsMoving, searchValue.value1, searchValue.str1);
+        IUnit::self().meter2speed(item->totalDistance / item->totalElapsedSecondsMoving, searchValue.value1, searchValue.str1);
         return searchValue;
     });
     map.insert(eSearchPropertyRteTrkActivity, [](CGisItemTrk* item){
         searchValue_t searchValue;
         QStringList strL;
         item->activities.getActivityNames(strL);
-        searchValue.str1=strL.join(", ");
+        searchValue.str1 = strL.join(", ");
         return searchValue;
     });
     map.insert(eSearchPropertyRteTrkTotalTime, [](CGisItemTrk* item){
         searchValue_t searchValue;
         searchValue.value1 = item->totalElapsedSeconds;
-        searchValue.str1="S";
+        searchValue.str1 = "S";
         return searchValue;
     });
     map.insert(eSearchPropertyRteTrkTimeMoving, [](CGisItemTrk* item){
         searchValue_t searchValue;
         searchValue.value1 = item->totalElapsedSecondsMoving;
-        searchValue.str1="S";
+        searchValue.str1 = "S";
         return searchValue;
     });
 

--- a/src/qmapshack/gis/trk/CListTrkPts.cpp
+++ b/src/qmapshack/gis/trk/CListTrkPts.cpp
@@ -168,12 +168,12 @@ void CListTrkPts::addTableRow(bool focus, const CTrackData::trkpt_t& trkpt, bool
     stream << "<tr style='"
            << "color: " << color << ";"
            << "background: " << bgFocus << ";"
-           <<"'>";
+           << "'>";
 
     stream << "<td style='background: " << bgInRange << ";'>" << QString::number(trkpt.idxTotal) << "</td>";
 
     stream << "<td>" << (trkpt.time.isValid()
-                         ? IUnit::self().datetime2string(trkpt.time, true, QPointF(trkpt.lon, trkpt.lat)*DEG_TO_RAD)
+                         ? IUnit::self().datetime2string(trkpt.time, true, QPointF(trkpt.lon, trkpt.lat) * DEG_TO_RAD)
                          : "-") << "</td>";
 
     QString val, unit;

--- a/src/qmapshack/gis/trk/CScrOptTrk.cpp
+++ b/src/qmapshack/gis/trk/CScrOptTrk.cpp
@@ -32,7 +32,7 @@ CScrOptTrk::CScrOptTrk(CGisItemTrk * trk, const QPoint& point, IMouse *parent)
     setupUi(this);
     setOrigin(point);
     label->setFont(CMainWindow::self().getMapFont());
-    label->setText(trk->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowActivity|IGisItem::eFeatureShowLinks));
+    label->setText(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity | IGisItem::eFeatureShowLinks));
     adjustSize();
 
     toolProfile->setChecked(trk->hasUserFocus());

--- a/src/qmapshack/gis/trk/CSelectActivityColor.cpp
+++ b/src/qmapshack/gis/trk/CSelectActivityColor.cpp
@@ -118,6 +118,6 @@ void CSelectActivityColor::slotSetColor(QToolButton * button, trkact_t act)
 
     if(trk != nullptr)
     {
-        trk->updateVisuals(CGisItemTrk::eVisualDetails|CGisItemTrk::eVisualPlot|CGisItemTrk::eVisualProject|CGisItemTrk::eVisualTrkInfo, "CSelectActivityColor::slotSetColor()");
+        trk->updateVisuals(CGisItemTrk::eVisualDetails | CGisItemTrk::eVisualPlot | CGisItemTrk::eVisualProject | CGisItemTrk::eVisualTrkInfo, "CSelectActivityColor::slotSetColor()");
     }
 }

--- a/src/qmapshack/gis/trk/CTableTrk.cpp
+++ b/src/qmapshack/gis/trk/CTableTrk.cpp
@@ -181,7 +181,7 @@ void CTableTrk::updateData()
         item->setText(eColNum, QString::number(trkpt.idxTotal));
 
         item->setText(eColTime, trkpt.time.isValid()
-                      ? IUnit::self().datetime2string(trkpt.time, true, QPointF(trkpt.lon, trkpt.lat)*DEG_TO_RAD)
+                      ? IUnit::self().datetime2string(trkpt.time, true, QPointF(trkpt.lon, trkpt.lat) * DEG_TO_RAD)
                       : "-"
                       );
 

--- a/src/qmapshack/gis/trk/CTableTrkInfo.cpp
+++ b/src/qmapshack/gis/trk/CTableTrkInfo.cpp
@@ -93,7 +93,7 @@ void CTableTrkInfo::updateData()
         QTreeWidgetItem * item = new QTreeWidgetItem();
         item->setIcon(eColNum, CDraw::number(cnt++, Qt::black));
         item->setText(eColDesc, trkpt.desc);
-        item->setFlags(item->flags()|Qt::ItemIsEditable);
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
         item->setData(eColDesc, Qt::UserRole, trkpt.idxTotal);
         items << item;
     }

--- a/src/qmapshack/gis/trk/filter/CFilterDouglasPeuker.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterDouglasPeuker.cpp
@@ -47,5 +47,5 @@ CFilterDouglasPeuker::~CFilterDouglasPeuker()
 void CFilterDouglasPeuker::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterReducePoints(spinBox->value()/IUnit::self().baseFactor);
+    trk.filterReducePoints(spinBox->value() / IUnit::self().baseFactor);
 }

--- a/src/qmapshack/gis/trk/filter/CFilterLoopsCut.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterLoopsCut.cpp
@@ -48,7 +48,7 @@ CFilterLoopsCut::~CFilterLoopsCut()
 void CFilterLoopsCut::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterLoopsCut(spinBox->value()/IUnit::self().baseFactor);
+    trk.filterLoopsCut(spinBox->value() / IUnit::self().baseFactor);
 }
 
 void CFilterLoopsCut::showHelp()

--- a/src/qmapshack/gis/trk/filter/CFilterOffsetElevation.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterOffsetElevation.cpp
@@ -45,5 +45,5 @@ CFilterOffsetElevation::~CFilterOffsetElevation()
 void CFilterOffsetElevation::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterOffsetElevation(spinBox->value()/IUnit::self().elevationFactor);
+    trk.filterOffsetElevation(spinBox->value() / IUnit::self().elevationFactor);
 }

--- a/src/qmapshack/gis/trk/filter/CFilterZeroSpeedDriftCleaner.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterZeroSpeedDriftCleaner.cpp
@@ -50,7 +50,7 @@ CFilterZeroSpeedDriftCleaner::~CFilterZeroSpeedDriftCleaner()
 void CFilterZeroSpeedDriftCleaner::slotApply()
 {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    trk.filterZeroSpeedDriftCleaner(distance->value()/IUnit::self().baseFactor, ratio->value());
+    trk.filterZeroSpeedDriftCleaner(distance->value() / IUnit::self().baseFactor, ratio->value());
 }
 
 void CFilterZeroSpeedDriftCleaner::showHelp()

--- a/src/qmapshack/gis/trk/filter/filter.cpp
+++ b/src/qmapshack/gis/trk/filter/filter.cpp
@@ -345,7 +345,7 @@ void CGisItemTrk::filterSpeed(qreal speed) // Constant speed
             continue;
         }
 
-        timestamp = speed == 0 ? QDateTime() : timestamp.addMSecs(qRound(1000 * pt.deltaDistance/speed));
+        timestamp = speed == 0 ? QDateTime() : timestamp.addMSecs(qRound(1000 * pt.deltaDistance / speed));
         pt.time   = timestamp;
     }
 
@@ -456,8 +456,8 @@ void CGisItemTrk::filterSpeed(const CFilterSpeedHike::hiking_type_t &hikingType)
         QVector<qreal> formulaTerms(7);
         formulaTerms[0] = 60 / B4;
         formulaTerms[1] = A9 * 60000 / B5;
-        formulaTerms[2] = (A9-0) * ((60 / B4 + 0.5 * (0.2 * 60000 / B5 - 60 / B4)) - (60 / B4)) / (0.2 - 0) + (60 / B4);
-        formulaTerms[3] = (A9 - 0.2) * ((60 / B4) - (0.2 * 60000 / B5)) / (((B5 / (B4 * 1000) - 0) * 0.5) -0.2) + (0.2 * 60000 / B5);
+        formulaTerms[2] = (A9 - 0) * ((60 / B4 + 0.5 * (0.2 * 60000 / B5 - 60 / B4)) - (60 / B4)) / (0.2 - 0) + (60 / B4);
+        formulaTerms[3] = (A9 - 0.2) * ((60 / B4) - (0.2 * 60000 / B5)) / (((B5 / (B4 * 1000) - 0) * 0.5) - 0.2) + (0.2 * 60000 / B5);
         formulaTerms[4] = -A9 * 60000 / B6;
         formulaTerms[5] = (A9 + 0.05) * ((60 / B4 + 0.5 * (0.25 * 60000 / B6 - 60 / B4)) - (60 / B4)) / (-0.25 + 0.05) + (60 / B4);
         formulaTerms[6] = (A9 + 0.25) * ((60 / B4) - (0.25 * 60000 / B6)) / ((-0.05 - 0.5 * (B6 / (B4 * 1000) - 0.05)) + 0.25) + (0.25 * 60000 / B6);
@@ -573,7 +573,7 @@ void CGisItemTrk::filterChangeStartPoint(qint32 idxNewStartPoint, const QString 
     }
 
     const QVector<CTrackData::trkpt_t>& part1 = pts.mid(0, idxNewStartPoint);
-    const QVector<CTrackData::trkpt_t>& part2 = pts.mid(idxNewStartPoint,-1);
+    const QVector<CTrackData::trkpt_t>& part2 = pts.mid(idxNewStartPoint, -1);
 
     trk.readFrom(part2 + part1);
 
@@ -604,13 +604,13 @@ void CGisItemTrk::filterLoopsCut(qreal minLoopLength)
 
         if (pts.size() >= 4)
         {
-            const QLineF headLine = QLineF(headPt.lon, headPt.lat, pts[pts.size()-2].lon, pts[pts.size()-2].lat);
+            const QLineF headLine = QLineF(headPt.lon, headPt.lat, pts[pts.size() - 2].lon, pts[pts.size() - 2].lat);
 
             bool firstCycle = true;
             CTrackData::trkpt_t prevScannedPt;
             for (const CTrackData::trkpt_t& scannedPt : pts)
             {
-                if (scannedPt.idxTotal == pts[pts.size()-2].idxTotal)
+                if (scannedPt.idxTotal == pts[pts.size() - 2].idxTotal)
                 {
                     break;
                 }
@@ -627,11 +627,11 @@ void CGisItemTrk::filterLoopsCut(qreal minLoopLength)
 
                 if ( ( headLine.intersect(scannedLine, &intersectionPoint) == QLineF::BoundedIntersection)
                      &&
-                     (pts[pts.size()-2].distance - scannedPt.distance) > minLoopLength) // loop is long enough to cut the track)
+                     (pts[pts.size() - 2].distance - scannedPt.distance) > minLoopLength) // loop is long enough to cut the track)
                 {
-                    new CGisItemTrk(tr("%1 (Part %2)").arg(trk.name).arg(part), pts.first().idxTotal, pts[pts.size()-2].idxTotal, trk, project);
+                    new CGisItemTrk(tr("%1 (Part %2)").arg(trk.name).arg(part), pts.first().idxTotal, pts[pts.size() - 2].idxTotal, trk, project);
                     part++;
-                    pts.remove(0, pts.size()-2);
+                    pts.remove(0, pts.size() - 2);
 
                     break;
                 }
@@ -670,7 +670,7 @@ void CGisItemTrk::filterZeroSpeedDriftCleaner(qreal distance, qreal ratio)
         }
         else
         {
-            const CTrackData::trkpt_t *prevVisiblePt = trk.getTrkPtByVisibleIndex(pt.idxVisible-1);
+            const CTrackData::trkpt_t *prevVisiblePt = trk.getTrkPtByVisibleIndex(pt.idxVisible - 1);
             qreal d = pt.distance - prevVisiblePt->distance; // "distance" field of trackpoints includes visible points only
 
             if (d < distance) // "distance" defines the threshold at which knots are detected: knot starts when

--- a/src/qmapshack/gis/wpt/CDetailsWpt.cpp
+++ b/src/qmapshack/gis/wpt/CDetailsWpt.cpp
@@ -107,7 +107,7 @@ void CDetailsWpt::setupGui()
 
     if(wpt.getTime().isValid())
     {
-        labelTime->setText(IUnit::datetime2string(wpt.getTime(), false, QPointF(pos.x()*DEG_TO_RAD, pos.y()*DEG_TO_RAD)));
+        labelTime->setText(IUnit::datetime2string(wpt.getTime(), false, QPointF(pos.x() * DEG_TO_RAD, pos.y() * DEG_TO_RAD)));
     }
 
     textCmtDesc->document()->clear();
@@ -161,12 +161,12 @@ void CDetailsWpt::slotLinkActivated(const QString& link)
     }
     else if(link == "proximity")
     {
-        QVariant var(wpt.getProximity()*IUnit::self().baseFactor);
+        QVariant var(wpt.getProximity() * IUnit::self().baseFactor);
         CInputDialog dlg(this, tr("Enter new proximity range."), var, QVariant(NOFLOAT), IUnit::self().baseUnit);
         dlg.setOption(tr("Is no-go area"), wpt.isNogo());
         if(dlg.exec() == QDialog::Accepted)
         {
-            wpt.setProximity(var.toDouble()/IUnit::self().baseFactor);
+            wpt.setProximity(var.toDouble() / IUnit::self().baseFactor);
             wpt.setNogo(dlg.optionIsChecked());
         }
     }

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -64,7 +64,7 @@ CGisItemWpt::CGisItemWpt(const QPointF &pos, qreal ele, const QDateTime &time, c
 CGisItemWpt::CGisItemWpt(const QPointF& pos, const QString& name, const QString &icon, IGisProject *project)
     : CGisItemWpt(pos, NOFLOAT, QDateTime::currentDateTimeUtc(), name, icon, project)
 {
-    flags = eFlagCreatedInQms|eFlagWriteAllowed;
+    flags = eFlagCreatedInQms | eFlagWriteAllowed;
     qreal ele = CMainWindow::self().getElevationAt(pos * DEG_TO_RAD);
     wpt.ele = (ele == NOFLOAT) ? NOINT : qRound(ele);
 
@@ -85,7 +85,7 @@ CGisItemWpt::CGisItemWpt(const QPointF& pos, const CGisItemWpt& parentWpt, IGisP
 
     key.clear();
     history.events.clear();
-    flags = eFlagCreatedInQms|eFlagWriteAllowed;
+    flags = eFlagCreatedInQms | eFlagWriteAllowed;
 
     qreal ele = CMainWindow::self().getElevationAt(pos * DEG_TO_RAD);
     wpt.ele = (ele == NOFLOAT) ? NOINT : qRound(ele);
@@ -208,7 +208,7 @@ void CGisItemWpt::genKey() const
 {
     if(geocache.hasData)
     {
-        key.item=QString::number(geocache.id);
+        key.item = QString::number(geocache.id);
     }
     IGisItem::genKey();
 }
@@ -404,7 +404,7 @@ QString CGisItemWpt::getInfo(quint32 feature) const
             {
                 str += "<br/>\n";
             }
-            str += tr("Created: %1").arg(IUnit::datetime2string(wpt.time, false, QPointF(wpt.lon*DEG_TO_RAD, wpt.lat*DEG_TO_RAD)));
+            str += tr("Created: %1").arg(IUnit::datetime2string(wpt.time, false, QPointF(wpt.lon * DEG_TO_RAD, wpt.lat * DEG_TO_RAD)));
         }
     }
 
@@ -474,7 +474,7 @@ void CGisItemWpt::setIcon()
         }
         else
         {
-            IGisItem::setIcon(CWptIconManager::self().getWptIconByName("gray_"+geocache.type, focus));
+            IGisItem::setIcon(CWptIconManager::self().getWptIconByName("gray_" + geocache.type, focus));
         }
     }
     else
@@ -593,7 +593,7 @@ bool CGisItemWpt::isCloseTo(const QPointF& pos)
         return false;
     }
 
-    closeToRadius = abs(QPointF::dotProduct(dist, dist)/radius - radius) < 22;
+    closeToRadius = abs(QPointF::dotProduct(dist, dist) / radius - radius) < 22;
     return closeToRadius;
 }
 
@@ -711,19 +711,19 @@ void CGisItemWpt::drawLabel(QPainter& p, const QPolygonF &viewport, QList<QRectF
     rect.adjust(-2, -2, 2, 2);
 
     // place label on top
-    rect.moveCenter(pt + QPointF(icon.width()/2, -fm.height()));
+    rect.moveCenter(pt + QPointF(icon.width() / 2, -fm.height()));
     if(CDraw::doesOverlap(blockedAreas, rect))
     {
         // place label on bottom
-        rect.moveCenter(pt + QPointF( icon.width()/2, +fm.height() + icon.height()));
+        rect.moveCenter(pt + QPointF( icon.width() / 2, +fm.height() + icon.height()));
         if(CDraw::doesOverlap(blockedAreas, rect))
         {
             // place label on right
-            rect.moveCenter(pt + QPointF( icon.width() + rect.width()/2, +fm.height()));
+            rect.moveCenter(pt + QPointF( icon.width() + rect.width() / 2, +fm.height()));
             if(CDraw::doesOverlap(blockedAreas, rect))
             {
                 // place label on left
-                rect.moveCenter(pt + QPointF( -rect.width()/2, +fm.height()));
+                rect.moveCenter(pt + QPointF( -rect.width() / 2, +fm.height()));
                 if(CDraw::doesOverlap(blockedAreas, rect))
                 {
                     // failed to place label anywhere
@@ -801,7 +801,7 @@ void CGisItemWpt::drawBubble(QPainter& p)
 
 void CGisItemWpt::drawCircle(QPainter& p, const QPointF& pos, const qreal& r, const bool& nogo, const bool& selected)
 {
-    QRect circle(pos.x() - r - 1, pos.y() - r - 1, 2*r + 1, 2*r + 1);
+    QRect circle(pos.x() - r - 1, pos.y() - r - 1, 2 * r + 1, 2 * r + 1);
     p.save();
     p.setBrush(Qt::NoBrush);
     if (selected)
@@ -840,8 +840,8 @@ QPolygonF CGisItemWpt::makePolyline(const QPointF& anchor, const QRectF& r)
 
     if(!r.contains(anchor))
     {
-        qreal w = rectBubble.width()>>1;
-        qreal h = rectBubble.height()>>1;
+        qreal w = rectBubble.width() >> 1;
+        qreal h = rectBubble.height() >> 1;
 
         if(w > 30)
         {
@@ -1042,7 +1042,7 @@ void CGisItemWpt::detBoundingRect()
 {
     if(proximity == NOFLOAT)
     {
-        boundingRect = QRectF(QPointF(wpt.lon, wpt.lat)*DEG_TO_RAD, QPointF(wpt.lon, wpt.lat)*DEG_TO_RAD);
+        boundingRect = QRectF(QPointF(wpt.lon, wpt.lat) * DEG_TO_RAD, QPointF(wpt.lon, wpt.lat) * DEG_TO_RAD);
     }
     else
     {
@@ -1209,7 +1209,7 @@ QDateTime CGisItemWpt::geocache_t::getLastFound() const
     {
         if(lastFound.isValid() == false || (log.type == "Found It" && log.date > lastFound))
         {
-            lastFound=log.date;
+            lastFound = log.date;
         }
     }
     return lastFound;
@@ -1251,7 +1251,7 @@ QMap<searchProperty_e, CGisItemWpt::fSearch> CGisItemWpt::initKeywordLambdaMap()
     });
     map.insert(eSearchPropertyGeneralFullText, [](CGisItemWpt* item){
         searchValue_t searchValue;
-        searchValue.str1 = item->getInfo(eFeatureShowFullText|eFeatureShowName);
+        searchValue.str1 = item->getInfo(eFeatureShowFullText | eFeatureShowName);
         return searchValue;
     });
     map.insert(eSearchPropertyGeneralElevation, [](CGisItemWpt* item){

--- a/src/qmapshack/gis/wpt/CScrOptWpt.cpp
+++ b/src/qmapshack/gis/wpt/CScrOptWpt.cpp
@@ -36,7 +36,7 @@ CScrOptWpt::CScrOptWpt(CGisItemWpt *wpt, const QPoint& point, IMouse *parent)
     setupUi(this);
     setOrigin(point);
     label->setFont(CMainWindow::self().getMapFont());
-    label->setText(wpt->getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowLinks));
+    label->setText(wpt->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowLinks));
     adjustSize();
 
     toolProj->setDisabled(wpt->isGeocache() || wpt->isOnDevice());

--- a/src/qmapshack/grid/CGrid.cpp
+++ b/src/qmapshack/grid/CGrid.cpp
@@ -107,35 +107,35 @@ void CGrid::setProjAndColor(const QString& proj, const QColor& c)
 void CGrid::findGridSpace(qreal min, qreal max, qreal& xSpace, qreal& ySpace)
 {
     qreal dX = qAbs(min - max) / 10;
-    if(dX < M_PI/180000)
+    if(dX < M_PI / 180000)
     {
-        xSpace = 5*M_PI/1800000;
-        ySpace = 5*M_PI/1800000;
+        xSpace = 5 * M_PI / 1800000;
+        ySpace = 5 * M_PI / 1800000;
     }
-    else if(dX < M_PI/18000)
+    else if(dX < M_PI / 18000)
     {
-        xSpace = 5*M_PI/180000;
-        ySpace = 5*M_PI/180000;
+        xSpace = 5 * M_PI / 180000;
+        ySpace = 5 * M_PI / 180000;
     }
-    else if(dX < M_PI/1800)
+    else if(dX < M_PI / 1800)
     {
-        xSpace = 5*M_PI/18000;
-        ySpace = 5*M_PI/18000;
+        xSpace = 5 * M_PI / 18000;
+        ySpace = 5 * M_PI / 18000;
     }
-    else if(dX < M_PI/180)
+    else if(dX < M_PI / 180)
     {
-        xSpace = 5*M_PI/1800;
-        ySpace = 5*M_PI/1800;
+        xSpace = 5 * M_PI / 1800;
+        ySpace = 5 * M_PI / 1800;
     }
-    else if(dX < M_PI/18)
+    else if(dX < M_PI / 18)
     {
-        xSpace = 5*M_PI/180;
-        ySpace = 5*M_PI/180;
+        xSpace = 5 * M_PI / 180;
+        ySpace = 5 * M_PI / 180;
     }
-    else if(dX < M_PI/1.8)
+    else if(dX < M_PI / 1.8)
     {
-        xSpace = 5*M_PI/180;
-        ySpace = 5*M_PI/180;
+        xSpace = 5 * M_PI / 180;
+        ySpace = 5 * M_PI / 180;
     }
 
     else if(dX < 3000)
@@ -193,7 +193,7 @@ void CGrid::findGridSpace(qreal min, qreal max, qreal& xSpace, qreal& ySpace)
 
 bool CGrid::calcIntersection(qreal x1, qreal y1, qreal x2, qreal y2, qreal x3, qreal y3, qreal x4, qreal y4, qreal& x, qreal& y)
 {
-    qreal ua = ((x4 - x3)*(y1 - y3) - (y4 - y3)*(x1 - x3))/((y4 - y3)*(x2 - x1) - (x4 - x3)*(y2 - y1));
+    qreal ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / ((y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1));
 
     x = x1 + ua * (x2 - x1);
     y = y1 + ua * (y2 - y1);
@@ -269,13 +269,13 @@ void CGrid::draw(QPainter& p, const QRect& rect)
 
     if(pj_is_latlong(pjGrid))
     {
-        if(y > (85*DEG_TO_RAD))
+        if(y > (85 * DEG_TO_RAD))
         {
-            y = (85*DEG_TO_RAD);
+            y = (85 * DEG_TO_RAD);
         }
-        if(btmMin < -(85*DEG_TO_RAD - yGridSpace))
+        if(btmMin < -(85 * DEG_TO_RAD - yGridSpace))
         {
-            btmMin = -(85*DEG_TO_RAD - yGridSpace);
+            btmMin = -(85 * DEG_TO_RAD - yGridSpace);
         }
 
         if(x > rightMax)
@@ -361,13 +361,13 @@ void CGrid::draw(QPainter& p, const QRect& rect)
     p.restore();
 
     QColor textColor;
-    textColor.setHsv(color.hslHue(), color.hsvSaturation(), (color.value() > 128 ? color.value()-128 : 0));
+    textColor.setHsv(color.hslHue(), color.hsvSaturation(), (color.value() > 128 ? color.value() - 128 : 0));
 
     if(pj_is_latlong(pjGrid))
     {
         QFontMetrics fm(CMainWindow::self().getMapFont());
         int yoff  = fm.height() + fm.ascent();
-        int xoff  = fm.width("XX.XXXX")>>1;
+        int xoff  = fm.width("XX.XXXX") >> 1;
 
         for(const val_t &val : horzTopTicks)
         {
@@ -393,26 +393,26 @@ void CGrid::draw(QPainter& p, const QRect& rect)
     {
         QFontMetrics fm(CMainWindow::self().getMapFont());
         int yoff  = fm.height() + fm.ascent();
-        int xoff  = fm.width("XXXX")>>1;
+        int xoff  = fm.width("XXXX") >> 1;
 
         for(const val_t &val : horzTopTicks)
         {
-            CDraw::text(QString("%1").arg(qint32(val.val/1000)), p, QPoint(val.pos, yoff), textColor);
+            CDraw::text(QString("%1").arg(qint32(val.val / 1000)), p, QPoint(val.pos, yoff), textColor);
         }
 
         for(const val_t &val : horzBtmTicks)
         {
-            CDraw::text(QString("%1").arg(qint32(val.val/1000)), p, QPoint(val.pos, h), textColor);
+            CDraw::text(QString("%1").arg(qint32(val.val / 1000)), p, QPoint(val.pos, h), textColor);
         }
 
         for(const val_t &val : vertLftTicks)
         {
-            CDraw::text(QString("%1").arg(qint32(val.val/1000)), p, QPoint(xoff, val.pos), textColor);
+            CDraw::text(QString("%1").arg(qint32(val.val / 1000)), p, QPoint(xoff, val.pos), textColor);
         }
 
         for(const val_t &val : vertRgtTicks)
         {
-            CDraw::text(QString("%1").arg(qint32(val.val/1000)), p, QPoint(w - xoff, val.pos), textColor);
+            CDraw::text(QString("%1").arg(qint32(val.val / 1000)), p, QPoint(w - xoff, val.pos), textColor);
         }
     }
 }

--- a/src/qmapshack/grid/CProjWizard.cpp
+++ b/src/qmapshack/grid/CProjWizard.cpp
@@ -132,7 +132,7 @@ void CProjWizard::findDatum(const QString& str)
                 ++si;
             }
 
-            cmp += QString("+a=%1 +b=%2 ").arg(si->dfA, 0, 'f', 4).arg(si->dfA * (1.0 - (1.0/si->dfInvFlattening)), 0, 'f', 4);
+            cmp += QString("+a=%1 +b=%2 ").arg(si->dfA, 0, 'f', 4).arg(si->dfA * (1.0 - (1.0 / si->dfInvFlattening)), 0, 'f', 4);
             cmp += QString("+towgs84=%1,%2,%3,%4,%5,%6,%7,%8 ").arg(di->dfShiftX).arg(di->dfShiftY).arg(di->dfShiftZ).arg(di->dfDatumParm0).arg(di->dfDatumParm1).arg(di->dfDatumParm2).arg(di->dfDatumParm3).arg(di->dfDatumParm4);
             cmp += "+units=m  +no_defs";
         }
@@ -193,7 +193,7 @@ void CProjWizard::slotChange()
             ++si;
         }
 
-        str += QString("+a=%1 +b=%2 ").arg(si->dfA, 0, 'f', 4).arg(si->dfA * (1.0 - (1.0/si->dfInvFlattening)), 0, 'f', 4);
+        str += QString("+a=%1 +b=%2 ").arg(si->dfA, 0, 'f', 4).arg(si->dfA * (1.0 - (1.0 / si->dfInvFlattening)), 0, 'f', 4);
         str += QString("+towgs84=%1,%2,%3,%4,%5,%6,%7,%8 ").arg(di.dfShiftX).arg(di.dfShiftY).arg(di.dfShiftZ).arg(di.dfDatumParm0).arg(di.dfDatumParm1).arg(di.dfDatumParm2).arg(di.dfDatumParm3).arg(di.dfDatumParm4);
         str += "+units=m  +no_defs";
     }

--- a/src/qmapshack/helpers/CDraw.cpp
+++ b/src/qmapshack/helpers/CDraw.cpp
@@ -36,7 +36,7 @@ QBrush CDraw::brushBackSemiBlue(QColor(127, 127, 255, 127));
 
 QImage CDraw::createBasicArrow(const QBrush &brush, qreal scale)
 {
-    QImage arrow(20*scale, 15*scale, QImage::Format_ARGB32);
+    QImage arrow(20 * scale, 15 * scale, QImage::Format_ARGB32);
     arrow.fill(qRgba(0, 0, 0, 0));
 
     QPainter painter(&arrow);
@@ -54,11 +54,11 @@ QImage CDraw::createBasicArrow(const QBrush &brush, qreal scale)
 
     QPointF arrowPoints[5] =
     {
-        QPointF(19.0*scale,  7.0*scale), // front
-        QPointF( 0.0*scale,  0.0*scale), // upper tail
-        QPointF( 5.0*scale,  7.0*scale), // mid   tail
-        QPointF( 0.0*scale, 14.0*scale), // lower tail
-        QPointF(19.0*scale,  7.0*scale)  // front
+        QPointF(19.0 * scale,  7.0 * scale), // front
+        QPointF( 0.0 * scale,  0.0 * scale), // upper tail
+        QPointF( 5.0 * scale,  7.0 * scale), // mid   tail
+        QPointF( 0.0 * scale, 14.0 * scale), // lower tail
+        QPointF(19.0 * scale,  7.0 * scale)  // front
     };
     painter.drawPolygon(arrowPoints, 5);
     painter.end();
@@ -78,9 +78,9 @@ static inline int pointDistanceSquare(const QPointF &p1, const QPointF &p2)
 
 void CDraw::arrows(const QPolygonF &line, const QRectF &viewport, QPainter &p, int minPointDist, int minArrowDist, qreal scale)
 {
-    const QImage& arrow = createBasicArrow(p.brush(), qMin(qMax(1.0, scale/3), 3.0));
-    qreal xoff = qCeil(arrow.width()/2.0);
-    qreal yoff = qFloor((arrow.height()-1)/2.0);
+    const QImage& arrow = createBasicArrow(p.brush(), qMin(qMax(1.0, scale / 3), 3.0));
+    qreal xoff = qCeil(arrow.width() / 2.0);
+    qreal yoff = qFloor((arrow.height() - 1) / 2.0);
 
     const qreal minArrowDistSquare = minArrowDist * minArrowDist;
     const qreal minPointDistSquare = minPointDist * minPointDist;
@@ -95,7 +95,7 @@ void CDraw::arrows(const QPolygonF &line, const QRectF &viewport, QPainter &p, i
         // ensure there is enough space between two linepts
         if( pointDistanceSquare(pt, prevPt) >= minPointDistSquare )
         {
-            QPointF arrowPos = prevPt + (pt - prevPt)/2;
+            QPointF arrowPos = prevPt + (pt - prevPt) / 2;
 
             if( (viewport.contains(arrowPos) || 0 == viewport.height()) // ensure the point is visible
                 && (firstArrow || pointDistanceSquare(prevArrow, arrowPos) >= minArrowDistSquare) )
@@ -134,7 +134,7 @@ void CDraw::nogos(const QPolygonF &line, const QRectF &viewport, QPainter &p, in
             const QPointF line = pt - prevPt;
             do
             {
-                const QPointF nogoPos = prevPt + line * l/dist;
+                const QPointF nogoPos = prevPt + line * l / dist;
 
                 if( (viewport.contains(nogoPos) || 0 == viewport.height())) // ensure the point is visible
                 {
@@ -300,7 +300,7 @@ QPixmap CDraw::number(int num, const QColor &color)
     USE_ANTI_ALIASING(p, true);
     p.translate(1, 1);
 
-    CDraw::number(num, size, p, {(size-2)/2.0, (size-2)/2.0}, color);
+    CDraw::number(num, size, p, {(size - 2) / 2.0, (size - 2) / 2.0}, color);
 
     return pixmap;
 }

--- a/src/qmapshack/helpers/CDraw.h
+++ b/src/qmapshack/helpers/CDraw.h
@@ -27,7 +27,7 @@
 #include "CMainWindow.h"
 inline void USE_ANTI_ALIASING(QPainter& p, bool useAntiAliasing)
 {
-    p.setRenderHints(QPainter::TextAntialiasing|QPainter::Antialiasing|QPainter::SmoothPixmapTransform|QPainter::HighQualityAntialiasing, useAntiAliasing);
+    p.setRenderHints(QPainter::TextAntialiasing | QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::HighQualityAntialiasing, useAntiAliasing);
 }
 
 #define RECT_RADIUS 3

--- a/src/qmapshack/helpers/CLinksDialog.cpp
+++ b/src/qmapshack/helpers/CLinksDialog.cpp
@@ -36,7 +36,7 @@ CLinksDialog::CLinksDialog(QList<IGisItem::link_t> &links, QWidget *parent)
         item->setText(0, link.type);
         item->setText(1, link.text);
         item->setText(2, link.uri.toString());
-        item->setFlags(item->flags()|Qt::ItemIsEditable);
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
     }
 }
 
@@ -56,7 +56,7 @@ void CLinksDialog::slotAddLink()
     item->setText(0, "");
     item->setText(1, "enter a text");
     item->setText(2, "enter a link");
-    item->setFlags(item->flags()|Qt::ItemIsEditable);
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
 }
 
 void CLinksDialog::slotDelLink()

--- a/src/qmapshack/helpers/CProgressDialog.cpp
+++ b/src/qmapshack/helpers/CProgressDialog.cpp
@@ -31,7 +31,7 @@ CProgressDialog::CProgressDialog(const QString text, int min, int max, QWidget *
     : QDialog(parent)
 {
     stackSelf.push(this);
-    int oldTopIndex = stackSelf.length()-2;
+    int oldTopIndex = stackSelf.length() - 2;
 
     setupUi(this);
     setWindowModality(Qt::ApplicationModal);
@@ -42,7 +42,7 @@ CProgressDialog::CProgressDialog(const QString text, int min, int max, QWidget *
     progressBar->setValue(0);
 
     time.start();
-    labelTime->setText(tr("Elapsed time: %1").arg(time.elapsed()/1000));
+    labelTime->setText(tr("Elapsed time: %1").arg(time.elapsed() / 1000));
 
     if(max == NOINT)
     {
@@ -140,7 +140,7 @@ void CProgressDialog::setValue(int val)
         QApplication::processEvents();
     }
     progressBar->setValue(val);
-    labelTime->setText(tr("Elapsed time: %1 seconds.").arg(time.elapsed()/1000.0, 0, 'f', 0));
+    labelTime->setText(tr("Elapsed time: %1 seconds.").arg(time.elapsed() / 1000.0, 0, 'f', 0));
 }
 
 bool CProgressDialog::wasCanceled()

--- a/src/qmapshack/helpers/CSelectProjectDialog.cpp
+++ b/src/qmapshack/helpers/CSelectProjectDialog.cpp
@@ -48,9 +48,9 @@ CSelectProjectDialog::CSelectProjectDialog(QString &key, QString &name, IGisProj
             }
 
             QListWidgetItem * item = new QListWidgetItem(project->icon(CGisListWks::eColumnIcon), project->text(CGisListWks::eColumnName), listWidget);
-            item->setData(Qt::UserRole+0, project->getKey());
-            item->setData(Qt::UserRole+1, project->getType());
-            item->setData(Qt::UserRole+2, project->getName());
+            item->setData(Qt::UserRole + 0, project->getKey());
+            item->setData(Qt::UserRole + 1, project->getType());
+            item->setData(Qt::UserRole + 2, project->getName());
 
             if(project->getKey() == lastkey)
             {
@@ -126,9 +126,9 @@ void CSelectProjectDialog::reject()
 
 void CSelectProjectDialog::slotItemClicked(QListWidgetItem * item)
 {
-    lineEdit->setText(item->data(Qt::UserRole+2).toString());
+    lineEdit->setText(item->data(Qt::UserRole + 2).toString());
     key     = item->data(Qt::UserRole).toString();
-    type    = IGisProject::type_e(item->data(Qt::UserRole+1).toInt());
+    type    = IGisProject::type_e(item->data(Qt::UserRole + 1).toInt());
     setType(type);
 
     frameType->setEnabled(false);
@@ -136,9 +136,9 @@ void CSelectProjectDialog::slotItemClicked(QListWidgetItem * item)
 
 void CSelectProjectDialog::slotItemDoubleClicked(QListWidgetItem * item)
 {
-    lineEdit->setText(item->data(Qt::UserRole+2).toString());
+    lineEdit->setText(item->data(Qt::UserRole + 2).toString());
     key     = item->data(Qt::UserRole).toString();
-    type    = IGisProject::type_e(item->data(Qt::UserRole+1).toInt());
+    type    = IGisProject::type_e(item->data(Qt::UserRole + 1).toInt());
 
     QDialog::accept();
 }

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -36,7 +36,7 @@ CWptIconManager::CWptIconManager(QObject *parent)
 
 CWptIconManager::~CWptIconManager()
 {
-    qDebug()<< "CWptIconManager::~CWptIconManager()";
+    qDebug() << "CWptIconManager::~CWptIconManager()";
     removeNumberedBullets();
 }
 
@@ -154,7 +154,7 @@ void CWptIconManager::init()
 void CWptIconManager::setWptIconByName(const QString& name, const QString& filename)
 {
     QPixmap icon(filename);
-    wptIcons[name] = icon_t(filename, icon.width()>>1, icon.height()>>1);
+    wptIcons[name] = icon_t(filename, icon.width() >> 1, icon.height() >> 1);
 }
 
 
@@ -165,7 +165,7 @@ void CWptIconManager::setWptIconByName(const QString& name, const QPixmap& icon)
     QString filename = dirIcon.filePath(name + ".png");
 
     icon.save(filename);
-    wptIcons[name] = icon_t(filename, icon.width()>>1, icon.height()>>1);
+    wptIcons[name] = icon_t(filename, icon.width() >> 1, icon.height() >> 1);
 }
 
 QPixmap CWptIconManager::loadIcon(const QString& path)
@@ -218,15 +218,15 @@ QPixmap CWptIconManager::getWptIconByName(const QString& name, QPointF &focus, Q
         qreal s;
         if(icon.width() > icon.height())
         {
-            s = 22.0/icon.width();
+            s = 22.0 / icon.width();
         }
         else
         {
-            s = 22.0/icon.height();
+            s = 22.0 / icon.height();
         }
 
         focus = focus * s;
-        icon  = icon.scaled(icon.size()*s, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        icon  = icon.scaled(icon.size() * s, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }
 
     return icon;

--- a/src/qmapshack/map/CMapDraw.cpp
+++ b/src/qmapshack/map/CMapDraw.cpp
@@ -329,7 +329,7 @@ void CMapDraw::buildMapList()
         QDir dir(path);
 
         // find available maps
-        for(const QString &filename : dir.entryList(supportedFormats, QDir::Files|QDir::Readable, QDir::Name))
+        for(const QString &filename : dir.entryList(supportedFormats, QDir::Files | QDir::Readable, QDir::Name))
         {
             createMapItem(dir.absoluteFilePath(filename), maps);
         }

--- a/src/qmapshack/map/CMapGEMF.cpp
+++ b/src/qmapshack/map/CMapGEMF.cpp
@@ -34,12 +34,12 @@
 
 inline int lon2tile(double lon, int z)
 {
-    return (int)(qRound(256*(lon + 180.0) / 360.0 * qPow(2.0, z)));
+    return (int)(qRound(256 * (lon + 180.0) / 360.0 * qPow(2.0, z)));
 }
 
 inline int lat2tile(double lat, int z)
 {
-    return (int)(qRound(256*(1.0 - log( qTan(lat * M_PI/180.0) + 1.0 / qCos(lat * M_PI/180.0)) / M_PI) / 2.0 * qPow(2.0, z)));
+    return (int)(qRound(256 * (1.0 - log( qTan(lat * M_PI / 180.0) + 1.0 / qCos(lat * M_PI / 180.0)) / M_PI) / 2.0 * qPow(2.0, z)));
 }
 
 inline double tile2lon(int x, int z)
@@ -92,8 +92,8 @@ CMapGEMF::CMapGEMF(const QString &filename, CMapDraw *parent)
 
     stream >> rangeNum;
     QList<range_t> ranges;
-    quint64 tiles=0;
-    for (quint32 i=0; i < rangeNum; i++)
+    quint64 tiles = 0;
+    for (quint32 i = 0; i < rangeNum; i++)
     {
         range_t range;
         stream >> range.zoomlevel;
@@ -105,14 +105,14 @@ CMapGEMF::CMapGEMF(const QString &filename, CMapDraw *parent)
         stream >> range.offset;
 
         ranges << range;
-        tiles += (range.maxX + 1 - range.minX)*(range.maxY + 1 - range.minY);
+        tiles += (range.maxX + 1 - range.minX) * (range.maxY + 1 - range.minY);
     }
     qDebug() << "CMapGEMF: Read " << rangeNum << "Ranges with " << tiles << " Tiles";
 
     minZoom = MAX_ZOOM_LEVEL;
     maxZoom = MIN_ZOOM_LEVEL;
 
-    for(quint32 i=0; i <= MAX_ZOOM_LEVEL; i++)
+    for(quint32 i = 0; i <= MAX_ZOOM_LEVEL; i++)
     {
         QList<range_t> rangeZoom;
         for(const range_t &range : ranges)
@@ -133,11 +133,11 @@ CMapGEMF::CMapGEMF(const QString &filename, CMapDraw *parent)
     QString partfile = filename;
     QFile f(partfile);
     f.open(QIODevice::ReadOnly);
-    quint32 i=1;
+    quint32 i = 1;
     do
     {
         gemffile_t gf;
-        gf.filename= partfile;
+        gf.filename = partfile;
         gf.size = f.size();
         f.close();
         files << gf;
@@ -166,7 +166,7 @@ void CMapGEMF::draw(IDrawContext::buffer_t &buf)
     // start to draw the map
     QPainter p(&buf.image);
     USE_ANTI_ALIASING(p, true);
-    p.setOpacity(getOpacity()/100.0);
+    p.setOpacity(getOpacity() / 100.0);
     p.translate(-pp);
 
     qreal x1 = qMin(buf.ref1.x(), buf.ref4.x());
@@ -175,13 +175,13 @@ void CMapGEMF::draw(IDrawContext::buffer_t &buf)
     qreal x2 = qMax(buf.ref2.x(), buf.ref3.x());
     qreal y2 = qMin(buf.ref3.y(), buf.ref4.y());
 
-    if(x1 < -180.0*DEG_TO_RAD)
+    if(x1 < -180.0 * DEG_TO_RAD)
     {
-        x1 = -180*DEG_TO_RAD;
+        x1 = -180 * DEG_TO_RAD;
     }
-    if(x2 > 180.0*DEG_TO_RAD)
+    if(x2 > 180.0 * DEG_TO_RAD)
     {
-        x2 = 180*DEG_TO_RAD;
+        x2 = 180 * DEG_TO_RAD;
     }
 
 
@@ -191,7 +191,7 @@ void CMapGEMF::draw(IDrawContext::buffer_t &buf)
 
     for(quint32 i = 0; i < MAX_ZOOM_LEVEL; i++)
     {
-        qreal s2 = 0.055 * (1<<i);
+        qreal s2 = 0.055 * (1 << i);
         if(qAbs(s2 - s1.x()) < d)
         {
             z = i;
@@ -238,7 +238,7 @@ quint64 CMapGEMF::getFilenameFromAddress(const quint64 offset, QString &filename
         temp -= gf.size;
     }
 
-    qDebug() << "CMAPGemf: ImageAddress was wrong "<< offset;
+    qDebug() << "CMAPGemf: ImageAddress was wrong " << offset;
     return 0;
 }
 

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -128,7 +128,7 @@ static inline bool isCluttered(QVector<QRectF>& rectPois, const QRectF& rect)
 
 
 CMapIMG::CMapIMG(const QString &filename, CMapDraw *parent)
-    : IMap(eFeatVisibility|eFeatVectorItems|eFeatTypFile, parent)
+    : IMap(eFeatVisibility | eFeatVectorItems | eFeatTypFile, parent)
     , filename(filename)
     , fm(CMainWindow::self().getMapFont())
     , selectedLanguage(NOIDX)
@@ -484,7 +484,7 @@ void CMapIMG::readFile(CFileExt& file, quint32 offset, quint32 size, QByteArray&
 
 #ifdef HOST_IS_64_BIT
     quint64 * p64 = (quint64*)data.data();
-    for(quint32 i = 0; i < size/8; ++i)
+    for(quint32 i = 0; i < size / 8; ++i)
     {
         *p64++ ^= mask64;
     }
@@ -492,7 +492,7 @@ void CMapIMG::readFile(CFileExt& file, quint32 offset, quint32 size, QByteArray&
     quint8 * p = (quint8*)p64;
 #else
     quint32 * p32 = (quint32*)data.data();
-    for(quint32 i = 0; i < size/4; ++i)
+    for(quint32 i = 0; i < size / 4; ++i)
     {
         *p32++ ^= mask32;
     }
@@ -518,7 +518,7 @@ void CMapIMG::readBasics()
         throw exce_t(eErrOpen, tr("Failed to open: ") + filename);
     }
 
-    mask = (quint8)*file.data(0, 1);
+    mask = (quint8) * file.data(0, 1);
 
     mask32 = mask;
     mask32 <<= 8;
@@ -695,7 +695,7 @@ void CMapIMG::readBasics()
         copyright += str;
     }
 
-    qDebug() << "dimensions:\t" << "N" << (maparea.bottom()*RAD_TO_DEG) << "E" << (maparea.right()*RAD_TO_DEG) << "S" << (maparea.top()*RAD_TO_DEG) << "W" << (maparea.left()*RAD_TO_DEG);
+    qDebug() << "dimensions:\t" << "N" << (maparea.bottom() * RAD_TO_DEG) << "E" << (maparea.right() * RAD_TO_DEG) << "S" << (maparea.top() * RAD_TO_DEG) << "W" << (maparea.left() * RAD_TO_DEG);
 }
 
 void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt &file)
@@ -757,7 +757,7 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt &file)
     }
 
 #ifdef DEBUG_SHOW_TRE_DATA
-    qDebug() << "bounding area (\260)" << (subfile.north*RAD_TO_DEG) << (subfile.east*RAD_TO_DEG) << (subfile.south*RAD_TO_DEG) << (subfile.west*RAD_TO_DEG);
+    qDebug() << "bounding area (\260)" << (subfile.north * RAD_TO_DEG) << (subfile.east * RAD_TO_DEG) << (subfile.south * RAD_TO_DEG) << (subfile.west * RAD_TO_DEG);
     qDebug() << "bounding area (rad)" << subfile.area;
 #endif                       // DEBUG_SHOW_TRE_DATA
 
@@ -777,7 +777,7 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt &file)
     quint32 nsubdivs_last = 0;
 
     // count subsections
-    for(quint32 i=0; i < nlevels; ++i)
+    for(quint32 i = 0; i < nlevels; ++i)
     {
         maplevel_t ml;
         ml.inherited    = TRE_MAP_INHER(pMapLevel);
@@ -834,7 +834,7 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt &file)
 
     // parse all 16 byte subdivision entries
     quint32 i;
-    for(i=0; i < nsubdivs_next; ++i, --nsubdiv)
+    for(i = 0; i < nsubdivs_next; ++i, --nsubdiv)
     {
         subdiv->n = i;
         subdiv->next         = gar_load(uint16_t, pSubDivN->next);
@@ -1114,7 +1114,7 @@ void CMapIMG::processPrimaryMapData()
 
 
 #ifdef DEBUG_SHOW_MAPLEVELS
-    for(int i=0; i < maplevels.count(); ++i)
+    for(int i = 0; i < maplevels.count(); ++i)
     {
         map_level_t& ml = maplevels[i];
         qDebug() << ml.bits << ml.level << ml.useBaseMap;
@@ -1233,7 +1233,7 @@ void CMapIMG::draw(IDrawContext::buffer_t& buf) /* override */
     }
 
     QPainter p(&buf.image);
-    p.setOpacity(getOpacity()/100.0);
+    p.setOpacity(getOpacity() / 100.0);
     USE_ANTI_ALIASING(p, true);
 
     QFont f = CMainWindow::self().getMapFont();
@@ -1719,7 +1719,7 @@ void CMapIMG::drawPolygons(QPainter& p, polytype_t& lines)
     const int N = polygonDrawOrder.size();
     for(int n = 0; n < N; ++n)
     {
-        quint32 type = polygonDrawOrder[(N-1) - n];
+        quint32 type = polygonDrawOrder[(N - 1) - n];
 
         p.setPen(polygonProperties[type].pen);
         p.setBrush(CMainWindow::self().isNight() ? polygonProperties[type].brushNight : polygonProperties[type].brushDay);
@@ -1864,7 +1864,7 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
                         p.save();
                         p.translate(p1);
                         p.rotate(angle);
-                        p.drawImage(0, -h/2, img2line(pixmap, segLength));
+                        p.drawImage(0, -h / 2, img2line(pixmap, segLength));
                         //imageCount++;
 
                         p.restore();
@@ -1997,7 +1997,7 @@ void CMapIMG::collectText(const CGarminPolygon& item, const QPolygonF& line, con
     const int size = line.size();
     for(int i = 1; i < size; ++i)
     {
-        const QPointF &p1 = line[i-1];
+        const QPointF &p1 = line[i - 1];
         const QPointF &p2 = line[i];
         qreal dx = p2.x() - p1.x();
         qreal dy = p2.y() - p1.y();
@@ -2056,7 +2056,7 @@ void CMapIMG::drawPoints(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPoi
         {
             if(size.width() <= 8 && size.height() <= 8)
             {
-                p.drawImage(pt->pos.x() - (size.width()/2), pt->pos.y() - (size.height()/2), icon);
+                p.drawImage(pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
             }
             else
             {
@@ -2070,7 +2070,7 @@ void CMapIMG::drawPoints(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPoi
 
         if(pointProperties.contains(pt->type))
         {
-            p.drawImage(pt->pos.x() - (size.width()/2), pt->pos.y() - (size.height()/2), icon);
+            p.drawImage(pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
             showLabel = pointProperties[pt->type].labelType != CGarminTyp::eNone;
         }
         else
@@ -2111,7 +2111,7 @@ void CMapIMG::drawPois(QPainter& p, pointtype_t& pts, QVector<QRectF> &rectPois)
         {
             if(size.width() <= 8 && size.height() <= 8)
             {
-                p.drawImage(pt.pos.x() - (size.width()/2), pt.pos.y() - (size.height()/2), icon);
+                p.drawImage(pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
             }
             else
             {
@@ -2123,7 +2123,7 @@ void CMapIMG::drawPois(QPainter& p, pointtype_t& pts, QVector<QRectF> &rectPois)
         labelType = CGarminTyp::eStandard;
         if(pointProperties.contains(pt.type))
         {
-            p.drawImage(pt.pos.x() - (size.width()/2), pt.pos.y() - (size.height()/2), icon);
+            p.drawImage(pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
             labelType = pointProperties[pt.type].labelType;
         }
         else
@@ -2208,14 +2208,14 @@ void CMapIMG::drawText(QPainter& p)
         {
             const qreal d = lengths[i];
 
-            if((offset + d/2) >= ref)
+            if((offset + d / 2) >= ref)
             {
                 offset = ref;
                 break;
             }
             if((offset + d) >= ref)
             {
-                offset += d/2;
+                offset += d / 2;
                 break;
             }
             offset += d;
@@ -2426,10 +2426,10 @@ void CMapIMG::getInfoPolylines(const QPoint &pt, QMultiMap<QString, QString>& di
         }
 
         // see http://local.wasp.uwa.edu.au/~pbourke/geometry/pointline/
-        for(int i=1; i < len; ++i)
+        for(int i = 1; i < len; ++i)
         {
-            p1.u = line.pixel[i-1].x();
-            p1.v = line.pixel[i-1].y();
+            p1.u = line.pixel[i - 1].x();
+            p1.v = line.pixel[i - 1].y();
             p2.u = line.pixel[i].x();
             p2.v = line.pixel[i].y();
 
@@ -2450,7 +2450,7 @@ void CMapIMG::getInfoPolylines(const QPoint &pt, QMultiMap<QString, QString>& di
             qreal x = p1.u + u * dx;
             qreal y = p1.v + u * dy;
 
-            qreal distance = qSqrt((x - pt.x())*(x - pt.x()) + (y - pt.y())*(y - pt.y()));
+            qreal distance = qSqrt((x - pt.x()) * (x - pt.x()) + (y - pt.y()) * (y - pt.y()));
 
             if(distance < shortest)
             {
@@ -2517,7 +2517,7 @@ void CMapIMG::getInfoPolygons(const QPoint& pt, QMultiMap<QString, QString>& dic
         {
             bool c = false;
             // see http://local.wasp.uwa.edu.au/~pbourke/geometry/insidepoly/
-            for (int i = 0, j = npol-1; i < npol; j = i++)
+            for (int i = 0, j = npol - 1; i < npol; j = i++)
             {
                 p1.u = line.pixel[j].x();
                 p1.v = line.pixel[j].y();

--- a/src/qmapshack/map/CMapJNX.cpp
+++ b/src/qmapshack/map/CMapJNX.cpp
@@ -303,7 +303,7 @@ void CMapJNX::draw(IDrawContext::buffer_t& buf) /* override */
     // ----- start drawing -----
     QPainter p(&buf.image);
     USE_ANTI_ALIASING(p, true);
-    p.setOpacity(getOpacity()/100.0);
+    p.setOpacity(getOpacity() / 100.0);
     p.translate(-pp);
 
     for(const file_t &mapFile : files)
@@ -319,7 +319,7 @@ void CMapJNX::draw(IDrawContext::buffer_t& buf) /* override */
         }
 
 
-        qint32 level = scale2level(bufferScale.x()/5, mapFile);
+        qint32 level = scale2level(bufferScale.x() / 5, mapFile);
 
         // no scalable level found, draw bounding box of map
         // derive maps corner coordinate
@@ -350,7 +350,7 @@ void CMapJNX::draw(IDrawContext::buffer_t& buf) /* override */
             continue;
         }
 
-        QByteArray data(1024*1024*4, 0);
+        QByteArray data(1024 * 1024 * 4, 0);
         //(char) typecast needed to avoid MSVC compiler warning
         //in MSVC, char is a signed type.
         //Maybe the QByteArray declaration should be fixed ;-)

--- a/src/qmapshack/map/CMapList.cpp
+++ b/src/qmapshack/map/CMapList.cpp
@@ -183,7 +183,7 @@ void CMapList::slotMoveUp()
 
     item->showChildren(false);
     treeWidget->takeTopLevelItem(index);
-    treeWidget->insertTopLevelItem(index-1, item);
+    treeWidget->insertTopLevelItem(index - 1, item);
     item->showChildren(true);
     treeWidget->setCurrentItem(0);
     emit treeWidget->sigChanged();
@@ -205,7 +205,7 @@ void CMapList::slotMoveDown()
 
     item->showChildren(false);
     treeWidget->takeTopLevelItem(index);
-    treeWidget->insertTopLevelItem(index+1, item);
+    treeWidget->insertTopLevelItem(index + 1, item);
     item->showChildren(true);
     treeWidget->setCurrentItem(0);
     emit treeWidget->sigChanged();

--- a/src/qmapshack/map/CMapMAP.cpp
+++ b/src/qmapshack/map/CMapMAP.cpp
@@ -24,14 +24,14 @@
 #include <proj_api.h>
 #include <QtWidgets>
 
-#define INT_TO_DEG(x) (qreal(x)/1e6)
+#define INT_TO_DEG(x) (qreal(x) / 1e6)
 
-#define INT_TO_RAD(x) (qreal(x)/(1e6*RAD_TO_DEG))
+#define INT_TO_RAD(x) (qreal(x) / (1e6 * RAD_TO_DEG))
 
 
 
 CMapMAP::CMapMAP(const QString &filename, CMapDraw *parent)
-    : IMap(eFeatVisibility|eFeatVectorItems, parent)
+    : IMap(eFeatVisibility | eFeatVectorItems, parent)
     , filename(filename)
 {
     qDebug() << "------------------------------";

--- a/src/qmapshack/map/CMapRMAP.cpp
+++ b/src/qmapshack/map/CMapRMAP.cpp
@@ -71,14 +71,14 @@ CMapRMAP::CMapRMAP(const QString &filename, CMapDraw *parent)
     qint32 nZoomLevels;
     stream >> nZoomLevels;
 
-    for(int i=0; i < nZoomLevels; i++)
+    for(int i = 0; i < nZoomLevels; i++)
     {
         level_t level;
         stream >> level.offsetLevel;
         levels << level;
     }
 
-    for(int i=0; i < levels.size(); i++)
+    for(int i = 0; i < levels.size(); i++)
     {
         level_t& level = levels[i];
         file.seek(level.offsetLevel);
@@ -88,7 +88,7 @@ CMapRMAP::CMapRMAP(const QString &filename, CMapDraw *parent)
         stream >> level.xTiles;
         stream >> level.yTiles;
 
-        for(int j=0; j < (level.xTiles * level.yTiles); j++)
+        for(int j = 0; j < (level.xTiles * level.yTiles); j++)
         {
             quint64 offset;
             stream >> offset;
@@ -323,7 +323,7 @@ CMapRMAP::CMapRMAP(const QString &filename, CMapDraw *parent)
     qreal widthL0  = levels[0].width;
     qreal heightL0 = levels[0].height;
 
-    for(int i=0; i < levels.size(); i++)
+    for(int i = 0; i < levels.size(); i++)
     {
         level_t& level = levels[i];
 
@@ -491,7 +491,7 @@ void CMapRMAP::draw(IDrawContext::buffer_t& buf) /* override */
     // ----- start drawing -----
     QPainter p(&buf.image);
     USE_ANTI_ALIASING(p, true);
-    p.setOpacity(getOpacity()/100.0);
+    p.setOpacity(getOpacity() / 100.0);
     p.translate(-pp);
 
     QFile file(filename);

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -34,12 +34,12 @@
 
 inline int lon2tile(double lon, int z)
 {
-    return (int)(qRound(256*(lon + 180.0) / 360.0 * qPow(2.0, z)));
+    return (int)(qRound(256 * (lon + 180.0) / 360.0 * qPow(2.0, z)));
 }
 
 inline int lat2tile(double lat, int z)
 {
-    return (int)(qRound(256*(1.0 - log( qTan(lat * M_PI/180.0) + 1.0 / qCos(lat * M_PI/180.0)) / M_PI) / 2.0 * qPow(2.0, z)));
+    return (int)(qRound(256 * (1.0 - log( qTan(lat * M_PI / 180.0) + 1.0 / qCos(lat * M_PI / 180.0)) / M_PI) / 2.0 * qPow(2.0, z)));
 }
 
 inline double tile2lon(int x, int z)
@@ -336,7 +336,7 @@ void CMapTMS::draw(IDrawContext::buffer_t& buf) /* override */
     // start to draw the map
     QPainter p(&buf.image);
     USE_ANTI_ALIASING(p, true);
-    p.setOpacity(getOpacity()/100.0);
+    p.setOpacity(getOpacity() / 100.0);
     p.translate(-pp);
 
     // calculate maximum viewport
@@ -346,13 +346,13 @@ void CMapTMS::draw(IDrawContext::buffer_t& buf) /* override */
     qreal x2 = buf.ref2.x() > buf.ref3.x() ? buf.ref2.x() : buf.ref3.x();
     qreal y2 = buf.ref3.y() < buf.ref4.y() ? buf.ref3.y() : buf.ref4.y();
 
-    if(x1 < -180.0*DEG_TO_RAD)
+    if(x1 < -180.0 * DEG_TO_RAD)
     {
-        x1 = -180*DEG_TO_RAD;
+        x1 = -180 * DEG_TO_RAD;
     }
-    if(x2 >  180.0*DEG_TO_RAD)
+    if(x2 >  180.0 * DEG_TO_RAD)
     {
-        x2 =  180*DEG_TO_RAD;
+        x2 =  180 * DEG_TO_RAD;
     }
 
     // draw layers
@@ -369,7 +369,7 @@ void CMapTMS::draw(IDrawContext::buffer_t& buf) /* override */
 
         for(qint32 i = layer.minZoomLevel; i < 21; i++)
         {
-            qreal s2 = 0.055 * (1<<i);
+            qreal s2 = 0.055 * (1 << i);
             if(qAbs(s2 - s1.x()) < d)
             {
                 z = i;

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -63,7 +63,7 @@ CMapVRT::CMapVRT(const QString &filename, CMapDraw *parent)
         if(pBand->GetColorInterpretation() ==  GCI_PaletteIndex )
         {
             GDALColorTable * pct = pBand->GetColorTable();
-            for(int i=0; i < pct->GetColorEntryCount(); ++i)
+            for(int i = 0; i < pct->GetColorEntryCount(); ++i)
             {
                 const GDALColorEntry& e = *pct->GetColorEntry(i);
                 colortable << qRgba(e.c1, e.c2, e.c3, e.c4);
@@ -71,7 +71,7 @@ CMapVRT::CMapVRT(const QString &filename, CMapDraw *parent)
         }
         else if(pBand->GetColorInterpretation() ==  GCI_GrayIndex )
         {
-            for(int i=0; i < 256; ++i)
+            for(int i = 0; i < 256; ++i)
             {
                 colortable << qRgba(i, i, i, 255);
             }
@@ -158,7 +158,7 @@ CMapVRT::CMapVRT(const QString &filename, CMapDraw *parent)
 
     if(adfGeoTransform[4] != 0.0)
     {
-        trFwd.rotate(qAtan(adfGeoTransform[2]/adfGeoTransform[4]));
+        trFwd.rotate(qAtan(adfGeoTransform[2] / adfGeoTransform[4]));
     }
 
     if(pj_is_latlong(pjsrc))
@@ -378,7 +378,7 @@ void CMapVRT::draw(IDrawContext::buffer_t& buf) /* override */
 
     // estimate number of tiles and use it as a limit if no
     // user defined limit is given
-    qreal nTiles = ((right - left) * (bottom - top) / (dx*dy));
+    qreal nTiles = ((right - left) * (bottom - top) / (dx * dy));
     if(hasOverviews)
     {
         // if there are overviews tiles can be reduced by reading
@@ -399,7 +399,7 @@ void CMapVRT::draw(IDrawContext::buffer_t& buf) /* override */
     // start to draw the map
     QPainter p(&buf.image);
     USE_ANTI_ALIASING(p, true);
-    p.setOpacity(getOpacity()/100.0);
+    p.setOpacity(getOpacity() / 100.0);
     p.translate(-pp);
 
 
@@ -522,7 +522,7 @@ void CMapVRT::draw(IDrawContext::buffer_t& buf) /* override */
 
 
                 QPolygonF l;
-                l << QPointF(x, y) << QPointF(x+dx_used, y) << QPointF(x+dx_used, y+dy_used) << QPointF(x, y+dy_used);
+                l << QPointF(x, y) << QPointF(x + dx_used, y) << QPointF(x + dx_used, y + dy_used) << QPointF(x, y + dy_used);
                 l = trFwd.map(l);
 
                 pj_transform(pjsrc, pjtar, 1, 0, &l[0].rx(), &l[0].ry(), 0);

--- a/src/qmapshack/map/CMapWMTS.cpp
+++ b/src/qmapshack/map/CMapWMTS.cpp
@@ -394,7 +394,7 @@ void CMapWMTS::draw(IDrawContext::buffer_t& buf) /* override */
     // start to draw the map
     QPainter p(&buf.image);
     USE_ANTI_ALIASING(p, true);
-    p.setOpacity(getOpacity()/100.0);
+    p.setOpacity(getOpacity() / 100.0);
     p.translate(-pp);
 
     // calculate maximum viewport
@@ -404,13 +404,13 @@ void CMapWMTS::draw(IDrawContext::buffer_t& buf) /* override */
     qreal x2 = buf.ref2.x() > buf.ref3.x() ? buf.ref2.x() : buf.ref3.x();
     qreal y2 = buf.ref3.y() < buf.ref4.y() ? buf.ref3.y() : buf.ref4.y();
 
-    if(x1 < -180.0*DEG_TO_RAD)
+    if(x1 < -180.0 * DEG_TO_RAD)
     {
-        x1 = -180*DEG_TO_RAD;
+        x1 = -180 * DEG_TO_RAD;
     }
-    if(x2 >  180.0*DEG_TO_RAD)
+    if(x2 >  180.0 * DEG_TO_RAD)
     {
-        x2 =  180*DEG_TO_RAD;
+        x2 =  180 * DEG_TO_RAD;
     }
 
 
@@ -442,7 +442,7 @@ void CMapWMTS::draw(IDrawContext::buffer_t& buf) /* override */
 
         // search matrix ID of tile level with best matching scale
         QString tileMatrixId;
-        QPointF s1 = (pt2 - pt1)/QPointF(buf.image.width(), buf.image.height());
+        QPointF s1 = (pt2 - pt1) / QPointF(buf.image.width(), buf.image.height());
         qreal d = NOFLOAT;
         for(const QString &key : tileset.tilematrix.keys())
         {

--- a/src/qmapshack/map/IMapPropSetup.h
+++ b/src/qmapshack/map/IMapPropSetup.h
@@ -33,7 +33,7 @@ public:
 
 
 protected slots:
-    virtual void slotPropertiesChanged()= 0;
+    virtual void slotPropertiesChanged() = 0;
 
 protected:
     IMap * mapfile;

--- a/src/qmapshack/map/cache/CDiskCache.cpp
+++ b/src/qmapshack/map/cache/CDiskCache.cpp
@@ -146,7 +146,7 @@ void CDiskCache::slotCleanup()
 
     if(tmpSize > maxSizeBytes)
     {
-        files = dir.entryInfoList(QStringList("*.png"), QDir::Files, QDir::Time|QDir::Reversed);
+        files = dir.entryInfoList(QStringList("*.png"), QDir::Files, QDir::Time | QDir::Reversed);
         // if cache is still too large remove oldest files
         for(const QFileInfo &fileinfo : files)
         {

--- a/src/qmapshack/map/garmin/CGarminPolygon.cpp
+++ b/src/qmapshack/map/garmin/CGarminPolygon.cpp
@@ -385,7 +385,7 @@ void CGarminPolygon::bits_per_coord(quint8 base, quint8 bfirst, quint32& bx, qui
         signinfo.y_has_sign = true;
     }
 
-    by = bits_per_coord((base>>4) & 0x0F, signinfo.y_has_sign);
+    by = bits_per_coord((base >> 4) & 0x0F, signinfo.y_has_sign);
 
     // Determine extra bits.
     if(isVer2)
@@ -434,11 +434,11 @@ int CGarminPolygon::bits_per_coord(quint8 base, bool is_signed)
 
     if ( base <= 9 )
     {
-        n+= base;
+        n += base;
     }
     else
     {
-        n+= (2*base-9);
+        n += (2 * base - 9);
     }
 
     if ( is_signed )
@@ -467,13 +467,13 @@ CShiftReg::CShiftReg(const quint8* pData, quint32 n, quint32 bx, quint32 by, boo
     , extraBit(extra_bit)
 {
     // create bit masks
-    xmask = (xmask << (32-bx)) >> (32-bx);
-    ymask = (ymask << (32-by)) >> (32-by);
+    xmask = (xmask << (32 - bx)) >> (32 - bx);
+    ymask = (ymask << (32 - by)) >> (32 - by);
 
     xsign   <<= (bits_per_x - 1);
     ysign   <<= (bits_per_y - 1);
-    xsign2  = xsign<<1;
-    ysign2  = ysign<<1;
+    xsign2  = xsign << 1;
+    ysign2  = ysign << 1;
 
     // add sufficient bytes for the first coord. pair
     fill(bits_per_coord + si.sign_info_bits);

--- a/src/qmapshack/map/garmin/CGarminTyp.cpp
+++ b/src/qmapshack/map/garmin/CGarminTyp.cpp
@@ -157,7 +157,7 @@ bool CGarminTyp::parseDrawOrder(QDataStream& in, QList<quint32>& drawOrder)
     quint8 typ;
     quint32 subtyp;
 
-    int count=1;
+    int count = 1;
 
     const int N = sectOrder.arraySize / sectOrder.arrayModulo;
 
@@ -185,13 +185,13 @@ bool CGarminTyp::parseDrawOrder(QDataStream& in, QList<quint32>& drawOrder)
             quint32 exttyp = 0x010000 | (typ << 8);
             quint32 mask = 0x1;
 
-            for(n=0; n < 0x20; ++n)
+            for(n = 0; n < 0x20; ++n)
             {
                 if(subtyp & mask)
                 {
-                    drawOrder.push_front(exttyp|n);
+                    drawOrder.push_front(exttyp | n);
 #ifdef DBG
-                    qDebug() << QString("Type 0x%1 is priority %2").arg(exttyp|n, 0, 16).arg(count);
+                    qDebug() << QString("Type 0x%1 is priority %2").arg(exttyp | n, 0, 16).arg(count);
 #endif
                 }
                 mask = mask << 1;
@@ -203,7 +203,7 @@ bool CGarminTyp::parseDrawOrder(QDataStream& in, QList<quint32>& drawOrder)
 #ifdef DBG
     for(unsigned i = 0; i < drawOrder.size(); ++i)
     {
-        if(i && i%16 == 0)
+        if(i && i % 16 == 0)
         {
             printf(" \n");
         }
@@ -239,7 +239,7 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
     {
         quint16 t16_1 = 0, t16_2, subtyp;
         quint8 t8;
-        quint32 typ, offset=0;
+        quint32 typ, offset = 0;
         bool hasLocalization = false;
         bool hasTextColor = false;
         quint8 ctyp;
@@ -253,7 +253,7 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
         if (sectPolygons.arrayModulo == 5)
         {
             in >> t16_1 >> t16_2 >> t8;
-            offset = t16_2|(t8<<16);
+            offset = t16_2 | (t8 << 16);
         }
         else if (sectPolygons.arrayModulo == 4)
         {
@@ -272,7 +272,7 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
 
         if(t16_1 & 0x2000)
         {
-            typ = 0x10000|(typ << 8)|subtyp;
+            typ = 0x10000 | (typ << 8) | subtyp;
         }
 
         in.device()->seek(sectPolygons.dataOffset + offset);
@@ -364,7 +364,7 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
             xpmNight.setColor(0, qRgb(r, g, b) );
 
             decodeBitmap(in, xpmDay, 32, 32, 1);
-            memcpy(xpmNight.bits(), xpmDay.bits(), (32*32));
+            memcpy(xpmNight.bits(), xpmDay.bits(), (32 * 32));
             property.brushDay.setTextureImage(xpmDay);
             property.brushNight.setTextureImage(xpmNight);
             property.pen      = Qt::NoPen;
@@ -388,7 +388,7 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
             xpmNight.setColor(0, qRgb(r, g, b) );
 
             decodeBitmap(in, xpmDay, 32, 32, 1);
-            memcpy(xpmNight.bits(), xpmDay.bits(), (32*32));
+            memcpy(xpmNight.bits(), xpmDay.bits(), (32 * 32));
             property.brushDay.setTextureImage(xpmDay);
             property.brushNight.setTextureImage(xpmNight);
             property.pen      = Qt::NoPen;
@@ -412,7 +412,7 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
             xpmNight.setColor(0, qRgba(255, 255, 255, 0) );
 
             decodeBitmap(in, xpmDay, 32, 32, 1);
-            memcpy(xpmNight.bits(), xpmDay.bits(), (32*32));
+            memcpy(xpmNight.bits(), xpmDay.bits(), (32 * 32));
             property.brushDay.setTextureImage(xpmDay);
             property.brushNight.setTextureImage(xpmNight);
             property.pen      = Qt::NoPen;
@@ -452,7 +452,7 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
             xpmNight.setColor(0, qRgba(255, 255, 255, 0) );
 
             decodeBitmap(in, xpmDay, 32, 32, 1);
-            memcpy(xpmNight.bits(), xpmDay.bits(), (32*32));
+            memcpy(xpmNight.bits(), xpmDay.bits(), (32 * 32));
             property.brushDay.setTextureImage(xpmDay);
             property.brushNight.setTextureImage(xpmNight);
             property.pen      = Qt::NoPen;
@@ -491,11 +491,11 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
                 QByteArray str;
                 in >> langcode;
                 languages << langcode;
-                len -= 2*n;
+                len -= 2 * n;
                 while(len > 0)
                 {
                     in >> t8;
-                    len -= 2*n;
+                    len -= 2 * n;
 
                     if(t8 == 0)
                     {
@@ -558,7 +558,7 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
     {
         quint16 t16_1 = 0, t16_2, subtyp;
         quint8 t8_1, t8_2;
-        quint32 typ, offset=0;
+        quint32 typ, offset = 0;
         bool hasLocalization = false;
         bool hasTextColor = false;
         //bool renderMode = false;
@@ -571,7 +571,7 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
         if (sectPolylines.arrayModulo == 5)
         {
             in >> t16_1 >> t16_2 >> t8_1;
-            offset = t16_2|(t8_1<<16);
+            offset = t16_2 | (t8_1 << 16);
         }
         else if (sectPolylines.arrayModulo == 4)
         {
@@ -590,7 +590,7 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
 
         if(t16_1 & 0x2000)
         {
-            typ = 0x10000|(typ << 8)|subtyp;
+            typ = 0x10000 | (typ << 8) | subtyp;
         }
 
         in.device()->seek(sectPolylines.dataOffset + offset);
@@ -665,7 +665,7 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
                 in >> b >> g >> r;
                 xpm2.setColor(0, qRgb(r, g, b) );
                 decodeBitmap(in, xpm1, 32, rows, 1);
-                memcpy(xpm2.bits(), xpm1.bits(), (32*rows));
+                memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
                 property.imgDay     = xpm1;
                 property.imgNight   = xpm2;
                 property.hasPixmap  = true;
@@ -708,7 +708,7 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
                 in >> b >> g >> r;
                 xpm2.setColor(0, qRgb(r, g, b) );
                 decodeBitmap(in, xpm1, 32, rows, 1);
-                memcpy(xpm2.bits(), xpm1.bits(), (32*rows));
+                memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
                 property.imgDay     = xpm1;
                 property.imgNight   = xpm2;
                 property.hasPixmap  = true;
@@ -751,7 +751,7 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
                 xpm2.setColor(1, qRgb(r, g, b) );
                 xpm2.setColor(0, qRgba(255, 255, 255, 0) );
                 decodeBitmap(in, xpm1, 32, rows, 1);
-                memcpy(xpm2.bits(), xpm1.bits(), (32*rows));
+                memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
                 property.imgDay     = xpm1;
                 property.imgNight   = xpm2;
                 property.hasPixmap  = true;
@@ -822,7 +822,7 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
                 xpm2.setColor(1, qRgb(r, g, b) );
                 xpm2.setColor(0, qRgba(255, 255, 255, 0) );
                 decodeBitmap(in, xpm1, 32, rows, 1);
-                memcpy(xpm2.bits(), xpm1.bits(), (32*rows));
+                memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
                 property.imgDay     = xpm1;
                 property.imgNight   = xpm2;
                 property.hasPixmap  = true;
@@ -881,11 +881,11 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
                 QByteArray str;
                 in >> langcode;
                 languages << langcode;
-                len -= 2*n;
+                len -= 2 * n;
                 while(len > 0)
                 {
                     in >> t8_1;
-                    len -= 2*n;
+                    len -= 2 * n;
 
                     if(t8_1 == 0)
                     {
@@ -1142,11 +1142,11 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
     QTextCodec * codec = getCodec(codepage);
 
     const int N = sectPoints.arraySize / sectPoints.arrayModulo;
-    for (int element=0; element < N; element++)
+    for (int element = 0; element < N; element++)
     {
         quint16 t16_1 = 0, t16_2, subtyp;
         quint8 t8_1;
-        quint32 typ, offset=0;
+        quint32 typ, offset = 0;
         bool hasLocalization = false;
         bool hasTextColor = false;
         quint8 langcode;
@@ -1157,7 +1157,7 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
         if (sectPoints.arrayModulo == 5)
         {
             in >> t16_1 >> t16_2 >> t8_1;
-            offset = t16_2|(t8_1<<16);
+            offset = t16_2 | (t8_1 << 16);
         }
         else if (sectPoints.arrayModulo == 4)
         {
@@ -1176,7 +1176,7 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
 
         if(t16_1 & 0x2000)
         {
-            typ = 0x10000|(typ << 8)|subtyp;
+            typ = 0x10000 | (typ << 8) | subtyp;
         }
         else
         {
@@ -1193,7 +1193,7 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
         hasTextColor    = t8_1 & 0x08;
         t8_1            = t8_1 & 0x03;
 #ifdef DBG
-        qDebug() << "Point typ:" << hex << typ << "ctyp:" << ctyp <<"offset:" << (sectPoints.dataOffset + offset) << "orig data:" << t16_1;
+        qDebug() << "Point typ:" << hex << typ << "ctyp:" << ctyp << "offset:" << (sectPoints.dataOffset + offset) << "orig data:" << t16_1;
 #endif
 
         if(!decodeBppAndBytes(ncolors, w, ctyp, bpp, wbytes))
@@ -1209,7 +1209,7 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
         {
             if((ncolors == 0) && (bpp >= 16))
             {
-                ncolors = w*h;
+                ncolors = w * h;
             }
         }
 
@@ -1285,11 +1285,11 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
                 QByteArray str;
                 in >> langcode;
                 languages << langcode;
-                len -= 2*n;
+                len -= 2 * n;
                 while(len > 0)
                 {
                     in >> t8_1;
-                    len -= 2*n;
+                    len -= 2 * n;
 
                     if(t8_1 == 0)
                     {

--- a/src/qmapshack/map/garmin/Garmin.h
+++ b/src/qmapshack/map/garmin/Garmin.h
@@ -25,6 +25,6 @@
 #endif
 
 #define GARMIN_DEG(x) ((x) < 0x800000 ? (qreal)(x) * 360.0 / 16777216.0 : (qreal)((x) - 0x1000000) * 360.0 / 16777216.0)
-#define GARMIN_RAD(x) ((x) < 0x800000 ? (qreal)(x) * (2*M_PI) / 16777216.0 : (qreal)((x) - 0x1000000) * (2*M_PI) / 16777216.0)
+#define GARMIN_RAD(x) ((x) < 0x800000 ? (qreal)(x) * (2 * M_PI) / 16777216.0 : (qreal)((x) - 0x1000000) * (2 * M_PI) / 16777216.0)
 typedef quint8 quint24[3];
 #endif                           //GARMIN_H

--- a/src/qmapshack/map/garmin/IGarminStrTbl.cpp
+++ b/src/qmapshack/map/garmin/IGarminStrTbl.cpp
@@ -91,7 +91,7 @@ void IGarminStrTbl::readFile(CFileExt &file, quint32 offset, quint32 size, QByte
 
 #ifdef HOST_IS_64_BIT
     quint64 * p64 = (quint64*)data.data();
-    for(quint32 i = 0; i < size/8; ++i)
+    for(quint32 i = 0; i < size / 8; ++i)
     {
         *p64++ ^= mask64;
     }
@@ -99,7 +99,7 @@ void IGarminStrTbl::readFile(CFileExt &file, quint32 offset, quint32 size, QByte
     quint8 * p = (quint8*)p64;
 #else
     quint32 * p32 = (quint32*)data.data();
-    for(quint32 i = 0; i < size/4; ++i)
+    for(quint32 i = 0; i < size / 4; ++i)
     {
         *p32++ ^= mask32;
     }
@@ -162,7 +162,7 @@ QString IGarminStrTbl::processLabel(const char * buffer, unsigned lastSeperator)
 
     if(lastSeperator == 0x1F)
     {
-        bool ok =false;
+        bool ok = false;
         qreal ele = label.toDouble(&ok);
         if(ok)
         {

--- a/src/qmapshack/map/mapsforge/types.cpp
+++ b/src/qmapshack/map/mapsforge/types.cpp
@@ -18,7 +18,7 @@
 
 #include "types.h"
 
-QDataStream& operator>>(QDataStream& s, uintX& v)
+QDataStream & operator>>(QDataStream& s, uintX& v)
 {
     quint8 tmp;
     int shift   = 0;
@@ -27,7 +27,7 @@ QDataStream& operator>>(QDataStream& s, uintX& v)
     s >> tmp;
     while(tmp & 0x80)
     {
-        v.val |= (tmp & 0x7F)<<shift;
+        v.val |= (tmp & 0x7F) << shift;
         shift += 7;
         s >> tmp;
     }
@@ -46,7 +46,7 @@ QDataStream& operator>>(QDataStream& s, intX& v)
     s >> tmp;
     while(tmp & 0x80)
     {
-        v.val |= (tmp & 0x7F)<<shift;
+        v.val |= (tmp & 0x7F) << shift;
         shift += 7;
         s >> tmp;
     }

--- a/src/qmapshack/misc.h
+++ b/src/qmapshack/misc.h
@@ -19,9 +19,9 @@
 #ifndef MISC_H
 #define MISC_H
 
-#include <QCollator>
 #include <algorithm>
 #include <initializer_list>
+#include <QCollator>
 
 #define QMS_DELETE(p) \
     delete p; \

--- a/src/qmapshack/mouse/CMouseEditTrk.cpp
+++ b/src/qmapshack/mouse/CMouseEditTrk.cpp
@@ -72,7 +72,7 @@ void CMouseEditTrk::slotCopyToOrig()
 
     if(!isNewLine)
     {
-        QMessageBox::StandardButton button = QMessageBox::warning(canvas, tr("Warning!"), tr("This will replace all data of the original by a simple line of coordinates. All other data will be lost permanently."), QMessageBox::Ok|QMessageBox::Abort, QMessageBox::Ok);
+        QMessageBox::StandardButton button = QMessageBox::warning(canvas, tr("Warning!"), tr("This will replace all data of the original by a simple line of coordinates. All other data will be lost permanently."), QMessageBox::Ok | QMessageBox::Abort, QMessageBox::Ok);
 
         if(button != QMessageBox::Ok)
         {

--- a/src/qmapshack/mouse/CMouseMoveWpt.cpp
+++ b/src/qmapshack/mouse/CMouseMoveWpt.cpp
@@ -34,7 +34,7 @@
 CMouseMoveWpt::CMouseMoveWpt(CGisItemWpt &wpt, CGisDraw * gis, CCanvas *canvas, CMouseAdapter *mouse)
     : IMouse(gis, canvas, mouse),
     key(wpt.getKey()),
-    origPos(wpt.getPosition()*DEG_TO_RAD),
+    origPos(wpt.getPosition() * DEG_TO_RAD),
     radius(wpt.getProximity()),
     avoid(wpt.isNogo())
 {

--- a/src/qmapshack/mouse/CMouseNormal.cpp
+++ b/src/qmapshack/mouse/CMouseNormal.cpp
@@ -288,9 +288,9 @@ void CMouseNormal::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect 
         if(curPOI.pos != NOPOINTF)
         {
             const QSize s = curPOI.symbolSize;
-            const qint32 x = (qMax(qMax(s.width(), s.height()), 7)<<1) & 0xFFFFFFFE;
+            const qint32 x = (qMax(qMax(s.width(), s.height()), 7) << 1) & 0xFFFFFFFE;
 
-            p.drawImage(curPOI.pos - QPointF(x, x), QImage("://cursors/wptHighlightBlue.png").scaled(x<<1, x<<1, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+            p.drawImage(curPOI.pos - QPointF(x, x), QImage("://cursors/wptHighlightBlue.png").scaled(x << 1, x << 1, Qt::KeepAspectRatio, Qt::SmoothTransformation));
         }
 
         /*

--- a/src/qmapshack/mouse/CMouseRangeTrk.h
+++ b/src/qmapshack/mouse/CMouseRangeTrk.h
@@ -43,7 +43,7 @@ public:
     void mouseMoved(const QPoint& pos) override;
     void leftButtonDown(const QPoint& pos) override;
 
-private:    
+private:
     const QString owner;
     IGisItem::key_t key;
 

--- a/src/qmapshack/mouse/CMouseRuler.cpp
+++ b/src/qmapshack/mouse/CMouseRuler.cpp
@@ -325,7 +325,7 @@ void CMouseRuler::updateStatus(const QPolygonF &line)
 
     for(int n = 1; n < N; n++)
     {
-        QPointF pt1 = ruler[n-1];
+        QPointF pt1 = ruler[n - 1];
         QPointF pt2 = ruler[n];
 
         qreal a1, a2;
@@ -419,7 +419,7 @@ void CMouseRuler::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect &
         QRectF r(0, 0, 50, 50);
         for(int n = 1; n < N; n++)
         {
-            QPointF pt1 = ruler[n-1];
+            QPointF pt1 = ruler[n - 1];
             QPointF pt2 = ruler[n];
 
             qreal a1, a2;
@@ -432,10 +432,10 @@ void CMouseRuler::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect &
 
             if((n > 1) && scrOptRuler->toolShowAngle->isChecked())
             {
-                r.moveCenter(line[n-1]);
+                r.moveCenter(line[n - 1]);
 
-                QLineF seg1(line[n-2], line[n-1]);
-                QLineF seg2(line[n-1], line[n]);
+                QLineF seg1(line[n - 2], line[n - 1]);
+                QLineF seg2(line[n - 1], line[n]);
 
                 qreal angleStart = seg2.angle();
                 qreal angleSpan  = (seg2.angleTo(seg1) - 180);
@@ -443,7 +443,7 @@ void CMouseRuler::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect &
                 p.setPen(Qt::black);
                 p.drawArc(r, angleStart * 16, angleSpan * 16);
 
-                CDraw::text(QString("%1°").arg(qAbs(qRound(angleSpan))), p, line[n-1], Qt::black);
+                CDraw::text(QString("%1°").arg(qAbs(qRound(angleSpan))), p, line[n - 1], Qt::black);
             }
 
 
@@ -470,7 +470,7 @@ void CMouseRuler::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect &
                 str += QString(", %1°").arg(val);
             }
 
-            QLineF seg(line[n-1], line[n]);
+            QLineF seg(line[n - 1], line[n]);
             p.save();
             p.translate(seg.center().toPoint());
             p.rotate(a1 + ((a1 > 0) ? -90 : 90));

--- a/src/qmapshack/mouse/CMouseSelect.cpp
+++ b/src/qmapshack/mouse/CMouseSelect.cpp
@@ -134,7 +134,7 @@ void CMouseSelect::findItems(QList<IGisItem*>& items)
     scrOptSelect->toolCombineTrk->setEnabled(cntTrk > 1);
     scrOptSelect->toolActivityTrk->setEnabled(cntTrk > 0);
     scrOptSelect->toolColorTrk->setEnabled(cntTrk > 0);
-    scrOptSelect->toolEleWptTrk->setEnabled((cntWpt > 0)|(cntTrk > 0));
+    scrOptSelect->toolEleWptTrk->setEnabled((cntWpt > 0) | (cntTrk > 0));
 }
 
 void CMouseSelect::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect &rect)

--- a/src/qmapshack/mouse/CScrOptUnclutter.cpp
+++ b/src/qmapshack/mouse/CScrOptUnclutter.cpp
@@ -186,11 +186,11 @@ void CScrOptUnclutter::draw(QPainter& p)
             item.text = fm.boundingRect(item.name);
             if(cnt & 0x01)
             {
-                item.text.moveTopLeft(item.area.topRight() + QPoint( 17, fm.height()/2));
+                item.text.moveTopLeft(item.area.topRight() + QPoint( 17, fm.height() / 2));
             }
             else
             {
-                item.text.moveTopRight(item.area.topLeft() + QPoint(-17, fm.height()/2));
+                item.text.moveTopRight(item.area.topLeft() + QPoint(-17, fm.height() / 2));
             }
             item.text.adjust(-4, -3, 4, 3);
         }

--- a/src/qmapshack/mouse/IMouse.cpp
+++ b/src/qmapshack/mouse/IMouse.cpp
@@ -35,7 +35,7 @@ IMouse::~IMouse()
 
 void IMouse::mouseDragged(const QPoint &start, const QPoint &last, const QPoint &end)
 {
-    canvas->moveMap(end-last);
+    canvas->moveMap(end - last);
 }
 
 void IMouse::rightButtonDown(const QPoint &pos)

--- a/src/qmapshack/mouse/IScrOpt.cpp
+++ b/src/qmapshack/mouse/IScrOpt.cpp
@@ -47,7 +47,7 @@ void IScrOpt::moveTo(const QPoint& anchor)
     CCanvas * canvas = CMainWindow::self().getVisibleCanvas();
     if(canvas == nullptr)
     {
-        move(anchor + QPoint(-width()/2, SCR_OPT_OFFSET));
+        move(anchor + QPoint(-width() / 2, SCR_OPT_OFFSET));
         return;
     }
 
@@ -55,7 +55,7 @@ void IScrOpt::moveTo(const QPoint& anchor)
     qint32 xmax = canvas->width() - width();
     qint32 ymax = canvas->height() - height() - SCR_OPT_OFFSET;
 
-    QPoint pt = anchor + QPoint(-width()/2, SCR_OPT_OFFSET);
+    QPoint pt = anchor + QPoint(-width() / 2, SCR_OPT_OFFSET);
     pt.rx() = qMax(xmin, pt.x());
     pt.rx() = qMin(xmax, pt.x());
     pt.ry() = qMin(ymax, pt.y());

--- a/src/qmapshack/mouse/range/CScrOptRangeTool.cpp
+++ b/src/qmapshack/mouse/range/CScrOptRangeTool.cpp
@@ -108,11 +108,11 @@ void CScrOptRangeTool::slotCanvasResize(const QSize& sizeCanvas)
 
     QFontMetrics fm(CMainWindow::self().getMapFont());
 
-    qint32 w = qMin(fm.width("X") * 125, sizeCanvas.width()-60);
+    qint32 w = qMin(fm.width("X") * 125, sizeCanvas.width() - 60);
     qint32 h = height();
 
     setMinimumWidth(w);
-    origin = {(cw - w)>>1, ch - h - 10};
+    origin = {(cw - w) >> 1, ch - h - 10};
     move(origin);
     resize(w, height());
 }

--- a/src/qmapshack/plot/CPlotAxis.cpp
+++ b/src/qmapshack/plot/CPlotAxis.cpp
@@ -22,7 +22,7 @@
 
 inline qreal qLog10(qreal x)
 {
-    return qLn(x)/qLn(10);
+    return qLn(x) / qLn(10);
 }
 
 void CPlotAxis::setLimits(qreal min, qreal max)

--- a/src/qmapshack/plot/CPlotTrack.cpp
+++ b/src/qmapshack/plot/CPlotTrack.cpp
@@ -65,6 +65,6 @@ void CPlotTrack::paintEvent(QPaintEvent * e)
     p.setBrush(Qt::red);
     p.scale(scale.x(), scale.y());
     p.translate(-xoff, -yoff);
-    p.drawEllipse(pos, 5/scale.x(), 5/scale.x());
+    p.drawEllipse(pos, 5 / scale.x(), 5 / scale.x());
 }
 

--- a/src/qmapshack/plot/IPlot.cpp
+++ b/src/qmapshack/plot/IPlot.cpp
@@ -619,7 +619,7 @@ void IPlot::setSizes()
     scaleWidthX1 = showScale ? data->x().getScaleWidth( fm ) : 0;
     scaleWidthY1 = showScale ? data->y().getScaleWidth( fm ) : 0;
 
-    scaleWidthY1 = (scaleWidthX1/2) > scaleWidthY1 ? scaleWidthX1/2 : scaleWidthY1;
+    scaleWidthY1 = (scaleWidthX1 / 2) > scaleWidthY1 ? scaleWidthX1 / 2 : scaleWidthY1;
 
     fontWidth    = fm.maxWidth();
     fontHeight   = fm.height();
@@ -1214,7 +1214,7 @@ void IPlot::drawDecoration( QPainter &p )
                     f.setBold(true);
                     QFontMetrics fm(f);
                     QRect r = fm.boundingRect(tag.label);
-                    r.moveCenter(QPoint(ptx, top - fm.height()/2 - fm.descent()));
+                    r.moveCenter(QPoint(ptx, top - fm.height() / 2 - fm.descent()));
                     r.adjust(-3, -2, 3, 0);
 
                     p.setPen(Qt::NoPen);
@@ -1413,14 +1413,14 @@ void IPlot::drawActivities(QPainter& p)
         int d = (x2 - x1);
         if(d >= 20)
         {
-            int c = x1 + d/2;
+            int c = x1 + d / 2;
 
             p.setPen(QPen(desc.color, 1));
-            rectIconFrame.moveCenter(QPoint(c, icon_frame/2 + color_width));
+            rectIconFrame.moveCenter(QPoint(c, icon_frame / 2 + color_width));
             p.setBrush(QColor(255, 255, 255, 100));
             p.drawRoundedRect(rectIconFrame, RECT_RADIUS, RECT_RADIUS);
 
-            rectIcon.moveCenter(QPoint(c, icon_frame/2 + color_width));
+            rectIcon.moveCenter(QPoint(c, icon_frame / 2 + color_width));
             p.drawPixmap(rectIcon, QPixmap(desc.iconSmall));
         }
 
@@ -1428,7 +1428,7 @@ void IPlot::drawActivities(QPainter& p)
         p.drawLine(x1, bar_height, x1, qMin(0, bar_height - y1));
 
         p.setPen(QPen(desc.color, color_width, Qt::SolidLine, Qt::FlatCap));
-        p.drawLine(x1, color_width/2, x2, color_width/2);
+        p.drawLine(x1, color_width / 2, x2, color_width / 2);
     }
 
     p.restore();

--- a/src/qmapshack/plot/ITrack.cpp
+++ b/src/qmapshack/plot/ITrack.cpp
@@ -55,7 +55,7 @@ void ITrack::save(QImage& image, const CTrackData::trkpt_t * pTrkpt)
         p.setBrush(Qt::red);
         p.scale(scale.x(), scale.y());
         p.translate(-xoff, -yoff);
-        p.drawEllipse(pos, 5/scale.x(), 5/scale.x());
+        p.drawEllipse(pos, 5 / scale.x(), 5 / scale.x());
     }
     image = buffer;
 }
@@ -74,11 +74,11 @@ void ITrack::setupProjection(const QRectF& boundingBox)
         pjsrc = nullptr;
     }
 
-    if(boundingBox.top() > (60*DEG_TO_RAD))
+    if(boundingBox.top() > (60 * DEG_TO_RAD))
     {
         pjsrc = pj_init_plus("+init=epsg:32661");
     }
-    else if(boundingBox.bottom() < (-60*DEG_TO_RAD))
+    else if(boundingBox.bottom() < (-60 * DEG_TO_RAD))
     {
         pjsrc = pj_init_plus("+init=epsg:32761");
     }
@@ -149,18 +149,18 @@ void ITrack::updateData()
         scale.rx() = (w2 - 10) / w1;
         scale.ry() = -scale.x();
         xoff = 0;
-        yoff = -((h2 - 10)/scale.y() + h1) / 2;
+        yoff = -((h2 - 10) / scale.y() + h1) / 2;
     }
     else
     {
         scale.ry() = (-h2 + 10) / h1;
         scale.rx() = -scale.y();
-        xoff = -((w2 - 10)/scale.x() - w1) / 2;
+        xoff = -((w2 - 10) / scale.x() - w1) / 2;
         yoff = 0;
     }
 
-    xoff += r1.left()   - 5/scale.x();
-    yoff += r1.bottom() - 5/scale.y();
+    xoff += r1.left()   - 5 / scale.x();
+    yoff += r1.bottom() - 5 / scale.y();
 
     needsRedraw = true;
 }
@@ -188,7 +188,7 @@ void ITrack::draw()
     p.setBrush(QColor(255, 255, 255, 255));
     PAINT_ROUNDED_RECT(p, buffer.rect().adjusted(1, 1, -1, -1));
 
-    p.setPen(QPen(Qt::darkBlue, 2/scale.x()));
+    p.setPen(QPen(Qt::darkBlue, 2 / scale.x()));
     p.scale(scale.x(), scale.y());
     p.translate(-xoff, -yoff);
     p.drawPolyline(line);

--- a/src/qmapshack/print/CPrintDialog.cpp
+++ b/src/qmapshack/print/CPrintDialog.cpp
@@ -145,7 +145,7 @@ void CPrintDialog::slotUpdateMetrics()
     qreal h = rectPrinterPage.height() * scale;
 
     // the page rectangle
-    QRectF rectTile(1, 1, w-2, h-2);
+    QRectF rectTile(1, 1, w - 2, h - 2);
 
     // paint page matrix
     QPainter p(&img);
@@ -156,7 +156,7 @@ void CPrintDialog::slotUpdateMetrics()
     {
         for(int x = 0; x < qCeil(xPages); x++)
         {
-            rectTile.moveCenter(QPointF(w/2 + x * w, h/2 + y * h));
+            rectTile.moveCenter(QPointF(w / 2 + x * w, h / 2 + y * h));
             p.drawRect(rectTile);
         }
     }
@@ -171,8 +171,8 @@ void CPrintDialog::slotUpdateMetrics()
 
     labelPages->setPixmap(img);
     labelPagesText->setText(tr("Pages: %1 x %2").arg(xPages, 0, 'f', 1).arg(yPages, 0, 'f', 1));
-    QString labelMapInfoText = tr("Zoom with mouse wheel on map below to change resolution:\n\n%1x%2 pixel\nx: %3 m/px\ny: %4 m/px").arg(rectSelAreaPixel.width()).arg(rectSelAreaPixel.height()).arg(mWidth/rectSelAreaPixel.width(), 0, 'f', 1).arg(mHeight/rectSelAreaPixel.height(), 0, 'f', 1);
-    labelMapInfoText += tr("\n This equals to a scale of approx. 1:") + QString::number((int)(mWidth*1000/(xPages*xPageSizeMm)));
+    QString labelMapInfoText = tr("Zoom with mouse wheel on map below to change resolution:\n\n%1x%2 pixel\nx: %3 m/px\ny: %4 m/px").arg(rectSelAreaPixel.width()).arg(rectSelAreaPixel.height()).arg(mWidth / rectSelAreaPixel.width(), 0, 'f', 1).arg(mHeight / rectSelAreaPixel.height(), 0, 'f', 1);
+    labelMapInfoText += tr("\n This equals to a scale of approx. 1:") + QString::number((int)(mWidth * 1000 / (xPages * xPageSizeMm)));
     labelMapInfo->setText(labelMapInfoText);
 }
 
@@ -300,5 +300,5 @@ void CPrintDialog::slotSave()
 
 void CPrintDialog::slotScaleOnAllChanged(bool checked)
 {
-    printScaleOnAllPages=checked;
+    printScaleOnAllPages = checked;
 }

--- a/src/qmapshack/print/CPrintDialog.h
+++ b/src/qmapshack/print/CPrintDialog.h
@@ -65,7 +65,7 @@ private:
     qreal xPages = 0.0; //< number of pages in x dimension
     qreal yPages = 0.0; //< number of pages in y dimension
 
-    bool printScaleOnAllPages=false;
+    bool printScaleOnAllPages = false;
 };
 
 #endif //CPRINTDIALOG_H

--- a/src/qmapshack/qlgt/CQlgtTrack.cpp
+++ b/src/qmapshack/qlgt/CQlgtTrack.cpp
@@ -22,7 +22,7 @@
 #include <QtWidgets>
 
 
-QDataStream& operator >>(QDataStream& s, CFlags& flag)
+QDataStream & operator >>(QDataStream& s, CFlags& flag)
 {
     quint32 f;
     s >> f;

--- a/src/qmapshack/qlgt/CQlgtTrack.h
+++ b/src/qmapshack/qlgt/CQlgtTrack.h
@@ -27,7 +27,7 @@ class CQlgtWpt;
 class CFlags
 {
 public:
-    CFlags(quint32 f=0)
+    CFlags(quint32 f = 0)
     {
         flags = f;
         changed = true;
@@ -49,24 +49,24 @@ public:
     }
     quint32 operator  &(quint32 f) const
     {
-        return flags&f;
+        return flags & f;
     }
     quint32 operator |=(quint32 f)
     {
-        if ( flags != (flags|f) )
+        if ( flags != (flags | f) )
         {
             changed = true;
         }
-        flags|=f;
+        flags |= f;
         return flags;
     }
     quint32 operator &=(quint32 f)
     {
-        if ( flags != (flags&f) )
+        if ( flags != (flags & f) )
         {
             changed = true;
         }
-        flags&=f;
+        flags &= f;
         return flags;
     }
     quint32 operator >>(quint32 & f)

--- a/src/qmapshack/qlgt/CQmsDb.cpp
+++ b/src/qmapshack/qlgt/CQmsDb.cpp
@@ -44,7 +44,7 @@ CQmsDb::CQmsDb(const QString &filename, CImportDatabase *parent)
 {
     if(QFile::exists(filename))
     {
-        int res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Existing file..."), tr("Remove existing %1?").arg(filename), QMessageBox::Ok|QMessageBox::Abort, QMessageBox::Ok);
+        int res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Existing file..."), tr("Remove existing %1?").arg(filename), QMessageBox::Ok | QMessageBox::Abort, QMessageBox::Ok);
         if(res != QMessageBox::Ok)
         {
             return;
@@ -266,7 +266,7 @@ quint64 CQmsDb::store(IGisItem& item)
     query.bindValue(":icon",    buffer.data());
     query.bindValue(":name",    item.getName());
     query.bindValue(":date",    item.getTimestamp());
-    query.bindValue(":comment", item.getInfo(IGisItem::eFeatureShowName|IGisItem::eFeatureShowFullText));
+    query.bindValue(":comment", item.getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowFullText));
     query.bindValue(":data", data);
     query.bindValue(":hash", item.getHash());
     QUERY_EXEC(return 0);

--- a/src/qmapshack/qlgt/converter.cpp
+++ b/src/qmapshack/qlgt/converter.cpp
@@ -127,7 +127,7 @@ CGisItemWpt::CGisItemWpt(const CQlgtWpt& wpt1, IGisProject * project)
 
         images << image;
     }
-    boundingRect = QRectF(QPointF(wpt.lon, wpt.lat)*DEG_TO_RAD, QPointF(wpt.lon, wpt.lat)*DEG_TO_RAD);
+    boundingRect = QRectF(QPointF(wpt.lon, wpt.lat) * DEG_TO_RAD, QPointF(wpt.lon, wpt.lat) * DEG_TO_RAD);
     setIcon();
     genKey();
     setupHistory();

--- a/src/qmapshack/realtime/CRtWorkspace.cpp
+++ b/src/qmapshack/realtime/CRtWorkspace.cpp
@@ -259,7 +259,7 @@ void CRtWorkspace::slotAddSource()
 
 void CRtWorkspace::slotDeleteSource()
 {
-    int res = QMessageBox::question(this, tr("Delete Source..."), tr("Do you really want to remove the realtime source?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+    int res = QMessageBox::question(this, tr("Delete Source..."), tr("Do you really want to remove the realtime source?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if(res != QMessageBox::Yes)
     {
         return;

--- a/src/qmapshack/realtime/IRtInfo.cpp
+++ b/src/qmapshack/realtime/IRtInfo.cpp
@@ -59,7 +59,7 @@ void IRtInfo::slotResetRecord()
         return;
     }
 
-    int res = QMessageBox::question(this, tr("Reset record..."), tr("Do you really want to reset the current record?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+    int res = QMessageBox::question(this, tr("Reset record..."), tr("Do you really want to reset the current record?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if(res == QMessageBox::Yes)
     {
         record->reset();

--- a/src/qmapshack/realtime/gpstether/CRtGpsTether.cpp
+++ b/src/qmapshack/realtime/gpstether/CRtGpsTether.cpp
@@ -47,7 +47,7 @@ void CRtGpsTether::registerWithTreeWidget()
     if(tree != nullptr)
     {
         QTreeWidgetItem * itemInfo = new QTreeWidgetItem(this);
-        itemInfo->setFlags(Qt::ItemIsEnabled|Qt::ItemNeverHasChildren);
+        itemInfo->setFlags(Qt::ItemIsEnabled | Qt::ItemNeverHasChildren);
         info = new CRtGpsTetherInfo(*this, tree);
         connect(info, &CRtGpsTetherInfo::sigChanged, this, &CRtGpsTether::sigChanged);
 

--- a/src/qmapshack/realtime/gpstether/CRtGpsTetherInfo.cpp
+++ b/src/qmapshack/realtime/gpstether/CRtGpsTetherInfo.cpp
@@ -309,7 +309,7 @@ void CRtGpsTetherInfo::nmeaGSV(const QStringList& tokens)
 
 void CRtGpsTetherInfo::nmeaGSA(const QStringList& tokens)
 {
-    const QString& id= tokens[0];
+    const QString& id = tokens[0];
     if(tokens.count() < 18)
     {
         qDebug() << id << "too short";
@@ -330,7 +330,7 @@ void CRtGpsTetherInfo::nmeaGSA(const QStringList& tokens)
 
 void CRtGpsTetherInfo::nmeaRMC(const QStringList& tokens)
 {
-    const QString& id= tokens[0];
+    const QString& id = tokens[0];
     if(tokens.count() < 12)
     {
         qDebug() << id << "too short";
@@ -344,20 +344,20 @@ void CRtGpsTetherInfo::nmeaRMC(const QStringList& tokens)
         return;
     }
     rmc.isValid = true;
-    rmc.datetime = QDateTime::fromString(tokens[1]+tokens[9], "hhmmss.00ddMMyy").addYears(100);
+    rmc.datetime = QDateTime::fromString(tokens[1] + tokens[9], "hhmmss.00ddMMyy").addYears(100);
     rmc.datetime.setTimeSpec(Qt::UTC);
 
     {
         qreal tmp = tokens[3].toDouble();
-        qreal val = int(tmp/100);
-        val += (tmp - val*100)/60;
+        qreal val = int(tmp / 100);
+        val += (tmp - val * 100) / 60;
         rmc.lat = tokens[4] == "N" ? val : -val;
     }
 
     {
         qreal tmp = tokens[5].toDouble();
-        qreal val = int(tmp/100);
-        val += (tmp - val*100)/60;
+        qreal val = int(tmp / 100);
+        val += (tmp - val * 100) / 60;
         rmc.lon = tokens[6] == "E" ? val : -val;
     }
 
@@ -389,15 +389,15 @@ void CRtGpsTetherInfo::nmeaGGA(const QStringList& tokens)
 
     {
         qreal tmp = tokens[2].toDouble();
-        qreal val = int(tmp/100);
-        val += (tmp - val*100)/60;
+        qreal val = int(tmp / 100);
+        val += (tmp - val * 100) / 60;
         gga.lat = tokens[3] == "N" ? val : -val;
     }
 
     {
         qreal tmp = tokens[4].toDouble();
-        qreal val = int(tmp/100);
-        val += (tmp - val*100)/60;
+        qreal val = int(tmp / 100);
+        val += (tmp - val * 100) / 60;
         gga.lon = tokens[5] == "E" ? val : -val;
     }
     gga.quality = tokens[6].toInt();

--- a/src/qmapshack/realtime/opensky/CRtOpenSky.cpp
+++ b/src/qmapshack/realtime/opensky/CRtOpenSky.cpp
@@ -56,7 +56,7 @@ void CRtOpenSky::registerWithTreeWidget()
     if(tree != nullptr)
     {
         QTreeWidgetItem * itemInfo = new QTreeWidgetItem(this);
-        itemInfo->setFlags(Qt::ItemIsEnabled|Qt::ItemNeverHasChildren);
+        itemInfo->setFlags(Qt::ItemIsEnabled | Qt::ItemNeverHasChildren);
         info = new CRtOpenSkyInfo(*this, tree);
         tree->setItemWidget(itemInfo, eColumnWidget, info);
         emit sigChanged();
@@ -207,7 +207,7 @@ void CRtOpenSky::fastDraw(QPainter& p, const QRectF& viewport, CRtDraw *rt)
         text += "<tr><td>" + tr("latitude:")        + "</td><td>" + QString::number(aircraft.latitude) + "°</td></tr>";
         text += "<tr><td>" + tr("geo. alt.:")       + "</td><td>" + QString::number(aircraft.geoAltitude) + "m</td></tr>";
         text += "<tr><td>" + tr("on ground:")       + "</td><td>" + QString::number(aircraft.onGround) + "</td></tr>";
-        text += "<tr><td>" + tr("velocity:")        + "</td><td>" + QString::number(aircraft.velocity*3.6) + "km/h</td></tr>";
+        text += "<tr><td>" + tr("velocity:")        + "</td><td>" + QString::number(aircraft.velocity * 3.6) + "km/h</td></tr>";
         text += "<tr><td>" + tr("heading:")         + "</td><td>" + QString::number(aircraft.heading) + "°</td></tr>";
         text += "<tr><td>" + tr("vert. rate:")      + "</td><td>" + QString::number(aircraft.verticalRate) + "m/s</td></tr>";
         text += "<tr><td>" + tr("baro. alt.:")      + "</td><td>" + QString::number(aircraft.baroAltitude) + "m</td></tr>";

--- a/src/qmapshack/setup/CAppSetupMac.cpp
+++ b/src/qmapshack/setup/CAppSetupMac.cpp
@@ -33,7 +33,7 @@ void CAppSetupMac::extendPath()
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     QStringList envlist = env.toStringList();
     QString value = "";
-    for(int i=0; i < envlist.size(); i++)
+    for(int i = 0; i < envlist.size(); i++)
     {
         QString entry = envlist[i];
         if(entry.startsWith("PATH="))
@@ -42,7 +42,7 @@ void CAppSetupMac::extendPath()
 
             if(index != -1)
             {
-                value = entry.right(entry.length() - (index+1)) + ":";
+                value = entry.right(entry.length() - (index + 1)) + ":";
             }
             break;
         }
@@ -149,7 +149,7 @@ void CAppSetupMac::migrateDirContent(QString dest)
         wdir.mkdir(newdir);
         qDebug() << "directory created" << newdir;
 
-        qDebug() << "migrate data from "<<dirSource.absolutePath() << "to" << dirDest.absolutePath();
+        qDebug() << "migrate data from " << dirSource.absolutePath() << "to" << dirDest.absolutePath();
         QDir mvDir;
         if(!mvDir.rename(dirSource.absolutePath(), dirDest.absolutePath()))
         {

--- a/src/qmapshack/setup/IAppSetup.cpp
+++ b/src/qmapshack/setup/IAppSetup.cpp
@@ -102,11 +102,11 @@ void IAppSetup::prepareTranslator(QString translationPath, QString translationPr
     if (qtTranslator->load(translationPrefix + locale, translationPath))
     {
         app->installTranslator(qtTranslator);
-        qDebug() << "using file '"+ translationPath + "/" + translationPrefix + locale + ".qm' for translations.";
+        qDebug() << "using file '" + translationPath + "/" + translationPrefix + locale + ".qm' for translations.";
     }
     else
     {
-        qWarning() << "no file found for translations '"+ translationPath + "/" + translationPrefix + locale + "' (using default).";
+        qWarning() << "no file found for translations '" + translationPath + "/" + translationPrefix + locale + "' (using default).";
     }
 }
 

--- a/src/qmapshack/units/CUnitAviation.cpp
+++ b/src/qmapshack/units/CUnitAviation.cpp
@@ -68,7 +68,7 @@ void CUnitAviation::meter2area(qreal meter, QString& val, QString& unit) const /
     }
     else
     {
-        val.sprintf("%1.2f", meter / (1/nauticalMilePerMeter * 1/nauticalMilePerMeter));
+        val.sprintf("%1.2f", meter / (1 / nauticalMilePerMeter * 1 / nauticalMilePerMeter));
         unit = "nm²";
     }
 }
@@ -82,7 +82,7 @@ void CUnitAviation::meter2area(qreal meter, qreal& val, QString& unit) const /* 
     }
     else
     {
-        val= meter / (1/nauticalMilePerMeter * 1/nauticalMilePerMeter);
+        val = meter / (1 / nauticalMilePerMeter * 1 / nauticalMilePerMeter);
         unit = "nm²";
     }
 }

--- a/src/qmapshack/units/CUnitImperial.cpp
+++ b/src/qmapshack/units/CUnitImperial.cpp
@@ -87,7 +87,7 @@ void CUnitImperial::meter2area(qreal meter, QString& val, QString& unit) const /
     }
     else
     {
-        val.sprintf("%1.2f", meter / (1/milePerMeter * 1/milePerMeter));
+        val.sprintf("%1.2f", meter / (1 / milePerMeter * 1 / milePerMeter));
         unit = "mi²";
     }
 }
@@ -101,7 +101,7 @@ void CUnitImperial::meter2area(qreal meter, qreal& val, QString& unit) const /* 
     }
     else
     {
-        val= meter / (1/milePerMeter * 1/milePerMeter);
+        val = meter / (1 / milePerMeter * 1 / milePerMeter);
         unit = "mi²";
     }
 }

--- a/src/qmapshack/units/CUnitNautic.cpp
+++ b/src/qmapshack/units/CUnitNautic.cpp
@@ -75,7 +75,7 @@ void CUnitNautic::meter2speed(qreal meter, qreal& val, QString& unit) const /* o
     }
     else
     {
-        val=meter * speedFactor;
+        val = meter * speedFactor;
         unit = speedUnit;
     }
 }
@@ -103,7 +103,7 @@ void CUnitNautic::meter2area(qreal meter, qreal& val, QString& unit) const /* ov
     }
     else
     {
-        val= meter / (1852 * 1852);
+        val = meter / (1852 * 1852);
         unit = "nm²";
     }
 }

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -18,10 +18,10 @@
 **********************************************************************************************/
 #include "CMainWindow.h"
 #include "GeoMath.h"
+#include "units/CUnitAviation.h"
 #include "units/CUnitImperial.h"
 #include "units/CUnitMetric.h"
 #include "units/CUnitNautic.h"
-#include "units/CUnitAviation.h"
 
 #include <proj_api.h>
 #include <QtWidgets>
@@ -422,7 +422,7 @@ const char * IUnit::tblTimezone[] =
     0
 };
 
-const int N_TIMEZONES = sizeof(IUnit::tblTimezone)/sizeof(const char*);
+const int N_TIMEZONES = sizeof(IUnit::tblTimezone) / sizeof(const char*);
 
 const QRegExp IUnit::reCoord1("^\\s*([N|S]){1}\\W*([0-9]+)\\W*([0-9]+\\.[0-9]+)\\s+([E|W|O]){1}\\W*([0-9]+)\\W*([0-9]+\\.[0-9]+)\\s*$");
 
@@ -582,7 +582,7 @@ void IUnit::slope2string(qreal slope, QString &val, QString &unit)
         break;
 
     case eSlopePercent:
-        val.sprintf("%.0f", qTan(qDegreesToRadians(slope))*100.0);
+        val.sprintf("%.0f", qTan(qDegreesToRadians(slope)) * 100.0);
         unit = "%";
         break;
     }
@@ -612,7 +612,7 @@ void IUnit::slope2unit(qreal slope, qreal &val, QString &unit)
         break;
 
     case eSlopePercent:
-        val = qTan(qDegreesToRadians(slope))*100.0;
+        val = qTan(qDegreesToRadians(slope)) * 100.0;
         unit = "%";
         break;
     }
@@ -718,7 +718,7 @@ QDateTime IUnit::parseTimestamp(const QString &timetext, int& tzoffset)
     i = timetext.indexOf(".");
     if (i != NOIDX)
     {
-        if(timetext[i+1] == '0')
+        if(timetext[i + 1] == '0')
         {
             format += ".zzz";
         }
@@ -803,7 +803,7 @@ QString IUnit::datetime2string(const QDateTime& time, bool shortDate, const QPoi
     }
 
     QDateTime tmp = time.toTimeZone(tz);
-    return tmp.toString((shortDate|useShortFormat) ? Qt::ISODate : Qt::SystemLocaleLongDate);
+    return tmp.toString((shortDate | useShortFormat) ? Qt::ISODate : Qt::SystemLocaleLongDate);
 }
 
 QByteArray IUnit::pos2timezone(const QPointF& pos)
@@ -983,7 +983,7 @@ bool IUnit::isValidCoordString(const QString& str)
     return false;
 }
 
-QMap<QString, qreal> IUnit::timeToMKSMap={
+QMap<QString, qreal> IUnit::timeToMKSMap = {
     {"s", 1.0},
     {"min", 60.0},
     {"h", 3600.0},
@@ -992,41 +992,41 @@ QMap<QString, qreal> IUnit::timeToMKSMap={
     {"ч", 3600.0},
 };
 
-QMap<QString, qreal> IUnit::distanceToMKSMap={
+QMap<QString, qreal> IUnit::distanceToMKSMap = {
     {"m", 1.0},
     {"km", 1000.0},
-    {"mi", 1.0/CUnitImperial::milePerMeter},
-    {"ft", 1.0/CUnitImperial::footPerMeter},
+    {"mi", 1.0 / CUnitImperial::milePerMeter},
+    {"ft", 1.0 / CUnitImperial::footPerMeter},
     {"м", 1.0},
     {"км", 1000.0},
 };
 
-QMap<QString, qreal> IUnit::speedToMKSMap={
+QMap<QString, qreal> IUnit::speedToMKSMap = {
     {"m/s", 1.0},
-    {"m/min", 1.0/60},
-    {"m/h", 1.0/3600},
+    {"m/min", 1.0 / 60},
+    {"m/h", 1.0 / 3600},
     {"km/s", 1000.0},
-    {"km/min", 1000.0/60},
-    {"km/h", 1000.0/3600},
-    {"mi/s", 1.0/CUnitImperial::milePerMeter},
-    {"mi/min", 1.0/(CUnitImperial::milePerMeter*60)},
-    {"mi/h", 1.0/(CUnitImperial::milePerMeter*3600)},
-    {"ft/s", 1.0/CUnitImperial::footPerMeter},
-    {"ft/min", 1.0/(CUnitImperial::footPerMeter*60)},
-    {"ft/h", 1.0/(CUnitImperial::footPerMeter*3600)},
+    {"km/min", 1000.0 / 60},
+    {"km/h", 1000.0 / 3600},
+    {"mi/s", 1.0 / CUnitImperial::milePerMeter},
+    {"mi/min", 1.0 / (CUnitImperial::milePerMeter*60)},
+    {"mi/h", 1.0 / (CUnitImperial::milePerMeter*3600)},
+    {"ft/s", 1.0 / CUnitImperial::footPerMeter},
+    {"ft/min", 1.0 / (CUnitImperial::footPerMeter*60)},
+    {"ft/h", 1.0 / (CUnitImperial::footPerMeter*3600)},
     {"м/с", 1.0},
-    {"м/мин", 1.0/60},
-    {"м/ч", 1.0/3600},
+    {"м/мин", 1.0 / 60},
+    {"м/ч", 1.0 / 3600},
     {"км/с", 1000.0},
-    {"км/мин", 1000.0/60},
-    {"км/ч", 1000.0/3600},
+    {"км/мин", 1000.0 / 60},
+    {"км/ч", 1000.0 / 3600},
 };
 
-QMap<QString, qreal> IUnit::areaToMKSMap={
+QMap<QString, qreal> IUnit::areaToMKSMap = {
     {"m²", 1.0},
-    {"km²", 1000.0*1000},
-    {"mi²", 1.0/(CUnitImperial::milePerMeter*CUnitImperial::milePerMeter)},
-    {"ft²", 1.0/(CUnitImperial::footPerMeter*CUnitImperial::footPerMeter)},
+    {"km²", 1000.0 * 1000},
+    {"mi²", 1.0 / (CUnitImperial::milePerMeter*CUnitImperial::milePerMeter)},
+    {"ft²", 1.0 / (CUnitImperial::footPerMeter*CUnitImperial::footPerMeter)},
     {"м²", 1.0},
-    {"км²", 1000.0*1000},
+    {"км²", 1000.0 * 1000},
 };

--- a/src/qmapshack/widgets/CColorLegend.cpp
+++ b/src/qmapshack/widgets/CColorLegend.cpp
@@ -116,7 +116,7 @@ int CColorLegend::paintLabel(QPainter &p, qreal value)
     p.drawLine(posX, posY - fontHeight / 2 + 1, posX + 2, posY - fontHeight / 2 + 1);
 
     if(value == minimum || value == maximum
-       || (posY > colorRect.top() + 3*fontHeight / 2 && posY < colorRect.bottom() - fontHeight / 2))
+       || (posY > colorRect.top() + 3 * fontHeight / 2 && posY < colorRect.bottom() - fontHeight / 2))
     {
         posX += 5;
         int precision = !((int)value == value);     // returns 0 or 1
@@ -196,7 +196,7 @@ void CColorLegend::paintEvent(QPaintEvent *event)
         qreal step           = legendRound(delta / 8, 0);
         qreal roundedMinimum = legendRound(minimum, delta > 60 ? -1 : 0);
 
-        for(qreal v = roundedMinimum; v < maximum; v+= step)
+        for(qreal v = roundedMinimum; v < maximum; v += step)
         {
             reqWidth = qMax(paintLabel(p, v), reqWidth);
         }
@@ -209,7 +209,7 @@ void CColorLegend::paintEvent(QPaintEvent *event)
 
         if(val != NOFLOAT)
         {
-            qreal y = qFloor(colorRect.bottom() - (val - minimum) * (colorRect.height()-1)/(maximum - minimum));
+            qreal y = qFloor(colorRect.bottom() - (val - minimum) * (colorRect.height() - 1) / (maximum - minimum));
             p.setPen(QPen(Qt::darkGray, 2));
             p.drawLine(colorRect.left() + 2, y, colorRect.right() - 2, y);
         }

--- a/src/qmapshack/widgets/CFadingIcon.cpp
+++ b/src/qmapshack/widgets/CFadingIcon.cpp
@@ -32,7 +32,7 @@ CFadingIcon::CFadingIcon(const QPoint& pt, const QString &resource, QWidget *par
 
     connect(timer, &QTimer::timeout, this, &CFadingIcon::slotTimeout);
 
-    move(pt.x() - icon.width()/2, pt.y() - icon.height()/2);
+    move(pt.x() - icon.width() / 2, pt.y() - icon.height() / 2);
     show();
 }
 

--- a/src/qmapshack/widgets/CPhotoAlbum.cpp
+++ b/src/qmapshack/widgets/CPhotoAlbum.cpp
@@ -188,7 +188,7 @@ void CPhotoAlbum::updateView()
 
         QRect r     = tmp.rect();
 
-        int yoff = (height()- r.height()) / 2;
+        int yoff = (height() - r.height()) / 2;
 
         p.save();
         p.translate(xoff, yoff);

--- a/src/qmapshack/widgets/CScaleLabel.cpp
+++ b/src/qmapshack/widgets/CScaleLabel.cpp
@@ -55,7 +55,7 @@ void CScaleLabel::paintEvent(QPaintEvent *e)
     int xBar = HOR_MARGIN;
     int yBar = (h - BAR_HEIGHT) / 2;
 
-    QRect bar(xBar, yBar, w-2*HOR_MARGIN, BAR_HEIGHT);
+    QRect bar(xBar, yBar, w - 2 * HOR_MARGIN, BAR_HEIGHT);
     p.setPen(Qt::darkBlue);
     p.setBrush(Qt::white);
     p.drawRect(bar);

--- a/src/qmapshack/widgets/CSelectDoubleListWidget.cpp
+++ b/src/qmapshack/widgets/CSelectDoubleListWidget.cpp
@@ -107,7 +107,7 @@ void CSelectDoubleListWidget::setLabelSelected(const QString & label) const
 const QList<QListWidgetItem *> CSelectDoubleListWidget::selected() const
 {
     QList<QListWidgetItem *> selected;
-    for (int i=0; i < listSelected->count(); i++)
+    for (int i = 0; i < listSelected->count(); i++)
     {
         selected << listSelected->item(i);
     }
@@ -157,7 +157,7 @@ void CSelectDoubleListWidget::slotRemove() const
         if (filter == nullptr || filter->shouldBeMoved(item))
         {
             int index = -1;
-            for (int i = available.indexOf(item)-1; i >= 0; i--)
+            for (int i = available.indexOf(item) - 1; i >= 0; i--)
             {
                 index = listAvailable->row(available.at(i));
                 if (index >= 0)
@@ -186,13 +186,13 @@ void CSelectDoubleListWidget::slotUp() const
     }
     std::sort(indices.begin(), indices.end());
 
-    int i=0;
+    int i = 0;
     for (int index : indices)
     {
         if (index > i)
         {
-            listSelected->insertItem(index-1, listSelected->takeItem(index));
-            listSelected->setCurrentRow(index-1, QItemSelectionModel::Select);
+            listSelected->insertItem(index - 1, listSelected->takeItem(index));
+            listSelected->setCurrentRow(index - 1, QItemSelectionModel::Select);
         }
         i++;
     }
@@ -208,13 +208,13 @@ void CSelectDoubleListWidget::slotDown() const
     }
     std::sort(indices.begin(), indices.end(), [] (int a, int b) { return a > b; });
 
-    int i=listSelected->count()-1;
+    int i = listSelected->count() - 1;
     for (int index : indices)
     {
         if (index < i)
         {
-            listSelected->insertItem(index+1, listSelected->takeItem(index));
-            listSelected->setCurrentRow(index+1, QItemSelectionModel::Select);
+            listSelected->insertItem(index + 1, listSelected->takeItem(index));
+            listSelected->setCurrentRow(index + 1, QItemSelectionModel::Select);
         }
         i--;
     }

--- a/src/qmapshack/widgets/CTextEditWidget.cpp
+++ b/src/qmapshack/widgets/CTextEditWidget.cpp
@@ -250,7 +250,7 @@ void CTextEditWidget::textStyle(int styleIndex)
             QTextListFormat::ListUpperRoman
         };
 
-        if( (unsigned) styleIndex <= sizeof(indexToFormat)/sizeof(QTextListFormat::Style))
+        if( (unsigned) styleIndex <= sizeof(indexToFormat) / sizeof(QTextListFormat::Style))
         {
             style = indexToFormat[styleIndex - 1];
         }


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#165

**Describe roughly what you have done:**

On OS X systems files to open are not passed on the comandline. They
are sent by system event. I installed  an event filter for the QFileOpenEvent.

**What steps have to be done to perform a simple smoke test:**

Double click on a GPX file on OSX should open the file with QMapShack

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
