### PR TITLE
[QMS-217] Fix Crash in Profile

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-158] Change Routino Profiles search for [prefix-]profiles.xml
+[QMS-217] Fix crash due to faulty profiles.xml
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -378,6 +378,10 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key)
         QString strLanguage = comboLanguage->currentData(Qt::UserRole).toString();
 
         Routino_Profile *profile         = Routino_GetProfile(strProfile.toUtf8());
+        if( profile == NULL )
+        {
+            throw tr("Required profile '%1' is not the current profiles file.").arg(strProfile);
+        }
         Routino_Translation *translation = Routino_GetTranslation(strLanguage.toUtf8());
 
         int res = Routino_ValidateProfile(data, profile);
@@ -466,6 +470,10 @@ int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
         QString strLanguage     = comboLanguage->currentData(Qt::UserRole).toString();
 
         Routino_Profile *profile         = Routino_GetProfile(strProfile.toUtf8());
+        if( profile == NULL )
+        {
+            throw tr("Required profile '%1' is not the current profiles file.").arg(strProfile);
+        }
         Routino_Translation *translation = Routino_GetTranslation(strLanguage.toUtf8());
 
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#217

**Describe roughly what you have done:**

Routino_GetProfile returns a NULL if a requested profile is not in the profiles xml.  This fix catches the NULL return value as an error and issues a User Message.  

**What steps have to be done to perform a simple smoke test:**

1. Modify a profile name in an existing working profiles.xml file.  Try to use that profile - an error is issued and routing is stops gracefully without aborting.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
