### PR TITLE
[QMS-183] Backward range selection causing small issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ V1.XX.X
 [QMS-165] OSX: GIS files not loaded when clicked
 [QMS-173] Misleading help text for DEM range slider
 [QMS-178] Automate list of code contributors in about dialog
+[QMS-183] Backward range selection causing small issues
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -806,10 +806,17 @@ QString CGisItemTrk::getInfoProgress(const CTrackData::trkpt_t& pt) const
     return QString("%1%2\n%3%4").arg(asc).arg(dsc).arg(dst).arg(mov);
 }
 
-QString CGisItemTrk::getInfoRange(const CTrackData::trkpt_t& pt1, const CTrackData::trkpt_t& pt2) const
+QString CGisItemTrk::getInfoRange(const CTrackData::trkpt_t& trkpt1, const CTrackData::trkpt_t& trkpt2) const
 {
     QString val, unit;
     qreal dt = NOFLOAT;
+
+    CTrackData::trkpt_t pt1 = trkpt1;
+    CTrackData::trkpt_t pt2 = trkpt2;
+    if(pt1.idxTotal > pt2.idxTotal)
+    {
+        qSwap(pt1, pt2);
+    }
 
     if(pt1.time.isValid() && pt2.time.isValid())
     {

--- a/src/qmapshack/gis/trk/CGisItemTrk.h
+++ b/src/qmapshack/gis/trk/CGisItemTrk.h
@@ -222,7 +222,7 @@ public:
     /// get a summary of a selected range
     QString getInfoRange() const;
     /// get a summary of a selected range defined by two track points
-    QString getInfoRange(const CTrackData::trkpt_t& pt1, const CTrackData::trkpt_t& pt2) const;
+    QString getInfoRange(const CTrackData::trkpt_t& trkpt1, const CTrackData::trkpt_t& trkpt2) const;
     /// get a summary for a track point
     QString getInfoTrkPt(const CTrackData::trkpt_t& pt) const;
     /// get a progress summary for a selected track point


### PR DESCRIPTION
Order start and end point of range by their total index.

**What is the linked issue for this pull request (start with a `#`):** QMS-#183

**Describe roughly what you have done:**

Start and end point where taken as provided. However for a backward selection they must be 
swapped to have the point with the lower index as point 1 and the one with the larger index as point 2.

**What steps have to be done to perform a simple smoke test:**

* Open edit window of track
* Select a range in the track from first point at the right side and second at the left side.
* The range data (on top of graphs, third column) must show positive values. Regardless of the order of selected points.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
