### PR TITLE
[QMS-216] QMapShack does not compile with Qt-5.15

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-158] Change Routino Profiles search for [prefix-]profiles.xml
+[QMS-216] QMapShack does not compile with Qt-5.15
 [QMS-217] Fix crash due to faulty profiles.xml
 
 V1.15.0

--- a/src/qmapshack/gis/rte/router/CRouterOptimization.h
+++ b/src/qmapshack/gis/rte/router/CRouterOptimization.h
@@ -19,9 +19,9 @@
 #ifndef CROUTEROPTIMIZATION_H
 #define CROUTEROPTIMIZATION_H
 #include <gis/IGisLine.h>
+#include <QCoreApplication>
 #include <QMap>
 #include <QPolygonF>
-#include <QCoreApplication>
 
 class CRouterOptimization
 {

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -267,7 +267,7 @@ void CRouterRoutino::buildDatabaseList()
             int pError = 0;
             dmap["profilesPath"] = "";
             QStringList profilesPaths = {
-                dir.filePath(prefix+"-profiles.xml"),
+                dir.filePath(prefix + "-profiles.xml"),
                 dir.filePath("profiles.xml"),
                 setup->routinoPath("profiles.xml").toUtf8()
             };
@@ -283,7 +283,7 @@ void CRouterRoutino::buildDatabaseList()
             }
             if( dmap["profilesPath"].toString().isEmpty() )
             {
-                QMessageBox::critical(this, "Routino...",tr("Could not find a profiles XML file in expected folders. Routino Routing will not function"), QMessageBox::Ok);
+                QMessageBox::critical(this, "Routino...", tr("Could not find a profiles XML file in expected folders. Routino Routing will not function"), QMessageBox::Ok);
                 pError = 1;
             }
             else
@@ -319,7 +319,7 @@ void CRouterRoutino::freeDatabaseList()
 {
     for(int i = 0; i < comboDatabase->count(); i++)
     {
-        QVariantMap map = comboDatabase->itemData(i,Qt::UserRole).toMap();
+        QVariantMap map = comboDatabase->itemData(i, Qt::UserRole).toMap();
         Routino_Database * data = (Routino_Database*)(map["db"].toULongLong());
         Routino_UnloadDatabase(data);
     }

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -36,6 +36,7 @@
 #include "mouse/IMouse.h"
 #include "units/IUnit.h"
 
+#include <QPainterPath>
 #include <QtWidgets>
 #include <QtXml>
 

--- a/src/qmapshack/helpers/CDraw.cpp
+++ b/src/qmapshack/helpers/CDraw.cpp
@@ -22,6 +22,7 @@
 
 #include <QDebug>
 #include <QImage>
+#include <QPainterPath>
 #include <QPointF>
 #include <QtMath>
 

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -32,6 +32,7 @@
 #include "map/garmin/CGarminTyp.h"
 #include "units/IUnit.h"
 
+#include <QPainterPath>
 #include <QtWidgets>
 
 #undef DEBUG_SHOW_SECT_DESC

--- a/src/qmapshack/mouse/IMouseSelect.cpp
+++ b/src/qmapshack/mouse/IMouseSelect.cpp
@@ -22,6 +22,7 @@
 #include "mouse/IMouseSelect.h"
 #include "mouse/IScrOpt.h"
 
+#include <QPainterPath>
 #include <QtWidgets>
 
 IMouseSelect::IMouseSelect(CGisDraw *gis, CCanvas *canvas, CMouseAdapter *mouse)

--- a/src/qmaptool/helpers/CDraw.cpp
+++ b/src/qmaptool/helpers/CDraw.cpp
@@ -24,6 +24,7 @@
 #include <QImage>
 #include <QPointF>
 #include <QtMath>
+#include <QPainterPath>
 
 QPen CDraw::penBorderBlue(QColor(10,10,150,220),2);
 QPen CDraw::penBorderGray(Qt::lightGray,2);

--- a/src/qmaptool/overlay/COverlayCutMap.cpp
+++ b/src/qmaptool/overlay/COverlayCutMap.cpp
@@ -23,12 +23,14 @@
 #include "overlay/COverlayCutMap.h"
 
 #include <functional>
+#include <QPainterPath>
 #include <QtWidgets>
+
 using std::bind;
 
 static inline qreal sqr(qreal a)
 {
-    return a*a;
+    return a * a;
 }
 
 static inline qreal sqrlen(const QPointF &a)
@@ -88,14 +90,14 @@ bool COverlayCutMap::drawFx(QPainter& p, CCanvas::redraw_e needsRedraw)
         path.addRect(rectMap);
         path.addPolygon(shape);
 
-        p.setPen(QPen(Qt::darkBlue,1));
+        p.setPen(QPen(Qt::darkBlue, 1));
 
         p.setBrush((idxFocus1 == NOIDX) ? Qt::BDiagPattern : Qt::NoBrush);
         p.drawPath(path);
     }
 
-    QRectF dot1(0,0,5,5);
-    QRectF dot2(0,0,7,7);
+    QRectF dot1(0, 0, 5, 5);
+    QRectF dot2(0, 0, 7, 7);
     const QPointF& pt1 = idxFocus1 != NOIDX ? shape[idxFocus1] : NOPOINTF;
     const QPointF& pt2 = idxFocus2 != NOIDX ? shape[idxFocus2] : NOPOINTF;
 
@@ -219,7 +221,7 @@ void COverlayCutMap::slotSetMode(mode_e m, bool on)
 
 void COverlayCutMap::slotResetMask()
 {
-    int res = QMessageBox::question(this, tr("Delete mask..."), tr("Are you sure to delete complete mask?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+    int res = QMessageBox::question(this, tr("Delete mask..."), tr("Are you sure to delete complete mask?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if(res != QMessageBox::Yes)
     {
         return;
@@ -317,7 +319,7 @@ void COverlayCutMap::slotLoadShape()
                 qreal x, y;
                 in2 >> x >> y;
 
-                QPointF pt(x,y);
+                QPointF pt(x, y);
                 context->convertCoord2Map(pt);
 
                 region << pt;
@@ -428,7 +430,7 @@ void COverlayCutMap::isCloseToLine(QPointF pt, QPolygonF line, qint32& idx1, qin
 
     QPointF b   = line[0];
     QPointF dbq = b - pt;
-    qreal dist  = 30*30;
+    qreal dist  = 30 * 30;
 
     for (qint32 i = 1; i < count; ++i)
     {
@@ -439,8 +441,8 @@ void COverlayCutMap::isCloseToLine(QPointF pt, QPolygonF line, qint32& idx1, qin
 
         const QPointF dab = a - b;
 
-        const qreal inv_sqrlen = 1./sqrlen(dab);
-        const qreal t = (dab.x()*daq.x() + dab.y()*daq.y())*inv_sqrlen;
+        const qreal inv_sqrlen = 1. / sqrlen(dab);
+        const qreal t = (dab.x() * daq.x() + dab.y() * daq.y()) * inv_sqrlen;
         if (t < 0.)
         {
             continue;
@@ -448,7 +450,7 @@ void COverlayCutMap::isCloseToLine(QPointF pt, QPolygonF line, qint32& idx1, qin
         qreal current_dist;
         if (t <= 1.)
         {
-            current_dist = sqr(dab.x()*dbq.y() - dab.y()*dbq.x())*inv_sqrlen;
+            current_dist = sqr(dab.x() * dbq.y() - dab.y() * dbq.x()) * inv_sqrlen;
         }
         else//t>1.
         {


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#216

**Describe roughly what you have done:**

Add `#include <QPainterPath>` whereever `QPainterPath` is used.
Additionally ran code beautifier

**What steps have to be done to perform a simple smoke test:**

Code should compile with QT5.15.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [ ] yes,
- [x] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
