### PR TITLE
[QMS-173] Misleading help text for DEM range slider

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-156] Request to unmount systemdrive on startup
 [QMS-164] Workspace filter is not applied to newly loaded projects
 [QMS-165] OSX: GIS files not loaded when clicked
+[QMS-173] Misleading help text for DEM range slider
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/dem/IDemPropSetup.ui
+++ b/src/qmapshack/dem/IDemPropSetup.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>269</width>
-    <height>181</height>
+    <height>182</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,7 +47,8 @@
      <item>
       <widget class="QToolButton" name="toolSetMinScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to use current scale as minimum scale to display the map.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Click to use the current zoom as maximum 
+zoom-in for use of the DEM data.</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -71,7 +72,10 @@
      <item>
       <widget class="CScaleLabel" name="labelScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Control the range of scale the map is displayed. Use the two buttons left and right to define the actual scale as either minimum or maximum scale.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Control the zoom range for which the DEM data 
+is used. Use the two buttons left and right to define 
+the actual zoom as either maximum zoom-in or zoom-out.
+</string>
        </property>
        <property name="text">
         <string/>
@@ -84,7 +88,8 @@
      <item>
       <widget class="QToolButton" name="toolSetMaxScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to use current scale as maximum scale to display the map.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Click to use the current zoom as maximum 
+zoom-out for use of the DEM data.</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -642,14 +647,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>CTinySpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>widgets/CTinySpinBox.h</header>
-  </customwidget>
-  <customwidget>
    <class>CScaleLabel</class>
    <extends>QLabel</extends>
    <header location="global">widgets/CScaleLabel.h</header>
+  </customwidget>
+  <customwidget>
+   <class>CTinySpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>widgets/CTinySpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/qmapshack/map/IMapPropSetup.ui
+++ b/src/qmapshack/map/IMapPropSetup.ui
@@ -47,7 +47,8 @@
      <item>
       <widget class="QToolButton" name="toolSetMinScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to use current scale as minimum scale to display the map.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Click to use the current zoom as maximum 
+zoom-in to display the map.</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -71,7 +72,11 @@
      <item>
       <widget class="CScaleLabel" name="labelScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Control the range of scale the map is displayed. Use the two buttons left and right to define the actual scale as either minimum or maximum scale.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Control the zoom range for which the map is 
+displayed. Use the two buttons left  and right 
+to define the actual zoom as either maximum 
+zoom-in or zoom-out.
+</string>
        </property>
        <property name="text">
         <string/>
@@ -84,7 +89,8 @@
      <item>
       <widget class="QToolButton" name="toolSetMaxScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to use current scale as maximum scale to display the map.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Click to use the current zoom as maximum 
+zoom-out to display the map.</string>
        </property>
        <property name="text">
         <string>...</string>


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#173

**Describe roughly what you have done:**

Replaced tool tips as suggested

**What steps have to be done to perform a simple smoke test:**

Check tool tips for scale slider in the maps and DEM lists.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
