### PR TITLE
[QMS-158] Change Routino Profiles search for [prefix-]profiles.xml

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-158] Change Routino Profiles search for [prefix-]profiles.xml
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.h
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.h
@@ -57,11 +57,13 @@ private:
     virtual ~CRouterRoutino();
     void buildDatabaseList();
     void freeDatabaseList();
+    int loadProfiles(const QString& profilesPath);
     void updateHelpText();
     QString xlateRoutinoError(int err);
     static CRouterRoutino * pSelf;
 
     QStringList dbPaths;
+    QString currentProfilesPath;
 
     QMutex mutex {QMutex::NonRecursive};
 };


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#158

**Describe roughly what you have done:**

I have added extra search paths for databasepath/[<prefix>-]profiles.xml and default_ routino_data_path/profiles.xml. Similar to what routino cammandline does.  This is done in the buildDatabaseList method.  This has required moving the parseProfilesXML calls into the calcRoute methods and expanding the userData argument to a map variable containing the database pointer and the path to an existing profiles.xml. 

**What steps have to be done to perform a simple smoke test:**

1. Run routing without any profiles.xml in the database folder. Uses profiles.xml from the default routino path.
2. Create a prefix-profiles.xml in the database folder with slightly different parameters, and it routes with those characterisitcs.
3. Change the routing database in the UI and routing with a new profiles works.
4. Tested a profiles.xml file with inserted bad data. This created an error message and abort as expected with  from the profiles parse call. 
5. Have been running this on a project where I setup a walking/foot only database and profiles, along with a motorcar only database and profiles. Databases and profiles use unique prefixes.  Can switch seamlessly between databases in one session.
6. Create a incorrect profiles.xml file, attempt to add its associated database into the databaselist, generates and error, posts the warning messagebox.  That database is not in the list to use.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
