### PR TITLE
[QMS-207] Fixing Availability of Geocaches

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ V1.XX.X
 [QMS-192] Fix URLs still pointing to the bitbucket wiki
 [QMS-201] Fix GDAL deprecation warnings
 [QMS-204] Garmin Map: Fix crash because of bad codec number
+[QMS-207] Fixing Availability of Geocaches
 
 V1.14.1
 [QMS-37] Inconsistent use of time zones

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -645,8 +645,8 @@ void CGisItemWpt::readGcExt(const QDomNode& xmlCache)
 
     QDomNode geocacheAttributes = xmlCache.namedItem("groundspeak:attributes");
 
-    geocache.archived   = attr.namedItem("archived").nodeValue().toLocal8Bit() == "True";
-    geocache.available  = attr.namedItem("available").nodeValue().toLocal8Bit() == "True";
+    geocache.archived   = attr.namedItem("archived").nodeValue().toLocal8Bit().toLower() == "true";
+    geocache.available  = attr.namedItem("available").nodeValue().toLocal8Bit().toLower() == "true";
 
     for(QDomNode xmlAttribute = geocacheAttributes.firstChild(); !xmlAttribute.isNull(); xmlAttribute = xmlAttribute.nextSibling())
     {


### PR DESCRIPTION


**What is the linked issue for this pull request (start with a `#`):** QMS-#

**Describe roughly what you have done:**

* Made check for 'available' and 'archived' properties case insensitive

**What steps have to be done to perform a simple smoke test:**

1. Open a file with lower-case availability of geocaches and see that they are correctly displayed
2. Open a file with first letter upper-case availability of geocaches and see that they are correctly displayed

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
