### PR TITLE
[QMS-156] Check if device is removable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-148] Misplaced track info window
 [QMS-151] Missing tooltip in route toolbar
 [QMS-153] Improved French translation
+[QMS-156] Request to unmount systemdrive on startup
 [QMS-165] OSX: GIS files not loaded when clicked
 
 V1.14.1

--- a/src/qmapshack/device/CDeviceWatcherLinux.cpp
+++ b/src/qmapshack/device/CDeviceWatcherLinux.cpp
@@ -64,9 +64,16 @@ void CDeviceWatcherLinux::slotDeviceAdded(const QDBusObjectPath& path, const QVa
     QDBusInterface * driveIface = new QDBusInterface("org.freedesktop.UDisks2", drive_object.path(), "org.freedesktop.UDisks2.Drive", QDBusConnection::systemBus(), this);
     QString vendor = driveIface->property("Vendor").toString();
     QString model  = driveIface->property("Model").toString();
+    bool removable = driveIface->property("Removable").toBool();
 
     delete blockIface;
     delete driveIface;
+
+    // GPS device are always removable
+    if(!removable)
+    {
+        return;
+    }
 
 #if !defined(Q_OS_FREEBSD)
 // currently bsdisks does not report model or vendor


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#156

**Describe roughly what you have done:**

I added check in CDeviceWatcherLinux::slotDeviceAdded(), testing if the device is removable. Non-removable devices can't be GPS devices. They are most likely your system drives.

**What steps have to be done to perform a simple smoke test:**

* Start QMapShack with -d option
* You shouldn't see any log about probing system drives anymore.
* Plugin a GPS device
* The device should be listed.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
