### PR TITLE
[QMS-164] Workspace filter is not applied to newly loaded projects

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-151] Missing tooltip in route toolbar
 [QMS-153] Improved French translation
 [QMS-156] Request to unmount systemdrive on startup
+[QMS-164] Workspace filter is not applied to newly loaded projects
 [QMS-165] OSX: GIS files not loaded when clicked
 
 V1.14.1

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -2126,6 +2126,7 @@ bool CGisListWks::event(QEvent * e)
                 {
                     delete project;
                 }
+                project->setWorkspaceFilter(CGisWorkspace::self().getCurrentSearch());
             }
             e->accept();
             emit sigChanged();

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -55,7 +55,7 @@
 CGisWorkspace * CGisWorkspace::pSelf = nullptr;
 
 CGisWorkspace::CGisWorkspace(QMenu *menuProject, QWidget *parent)
-    : QWidget(parent)
+    : QWidget(parent), currentSearch("")
 {
     pSelf = this;
     setupUi(this);
@@ -143,6 +143,11 @@ void CGisWorkspace::loadGisProject(const QString& filename)
         }
 
         treeWks->blockSignals(false);
+
+        if(item != nullptr)
+        {
+            item->setWorkspaceFilter(currentSearch);
+        }
     }
 
     emit sigChanged();
@@ -161,6 +166,7 @@ void CGisWorkspace::slotSetGisLayerOpacity(int val)
 
 void CGisWorkspace::slotSearch(const CSearch& currentSearch)
 {
+    this->currentSearch = currentSearch;
     {
         CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
         QMutexLocker lock(&IGisItem::mutexItems);

--- a/src/qmapshack/gis/CGisWorkspace.h
+++ b/src/qmapshack/gis/CGisWorkspace.h
@@ -435,6 +435,11 @@ public:
 
     void tagItemsByKey(const QList<IGisItem::key_t>& keys);
 
+    const CSearch& getCurrentSearch() const
+    {
+        return currentSearch;
+    }
+
 signals:
     void sigChanged();
 
@@ -463,7 +468,7 @@ private:
         the mouse object to find items close by for highlight.
      */
     IGisItem::key_t keyWksSelection;
-
+    CSearch currentSearch;
 
     enum tags_hidden_e
     {

--- a/src/qmapshack/gis/search/CSearch.cpp
+++ b/src/qmapshack/gis/search/CSearch.cpp
@@ -408,6 +408,7 @@ QMap<QString, CSearch::search_type_e> CSearch::initKeywordSearchTypeMap()
     map.insert(tr("regex"), eSearchTypeRegEx);
     map.insert("=", eSearchTypeEquals);
     map.insert(tr("equals"), eSearchTypeEquals);
+    map.insert(tr("is"), eSearchTypeEquals);
     map.insert(tr("between"), eSearchTypeBetween);
     return map;
 }
@@ -440,6 +441,7 @@ QMap<QString, QString> CSearch::initKeywordSearchExampleMap()
     map.insert(tr("regex"), tr("example: size regex (regular|large)"));
     map.insert("=", tr("example: size = micro"));
     map.insert(tr("equals"), tr("example: activity equals bike"));
+    map.insert(tr("is"), tr("example: status is available"));
     map.insert(tr("between"), tr("example: length between 20km and 20mi"));
     return map;
 }

--- a/src/qmapshack/gis/search/CSearchLineEdit.h
+++ b/src/qmapshack/gis/search/CSearchLineEdit.h
@@ -19,6 +19,7 @@
 #define CSEARCHLINEEDIT_H
 
 #include <QLineEdit>
+class QTimer;
 class IGisProject;
 class CSearch;
 class QTreeWidgetItem;
@@ -57,6 +58,7 @@ private:
     IGisProject * connectedProject = nullptr;
     QTreeWidgetItem * searchItem = nullptr;
 
+    QTimer * searchCreationTimer = nullptr;
     static CSearchExplanationDialog* explanationDlg;
 };
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#164

**Describe roughly what you have done:**

* Fixed non-filtering
* Added timout to start filtering

**What steps have to be done to perform a simple smoke test:**

1. Apply a filter
2. Load file with many Items
3. See that filter is applied
4. Change the filter
5. See that you don't hang after typing single characters if you are typing normally

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
