### PR TITLE
Fix build with Qt 5.15

### DIFF
--- a/src/qmapshack/helpers/CDraw.cpp
+++ b/src/qmapshack/helpers/CDraw.cpp
@@ -24,6 +24,7 @@
 #include <QImage>
 #include <QPointF>
 #include <QtMath>
+#include <QPainterPath>
 
 QPen CDraw::penBorderBlue(QColor(10, 10, 150, 220), 2);
 QPen CDraw::penBorderGray(Qt::lightGray, 2);

--- a/src/qmaptool/helpers/CDraw.cpp
+++ b/src/qmaptool/helpers/CDraw.cpp
@@ -24,6 +24,7 @@
 #include <QImage>
 #include <QPointF>
 #include <QtMath>
+#include <QPainterPath>
 
 QPen CDraw::penBorderBlue(QColor(10,10,150,220),2);
 QPen CDraw::penBorderGray(Qt::lightGray,2);


### PR DESCRIPTION
Build with Qt 5.15 causes the following error:
```
  qmapshack-V_1.14.0/src/qmapshack/helpers/CDraw.cpp:210:18: error: aggregate ‘QPainterPath bubblePath’ has incomplete type and cannot be defined
```