### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/qmapshack/locale/qmapshack.ts
+++ b/src/qmapshack/locale/qmapshack.ts
@@ -11974,7 +11974,7 @@ or
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_ca.ts
+++ b/src/qmapshack/locale/qmapshack_ca.ts
@@ -12240,7 +12240,7 @@ o
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_cs.ts
+++ b/src/qmapshack/locale/qmapshack_cs.ts
@@ -12136,7 +12136,7 @@ nebo
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_de.ts
+++ b/src/qmapshack/locale/qmapshack_de.ts
@@ -12240,7 +12240,7 @@ sein</translation>
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation>Wählen Siie eine Aktion aus die nach dem Anwenden der oben genannten Funktionen ausgeführt wird.</translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_es.ts
+++ b/src/qmapshack/locale/qmapshack_es.ts
@@ -12260,7 +12260,7 @@ o
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation>Configurar comportamiento después de finalizadas cada una de las acciones.</translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_fr.ts
+++ b/src/qmapshack/locale/qmapshack_fr.ts
@@ -12175,7 +12175,7 @@ or
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation>Lorsque qu&apos;un des outils ci-dessus est utilisé, il est possible d&apos;agir sur la sélection. Choisissez l&apos;action à effectuer ci-dessus. La légende des icônes est la suivante:</translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_it.ts
+++ b/src/qmapshack/locale/qmapshack_it.ts
@@ -12250,7 +12250,7 @@ oppure
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_nl.ts
+++ b/src/qmapshack/locale/qmapshack_nl.ts
@@ -12080,7 +12080,7 @@ of
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_ru.ts
+++ b/src/qmapshack/locale/qmapshack_ru.ts
@@ -12438,7 +12438,7 @@ or
     </message>
     <message>
         <location filename="../mouse/range/IRangeToolSetup.ui" line="312"/>
-        <source>Select one of the actions to be applied after the operations from above excuted on a selection.</source>
+        <source>Select one of the actions to be applied after the operations from above executed on a selection.</source>
         <translation>Выберите действие, которое будет применяться после того, как операция из вышеприведенного списка будет выполнена с выбранным интервалом.</translation>
     </message>
     <message>

--- a/src/qmapshack/mouse/range/IRangeToolSetup.ui
+++ b/src/qmapshack/mouse/range/IRangeToolSetup.ui
@@ -309,7 +309,7 @@
    <item>
     <widget class="QLabel" name="label_15">
      <property name="text">
-      <string>Select one of the actions to be applied after the operations from above excuted on a selection.</string>
+      <string>Select one of the actions to be applied after the operations from above executed on a selection.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
The lintian QA tool reported a spelling errors for the Debian package build:

 * excuted -> executed