### PR TITLE
[QMS-201] Fix GDAL deprecation warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ V1.XX.X
 [QMS-178] Automate list of code contributors in about dialog
 [QMS-183] Backward range selection causing small issues
 [QMS-192] Fix URLs still pointing to the bitbucket wiki
+[QMS-201] Fix GDAL deprecation warnings
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -76,7 +76,7 @@ CDemVRT::CDemVRT(const QString &filename, CDemDraw *parent)
         strncpy(str, dataset->GetProjectionRef(), sizeof(str) - 1);
     }
     OGRSpatialReference oSRS;
-    char *wkt = str;
+    const char *wkt = str;
     oSRS.importFromWkt(&wkt);
 
     char *proj4 = nullptr;

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -125,7 +125,7 @@ CMapVRT::CMapVRT(const QString &filename, CMapDraw *parent)
     }
 
     OGRSpatialReference oSRS;
-    char *wkt = str;
+    const char *wkt = str;
     oSRS.importFromWkt(&wkt);
 
     char *proj4 = nullptr;

--- a/src/qmaptool/helpers/CGdalFile.cpp
+++ b/src/qmaptool/helpers/CGdalFile.cpp
@@ -62,7 +62,7 @@ void CGdalFile::load(const QString& filename)
 
     {
         OGRSpatialReference oSRS;
-        char *wkt = str;
+        const char *wkt = str;
         oSRS.importFromWkt(&wkt);
 
         char *proj4 = nullptr;

--- a/src/qmt_map2jnx/main.cpp
+++ b/src/qmt_map2jnx/main.cpp
@@ -689,16 +689,18 @@ int main(int argc, char ** argv)
         }
 
         projPJ   pj;
-        char * ptr = projstr;
+        const char * wkt = projstr;
 
         if(dataset->GetProjectionRef())
         {
             strncpy(projstr,dataset->GetProjectionRef(),sizeof(projstr));
         }
-        oSRS.importFromWkt(&ptr);
-        oSRS.exportToProj4(&ptr);
+        oSRS.importFromWkt(&wkt);
 
-        pj = pj_init_plus(ptr);
+        char *proj4 = nullptr;
+        oSRS.exportToProj4(&proj4);
+
+        pj = pj_init_plus(proj4);
         if(pj == 0)
         {
             fprintf(stderr,"\nUnknown projection in file %s\n", argv[i]);
@@ -713,7 +715,7 @@ int main(int argc, char ** argv)
 
         file_t& file    = *f;
         file.filename   = argv[i];
-        file.projection = ptr;
+        file.projection = proj4;
         file.dataset    = dataset;
         file.pj         = pj;
         file.width      = dataset->GetRasterXSize();


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#201

**Describe roughly what you have done:**

I just fixed the code according to GDAL's suggestions in the deprecation warning.

**What steps have to be done to perform a simple smoke test:**

Compile and enjoy the lack of senseless warnings.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [ ] yes,
- [x] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
