### PR TITLE
[QMS-204] Garmin Map: Fix crash because of bad codec number

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ V1.XX.X
 [QMS-183] Backward range selection causing small issues
 [QMS-192] Fix URLs still pointing to the bitbucket wiki
 [QMS-201] Fix GDAL deprecation warnings
+[QMS-204] Garmin Map: Fix crash because of bad codec number
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/map/garmin/CGarminTyp.cpp
+++ b/src/qmapshack/map/garmin/CGarminTyp.cpp
@@ -504,7 +504,10 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
 
                     str += t8;
                 }
-                property.strings[langcode] = codec->toUnicode(str);
+                if(codec != nullptr)
+                {
+                    property.strings[langcode] = codec->toUnicode(str);
+                }
 #ifdef DBG
                 qDebug() << len << langcode << property.strings[langcode];
 #endif
@@ -894,7 +897,10 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
 
                     str += t8_1;
                 }
-                property.strings[langcode] = codec->toUnicode(str);
+                if(codec != nullptr)
+                {
+                    property.strings[langcode] = codec->toUnicode(str);
+                }
 #ifdef DBG
                 qDebug() << len << langcode << property.strings[langcode];
 #endif
@@ -1298,7 +1304,10 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
 
                     str += t8_1;
                 }
-                property.strings[langcode] = codec->toUnicode(str);
+                if(codec != nullptr)
+                {
+                    property.strings[langcode] = codec->toUnicode(str);
+                }
 #ifdef DBG
                 qDebug() << len << langcode << property.strings[langcode];
 #endif


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#204

**Describe roughly what you have done:**

If the typ file has a bad codec number for UTF8 the code will be
a nullptr. As a consequence the pointer has to be tested before
it is used.

**What steps have to be done to perform a simple smoke test:**

Download and activate the map from the ticket.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
