### PR TITLE
[QMS-158] Change Routino Profiles search for [prefix-]profiles.xml

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-151] Missing tooltip in route toolbar
 [QMS-153] Improved French translation
 [QMS-156] Request to unmount systemdrive on startup
+[QMS-158] Change Routino Profiles search for [prefix-]profiles.xml
 [QMS-164] Workspace filter is not applied to newly loaded projects
 [QMS-165] OSX: GIS files not loaded when clicked
 [QMS-173] Misleading help text for DEM range slider

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -29,9 +29,7 @@
 #include <QtWidgets>
 #include <routino.h>
 
-
 QPointer<CProgressDialog> CRouterRoutino::progress;
-
 
 int ProgressFunc(double complete)
 {
@@ -64,15 +62,9 @@ CRouterRoutino::CRouterRoutino(QWidget *parent)
     comboMode->addItem(tr("Shortest"));
     comboMode->addItem(tr("Quickest"));
 
+
     int res = 0;
     IAppSetup *setup = IAppSetup::getPlatformInstance();
-    res = Routino_ParseXMLProfiles(setup->routinoPath("profiles.xml").toUtf8());
-    if(res)
-    {
-        QMessageBox::critical(this, "Routino...", xlateRoutinoError(Routino_errno), QMessageBox::Abort);
-        return;
-    }
-
     res = Routino_ParseXMLTranslations(setup->routinoPath("translations.xml").toUtf8());
     if(res)
     {
@@ -233,6 +225,11 @@ void CRouterRoutino::buildDatabaseList()
     QRegExp re("(.*)-segments.mem");
     freeDatabaseList();
 
+    // initialise
+    currentProfilesPath = "";
+
+    IAppSetup *setup = IAppSetup::getPlatformInstance();
+
     for(const QString &path : dbPaths)
     {
         QDir dir(path);
@@ -248,18 +245,67 @@ void CRouterRoutino::buildDatabaseList()
                 continue;
             }
 
+            // qDebug() << "buildDatabase Prefix" << prefix;
+
 #ifdef Q_OS_WIN
             Routino_Database * data = Routino_LoadDatabase(dir.absolutePath().toLocal8Bit(), prefix.toLocal8Bit());
 #else
             Routino_Database * data = Routino_LoadDatabase(dir.absolutePath().toUtf8(), prefix.toUtf8());
 #endif
-            if(data)
+            qDebug() << "Loaded Routino DB" << dir.absolutePath().toUtf8().data() << "  " << prefix.toUtf8().data();
+
+            if(data == nullptr)
             {
-                comboDatabase->addItem(prefix.replace("_", " "), quint64(data));
+                QMessageBox::critical(this, "Routino ...", xlateRoutinoError(Routino_errno), QMessageBox::Abort);
+                continue;
+            }
+            /* determine the profile to use for each database*/
+            QVariantMap dmap;
+            dmap["db"] = QVariant ((qulonglong)data);
+
+            /* check possible profiles.xml locations and use the first available */
+            int pError = 0;
+            dmap["profilesPath"] = "";
+            QStringList profilesPaths = {
+                dir.filePath(prefix+"-profiles.xml"),
+                dir.filePath("profiles.xml"),
+                setup->routinoPath("profiles.xml").toUtf8()
+            };
+            for(const QString& profilePath : profilesPaths)
+            {
+                QFileInfo pinfo(profilePath);
+                if( pinfo.isReadable())
+                {
+                    dmap["profilesPath"] = pinfo.filePath();
+                    break;
+                }
+            }
+            if( dmap["profilesPath"].toString().isEmpty() )
+            {
+                QMessageBox::critical(this, "Routino...",tr("Could not find a profiles XML file in expected folders. Routino Routing will not function"), QMessageBox::Ok);
+                pError = 1;
             }
             else
             {
-                QMessageBox::critical(this, "Routino...", xlateRoutinoError(Routino_errno), QMessageBox::Abort);
+                /* check if profile will load - will abort if not good */
+                pError = loadProfiles(dmap["profilesPath"].toString());
+            }
+
+            qDebug() << "Profile ... Using \n" << dmap["prefixpath"].toString();
+
+            if( pError == 0 )
+            {
+                comboDatabase->addItem(prefix.replace("_", " "), dmap);
+            }
+            else
+            {
+                QMessageBox::warning(this, "Routino...", xlateRoutinoError(Routino_errno)
+                    +"<FONT COLOR= 'RED'>"
+                    +tr("<br>Error in '")+dmap["profilesPath"].toString()
+                    +tr("'<br>This needs to be Fixed<br>The associated database '")
+                    +prefix
+                    +tr("' is ignored")
+                    +"</FONT>", QMessageBox::Ok);
             }
         }
     }
@@ -269,10 +315,22 @@ void CRouterRoutino::freeDatabaseList()
 {
     for(int i = 0; i < comboDatabase->count(); i++)
     {
-        Routino_Database * data = (Routino_Database*)comboDatabase->itemData(i, Qt::UserRole).toULongLong();
+        QVariantMap map = comboDatabase->itemData(i,Qt::UserRole).toMap();
+        Routino_Database * data = (Routino_Database*)(map["db"].toULongLong());
         Routino_UnloadDatabase(data);
     }
     comboDatabase->clear();
+}
+
+int CRouterRoutino::loadProfiles(const QString& profilesPath)
+{
+    int res = 0;
+    if( currentProfilesPath != profilesPath)
+    {
+        currentProfilesPath = profilesPath;
+        res = Routino_ParseXMLProfiles(profilesPath.toUtf8());
+    }
+    return res;
 }
 
 void CRouterRoutino::updateHelpText()
@@ -301,11 +359,14 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key)
             throw QString();
         }
 
-        Routino_Database * data = (Routino_Database*)comboDatabase->currentData(Qt::UserRole).toULongLong();
+        QVariantMap map = comboDatabase->currentData(Qt::UserRole).toMap();
+        Routino_Database * data = (Routino_Database*)(map["db"].toULongLong());
         if(nullptr == data)
         {
             throw QString();
         }
+
+        loadProfiles(map["profilesPath"].toString());
 
         rte->reset();
 
@@ -388,17 +449,21 @@ int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
 
     try
     {
-        Routino_Database * data = (Routino_Database*)comboDatabase->currentData(Qt::UserRole).toULongLong();
+        QVariantMap map = comboDatabase->currentData(Qt::UserRole).toMap();
+        Routino_Database * data = (Routino_Database*)(map["db"].toULongLong());
         if(nullptr == data)
         {
             throw QString();
         }
+
+        loadProfiles(map["profilesPath"].toString());
 
         QString strProfile      = comboProfile->currentData(Qt::UserRole).toString();
         QString strLanguage     = comboLanguage->currentData(Qt::UserRole).toString();
 
         Routino_Profile *profile         = Routino_GetProfile(strProfile.toUtf8());
         Routino_Translation *translation = Routino_GetTranslation(strLanguage.toUtf8());
+
 
         int res = Routino_ValidateProfile(data, profile);
         if(res != 0)

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.h
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.h
@@ -57,11 +57,13 @@ private:
     virtual ~CRouterRoutino();
     void buildDatabaseList();
     void freeDatabaseList();
+    int loadProfiles(const QString& profilesPath);
     void updateHelpText();
     QString xlateRoutinoError(int err);
     static CRouterRoutino * pSelf;
 
     QStringList dbPaths;
+    QString currentProfilesPath;
 
     QMutex mutex {QMutex::NonRecursive};
 };


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#158

**Describe roughly what you have done:**

I have added extra search paths for databasepath/[<prefix>-]profiles.xml and default_ routino_data_path/profiles.xml. Similar to what routino cammandline does.  This is done in the buildDatabaseList method.  This has required moving the parseProfilesXML call into a new method loadProfiles() which is called from the calcRoute methods and expanding the userData argument to a map variable containing the database pointer and the path to an existing profiles.xml.

**What steps have to be done to perform a simple smoke test:**

1. Run routing without any profiles.xml in the database folder. Program uses profiles.xml from the default routino path.
2. Create a prefix-profiles.xml in the database folder with slightly different parameters, and it routes with those characterisitcs.
3. Change the routing database in the UI and routing with a new profiles works.
4. Tested a profiles.xml file with inserted bad data. This created an error message and abort as expected with  from the profiles parse call. 
5. Have been running this on a project where I setup a walking/foot only database and profiles, along with a motorcar only database and profiles. Databases and profiles use unique prefixes.  Can switch seamlessly between databases in one session.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
