### PR TITLE
[QMS-172] Select action "for all" in Database Conflict

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-156] Request to unmount systemdrive on startup
 [QMS-164] Workspace filter is not applied to newly loaded projects
 [QMS-165] OSX: GIS files not loaded when clicked
+[QMS-172] Select action "for all" in Database Conflict
 [QMS-173] Misleading help text for DEM range slider
 [QMS-178] Automate list of code contributors in about dialog
 

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -66,6 +66,7 @@ set( SRCS
     gis/db/CExportDatabase.cpp
     gis/db/CExportDatabaseThread.cpp
     gis/db/CLostFoundProject.cpp
+    gis/db/CResolveDatabaseConflict.cpp
     gis/db/CSearchDatabase.cpp
     gis/db/CSelectDBFolder.cpp
     gis/db/CSelectSaveAction.cpp
@@ -415,6 +416,7 @@ set( HDRS
     gis/db/CExportDatabase.h
     gis/db/CExportDatabaseThread.h
     gis/db/CLostFoundProject.h
+    gis/db/CResolveDatabaseConflict.h
     gis/db/CSearchDatabase.h
     gis/db/CSelectDBFolder.h
     gis/db/CSelectSaveAction.h
@@ -736,6 +738,7 @@ set( UIS
     gis/IGisWorkspace.ui
     gis/ISelDevices.ui
     gis/db/IExportDatabase.ui
+    gis/db/IResolveDatabaseConflict.ui
     gis/db/ISearchDatabase.ui
     gis/db/ISelectDBFolder.ui
     gis/db/ISelectSaveAction.ui

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -509,7 +509,7 @@ void CGisListWks::dropEvent( QDropEvent  * e )
         return;
     }
 
-    int lastResult = CSelectCopyAction::eResultNone;
+    CSelectCopyAction::result_e lastResult = CSelectCopyAction::eResultNone;
 
     // go on with item insertion
     /*

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -673,9 +673,8 @@ void CGisWorkspace::copyItemByKey(const IGisItem::key_t &key)
     {
         return;
     }
-
-    int lastResult = CSelectCopyAction::eResultNone;
-    project->insertCopyOfItem(item, NOIDX, lastResult);
+    CSelectCopyAction::result_e actionForAll = CSelectCopyAction::eResultNone;
+    project->insertCopyOfItem(item, NOIDX, actionForAll);
 
 
     emit sigChanged();
@@ -691,7 +690,7 @@ void CGisWorkspace::copyItemsByKey(const QList<IGisItem::key_t> &keys)
         return;
     }
 
-    int lastResult = CSelectCopyAction::eResultNone;
+    CSelectCopyAction::result_e lastResult = CSelectCopyAction::eResultNone;
 
     project->blockUpdateItems(true);
     int cnt = 1;

--- a/src/qmapshack/gis/db/CDBProject.h
+++ b/src/qmapshack/gis/db/CDBProject.h
@@ -110,6 +110,16 @@ public:
 
     void update();
 
+    enum action_e
+    {
+        eActionNone = 0x00
+        , eActionLink = 0x01
+        , eActionUpdate = 0x02
+        , eActionInsert = 0x04
+        , eActionClone  = 0x08
+        , eActionReload = 0x10
+    };
+
 protected:
     /**
        @brief Setup the items text with the name and suffix
@@ -148,17 +158,9 @@ protected:
         , eReasonConflict   = -3
     };
 
-    enum action_e
-    {
-        eActionNone = 0x00
-        , eActionLink = 0x01
-        , eActionUpdate = 0x02
-        , eActionInsert = 0x04
-        , eActionClone  = 0x08
-        , eActionReload = 0x10
-    };
-
     Qt::CheckState checkState = Qt::Unchecked;
+
+    action_e action2ForAll = eActionNone;
 };
 
 #endif //CDBPROJECT_H

--- a/src/qmapshack/gis/db/CResolveDatabaseConflict.cpp
+++ b/src/qmapshack/gis/db/CResolveDatabaseConflict.cpp
@@ -1,0 +1,79 @@
+/**********************************************************************************************
+    Copyright (C) 2020 Henri Hornburg <hrnbg@t-online.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#include "gis/db/CResolveDatabaseConflict.h"
+#include "gis/wpt/CGisItemWpt.h"
+#include "helpers/CProgressDialog.h"
+
+CResolveDatabaseConflict::CResolveDatabaseConflict(QString msg, IGisItem* item, CDBProject::action_e& actionForAll, QWidget *parent)
+    : QDialog (parent),
+    actionForAll (actionForAll)
+{
+    setupUi(this);
+
+    labelMsg->setText(msg);
+    connect(pButAbort, &QPushButton::clicked, this, [this] { slotButttonClicked(CDBProject::eActionNone); });
+    connect(pButRemote, &QPushButton::clicked, this, [this] { slotButttonClicked(CDBProject::eActionReload); });
+    connect(pButLocal, &QPushButton::clicked, this, [this] { slotButttonClicked(CDBProject::eActionUpdate); });
+
+    //Cloning a geocache leads to an error, as they are identified by their GCCode
+    CGisItemWpt* wpt = static_cast<CGisItemWpt*>(item);
+    if(wpt != nullptr && wpt->isGeocache())
+    {
+        pButClone->hide();
+    }
+    else
+    {
+        connect(pButClone, &QPushButton::clicked, this, [this] { slotButttonClicked(CDBProject::eActionClone); });
+    }
+}
+
+CDBProject::action_e CResolveDatabaseConflict::getAction()
+{
+    //If the clone button is hidden, thus the item being a geocache, and the action for all is clone,
+    //the user will have to make a new selection for this item
+    if(actionForAll != CDBProject::eActionNone && !(actionForAll == CDBProject::eActionClone && pButClone->isHidden()))
+    {
+        return actionForAll;
+    }
+    else
+    {
+        CProgressDialog::setAllVisible(false);
+        exec();
+        CProgressDialog::setAllVisible(true);
+        return actionSelected;
+    }
+}
+
+void CResolveDatabaseConflict::slotButttonClicked(CDBProject::action_e actionConnected)
+{
+    actionSelected = actionConnected;
+    if(checkBoxAll->isChecked())
+    {
+        actionForAll = actionSelected;
+    }
+
+    if(actionConnected == CDBProject::eActionNone)
+    {
+        done(QDialog::Rejected);
+    }
+    else
+    {
+        done(QDialog::Accepted);
+    }
+}

--- a/src/qmapshack/gis/db/CResolveDatabaseConflict.h
+++ b/src/qmapshack/gis/db/CResolveDatabaseConflict.h
@@ -20,10 +20,10 @@
 #define CDATABASECONFLICT_H
 
 #include "gis/db/CDBProject.h"
-#include "ui_IDatabaseConflict.h"
+#include "ui_IResolveDatabaseConflict.h"
 #include <QDialog>
 
-class CResolveDatabaseConflict : public QDialog, private Ui_IDatabaseConflict
+class CResolveDatabaseConflict : public QDialog, private Ui::IResolveDatabaseConflict
 {
 public:
     CResolveDatabaseConflict(QString msg, IGisItem *item, CDBProject::action_e &actionForAll, QWidget *parent = nullptr);

--- a/src/qmapshack/gis/db/CResolveDatabaseConflict.h
+++ b/src/qmapshack/gis/db/CResolveDatabaseConflict.h
@@ -1,0 +1,41 @@
+/**********************************************************************************************
+    Copyright (C) 2020 Henri Hornburg <hrnbg@t-online.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CDATABASECONFLICT_H
+#define CDATABASECONFLICT_H
+
+#include "gis/db/CDBProject.h"
+#include "ui_IDatabaseConflict.h"
+#include <QDialog>
+
+class CResolveDatabaseConflict : public QDialog, private Ui_IDatabaseConflict
+{
+public:
+    CResolveDatabaseConflict(QString msg, IGisItem *item, CDBProject::action_e &actionForAll, QWidget *parent = nullptr);
+
+    CDBProject::action_e getAction();
+
+private slots:
+    void slotButttonClicked(CDBProject::action_e actionConnected);
+
+private:
+    CDBProject::action_e actionSelected = CDBProject::eActionNone;
+    CDBProject::action_e& actionForAll;
+};
+
+#endif // CDATABASECONFLICT_H

--- a/src/qmapshack/gis/db/IResolveDatabaseConflict.ui
+++ b/src/qmapshack/gis/db/IResolveDatabaseConflict.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IResolveDatabaseConflict</class>
+ <widget class="QDialog" name="IResolveDatabaseConflict">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>412</width>
+    <height>127</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Database Conflict</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="labelMsg">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxAll">
+     <property name="text">
+      <string>Remember choice for all items of this project</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="pButClone">
+       <property name="text">
+        <string>Clone &amp;&amp; Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pButRemote">
+       <property name="text">
+        <string>Take Remote</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pButLocal">
+       <property name="text">
+        <string>Force Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pButAbort">
+       <property name="text">
+        <string>Abort</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qmapshack/gis/gpx/CGpxProject.cpp
+++ b/src/qmapshack/gis/gpx/CGpxProject.cpp
@@ -58,7 +58,7 @@ CGpxProject::CGpxProject(const QString &filename, const IGisProject * project, I
     *(IGisProject*)this = *project;
     blockUpdateItems(project->blockUpdateItems());
 
-    int res     = CSelectCopyAction::eResultNone;
+    CSelectCopyAction::result_e res = CSelectCopyAction::eResultNone;
     const int N = project->childCount();
     for(int n = 0; n < N; n++)
     {

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -775,7 +775,7 @@ void IGisProject::editItemByKey(const IGisItem::key_t& key)
 }
 
 
-void IGisProject::insertCopyOfItem(IGisItem * item, int off, int& lastResult)
+void IGisProject::insertCopyOfItem(IGisItem * item, int off, CSelectCopyAction::result_e& lastResult)
 {
     bool clone = false;
     IGisItem::key_t key = item->getKey();
@@ -785,7 +785,7 @@ void IGisProject::insertCopyOfItem(IGisItem * item, int off, int& lastResult)
     IGisItem * item2 = getItemByKey(key);
     if(item2 != nullptr)
     {
-        int result = lastResult;
+        CSelectCopyAction::result_e result = lastResult;
         if(lastResult == CSelectCopyAction::eResultNone)
         {
             CSelectCopyAction dlg(item, item2, CMainWindow::getBestWidgetForParent());

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -24,6 +24,7 @@
 #include "gis/rte/router/IRouter.h"
 #include "gis/search/CProjectFilterItem.h"
 #include "gis/search/CSearch.h"
+#include "helpers/CSelectCopyAction.h"
 #include <QDebug>
 #include <QMessageBox>
 #include <QPointer>
@@ -416,7 +417,7 @@ public:
        @param off           the offset into the tree widget, -1 for none
        @param lastResult    a reference to hold the last result of the copy option dialog
      */
-    void insertCopyOfItem(IGisItem *item, int off, int &lastResult);
+    void insertCopyOfItem(IGisItem *item, int off, CSelectCopyAction::result_e &lastResult);
 
     /**
        @brief Check if the project was initialized correctly.

--- a/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
+++ b/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
@@ -117,16 +117,17 @@ void CGisSummaryDropZone::dropEvent(QDropEvent  * e)
         }
     }
 
-    int lastResult = CSelectCopyAction::eResultSkip;
+    CSelectSaveAction::result_e saveActionForAll = CSelectSaveAction::eResultSkip;
+    CSelectCopyAction::result_e copyActionForAll = CSelectCopyAction::eResultSkip;
     for(const CGisSummary::folder_t& folder : folders)
     {
         CDBProject * project = new CDBProject(folder.db, folder.id, nullptr);
         for(IGisItem * gisItem : gisItems)
         {
-            project->insertCopyOfItem(gisItem, -1, lastResult);
+            project->insertCopyOfItem(gisItem, -1, copyActionForAll);
         }
 
-        project->save(lastResult);
+        project->save(saveActionForAll);
         delete project;
     }
 }

--- a/src/qmapshack/gis/tcx/CTcxProject.cpp
+++ b/src/qmapshack/gis/tcx/CTcxProject.cpp
@@ -50,7 +50,7 @@ CTcxProject::CTcxProject(const QString &filename, const IGisProject * project, I
     *(IGisProject*)this = *project;
     blockUpdateItems(project->blockUpdateItems());
 
-    int res     = CSelectCopyAction::eResultNone;
+    CSelectCopyAction::result_e res = CSelectCopyAction::eResultNone;
     const int N = project->childCount();
     for(int n = 0; n < N; n++)
     {

--- a/src/qmapshack/gis/tnv/CTwoNavProject.cpp
+++ b/src/qmapshack/gis/tnv/CTwoNavProject.cpp
@@ -51,7 +51,7 @@ CTwoNavProject::CTwoNavProject(const QString &filename, const IGisProject * proj
     setIcon(CGisListWks::eColumnIcon, QIcon("://icons/32x32/2NavProject.png"));
     *(IGisProject*)this = *project;
 
-    int res     = CSelectCopyAction::eResultNone;
+    CSelectCopyAction::result_e res = CSelectCopyAction::eResultNone;
     const int N = project->childCount();
     for(int n = 0; n < N; n++)
     {


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#172

**Describe roughly what you have done:**

* Added seperate dialog class for database conflict with checkbox
* catched error of cloning geocaches

**What steps have to be done to perform a simple smoke test:**

1. Copy two different versions of a geocache into two different database folders
2. Save workspace
3. Select that you want to replace the geocache
4. See in the appearing database conflict that you can choose action for all and that if you provoke multiple errors you will not be asked again.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
