### PR TITLE
[QMS-223] Add additional filter properties

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-158] Change Routino Profiles search for [prefix-]profiles.xml
 [QMS-216] QMapShack does not compile with Qt-5.15
 [QMS-217] Fix crash due to faulty profiles.xml
+[QMS-223] Add additional filter properties
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/gis/ovl/CGisItemOvlArea.cpp
+++ b/src/qmapshack/gis/ovl/CGisItemOvlArea.cpp
@@ -602,6 +602,11 @@ QMap<searchProperty_e, CGisItemOvlArea::fSearch> CGisItemOvlArea::initKeywordLam
         searchValue.str1 = QStringList(item->getKeywords().toList()).join(", ");
         return searchValue;
     });
+    map.insert(eSearchPropertyGeneralType, [](CGisItemOvlArea* item){
+        searchValue_t searchValue;
+        searchValue.str1 = tr("area");
+        return searchValue;
+    });
     //Area specific
     map.insert(eSearchPropertyAreaArea, [](CGisItemOvlArea* item){
         searchValue_t searchValue;

--- a/src/qmapshack/gis/rte/CGisItemRte.cpp
+++ b/src/qmapshack/gis/rte/CGisItemRte.cpp
@@ -1355,6 +1355,11 @@ QMap<searchProperty_e, CGisItemRte::fSearch> CGisItemRte::initKeywordLambdaMap()
         searchValue.str1 = QStringList(item->getKeywords().toList()).join(", ");
         return searchValue;
     });
+    map.insert(eSearchPropertyGeneralType, [](CGisItemRte* item){
+        searchValue_t searchValue;
+        searchValue.str1 = tr("route");
+        return searchValue;
+    });
     //Route specific
     map.insert(eSearchPropertyRteTrkDistance, [](CGisItemRte* item){
         searchValue_t searchValue;

--- a/src/qmapshack/gis/search/CSearch.cpp
+++ b/src/qmapshack/gis/search/CSearch.cpp
@@ -458,6 +458,7 @@ QMap<QString, searchProperty_e> CSearch::initSearchPropertyEnumMap()
     map.insert(tr("description"), eSearchPropertyGeneralDescription);
     map.insert(tr("rating"), eSearchPropertyGeneralRating);
     map.insert(tr("keywords"), eSearchPropertyGeneralKeywords);
+    map.insert(tr("type"), eSearchPropertyGeneralType);
 
     //Area keywords
     map.insert(tr("area"), eSearchPropertyAreaArea);
@@ -474,6 +475,12 @@ QMap<QString, searchProperty_e> CSearch::initSearchPropertyEnumMap()
     map.insert(tr("GCCode"), eSearchPropertyGeocacheGCCode);
     map.insert(tr("GCName"), eSearchPropertyGeocacheGCName);
     map.insert(tr("status"), eSearchPropertyGeocacheStatus);
+    map.insert(tr("GCType"), eSearchPropertyGeocacheGCType);
+    map.insert(tr("logged by"), eSearchPropertyGeocacheLoggedBy);
+    map.insert(tr("latest log date"), eSearchPropertyGeocacheLastLogDate);
+    map.insert(tr("latest log type"), eSearchPropertyGeocacheLastLogType);
+    map.insert(tr("latest log by"), eSearchPropertyGeocacheLastLogBy);
+    map.insert(tr("GCOwner"), eSearchPropertyGeocacheGCOwner);
 
     //Waypoint keywords
 
@@ -512,6 +519,7 @@ QMap<searchProperty_e, QString> CSearch::initSearchPropertyMeaningMap()
     map.insert(eSearchPropertyGeneralDescription, tr("searches the Description"));
     map.insert(eSearchPropertyGeneralKeywords, tr("searches the Keywords"));
     map.insert(eSearchPropertyGeneralRating, tr("compares the Rating"));
+    map.insert(eSearchPropertyGeneralType, tr("searches the type of the GisItem (Waypoint, Track, Route, Area)"));
 
     //Area keywords
     map.insert(eSearchPropertyAreaArea, tr("searches the area"));
@@ -525,6 +533,12 @@ QMap<searchProperty_e, QString> CSearch::initSearchPropertyMeaningMap()
     map.insert(eSearchPropertyGeocacheGCCode, tr("searches the GCCode of a geocache."));
     map.insert(eSearchPropertyGeocacheGCName, tr("searches the Name of a geocache."));
     map.insert(eSearchPropertyGeocacheStatus, tr("searches the status of a geocache. (available, not available, archived)"));
+    map.insert(eSearchPropertyGeocacheGCType, tr("searches the type of a geocache. (traditional, unknown, virtual...)"));
+    map.insert(eSearchPropertyGeocacheLoggedBy, tr("searches the available logs for a username"));
+    map.insert(eSearchPropertyGeocacheLastLogDate, tr("searches the date of the latest log"));
+    map.insert(eSearchPropertyGeocacheLastLogType, tr("searches the type of the latest log (Found It, Didn't find it, Owner Maintenance, Write Note...)"));
+    map.insert(eSearchPropertyGeocacheLastLogBy, tr("searches the username of the latest log"));
+    map.insert(eSearchPropertyGeocacheGCOwner, tr("searches the username of the geocache owner"));
 
     //Waypoint keywords
 

--- a/src/qmapshack/gis/search/CSearch.h
+++ b/src/qmapshack/gis/search/CSearch.h
@@ -72,6 +72,7 @@ enum searchProperty_e: unsigned int
     eSearchPropertyGeneralDescription,
     eSearchPropertyGeneralRating,
     eSearchPropertyGeneralKeywords,
+    eSearchPropertyGeneralType,
 
     //Area keywords
     eSearchPropertyAreaArea,
@@ -85,6 +86,12 @@ enum searchProperty_e: unsigned int
     eSearchPropertyGeocacheGCCode,
     eSearchPropertyGeocacheGCName,
     eSearchPropertyGeocacheStatus,
+    eSearchPropertyGeocacheGCType,
+    eSearchPropertyGeocacheLoggedBy,
+    eSearchPropertyGeocacheLastLogDate,
+    eSearchPropertyGeocacheLastLogType,
+    eSearchPropertyGeocacheLastLogBy,
+    eSearchPropertyGeocacheGCOwner,
 
     //Waypoint keywords
 

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -3320,6 +3320,11 @@ QMap<searchProperty_e, CGisItemTrk::fSearch> CGisItemTrk::initKeywordLambdaMap()
         searchValue.str1 = QStringList(item->getKeywords().toList()).join(", ");
         return searchValue;
     });
+    map.insert(eSearchPropertyGeneralType, [](CGisItemTrk* item){
+        searchValue_t searchValue;
+        searchValue.str1 = tr("track");
+        return searchValue;
+    });
     //Route / track keywords
     map.insert(eSearchPropertyRteTrkDistance, [](CGisItemTrk* item){
         searchValue_t searchValue;

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -1289,6 +1289,11 @@ QMap<searchProperty_e, CGisItemWpt::fSearch> CGisItemWpt::initKeywordLambdaMap()
         searchValue.str1 = QStringList(item->getKeywords().toList()).join(", ");
         return searchValue;
     });
+    map.insert(eSearchPropertyGeneralType, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        searchValue.str1 = tr("waypoint");
+        return searchValue;
+    });
     //Geocache keywords
     map.insert(eSearchPropertyGeocacheDifficulty, [](CGisItemWpt* item){
         searchValue_t searchValue;
@@ -1367,6 +1372,49 @@ QMap<searchProperty_e, CGisItemWpt::fSearch> CGisItemWpt::initKeywordLambdaMap()
             searchValue.str1 = tr("not available");
         }
 
+        return searchValue;
+    });
+    map.insert(eSearchPropertyGeocacheGCType, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        searchValue.str1 = item->geocache.type;
+        return searchValue;
+    });
+    map.insert(eSearchPropertyGeocacheLoggedBy, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        for(geocachelog_t log : item->geocache.logs)
+        {
+            searchValue.str1 += log.finder + ", ";
+        }
+        return searchValue;
+    });
+    map.insert(eSearchPropertyGeocacheLastLogDate, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        if(item->geocache.logs.size() > 0)
+        {
+            searchValue.value1 = item->geocache.logs[0].date.toSecsSinceEpoch();
+            searchValue.str1 = "SsE"; //To differentiate Dates and Durations
+        }
+        return searchValue;
+    });
+    map.insert(eSearchPropertyGeocacheLastLogType, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        if(item->geocache.logs.size() > 0)
+        {
+            searchValue.str1 = item->geocache.logs[0].type;
+        }
+        return searchValue;
+    });
+    map.insert(eSearchPropertyGeocacheLastLogBy, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        if(item->geocache.logs.size() > 0)
+        {
+            searchValue.str1 = item->geocache.logs[0].finder;
+        }
+        return searchValue;
+    });
+    map.insert(eSearchPropertyGeocacheGCOwner, [](CGisItemWpt* item){
+        searchValue_t searchValue;
+        searchValue.str1 = item->geocache.owner;
         return searchValue;
     });
     return map;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#223

**Describe roughly what you have done:**

Add new search properties:
 
* QMS Type (Route, Track, Wpt, Area)
* GC Type (Traditional, Unknown etc.)
* GC Owner
* logged by
* latest log date
* latest log type
* latest log by


**What steps have to be done to perform a simple smoke test:**

1. Conduct a search for these properties

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
