### PR TITLE
QMS-231 Improve English spelling

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-216] QMapShack does not compile with Qt-5.15
 [QMS-217] Fix crash due to faulty profiles.xml
 [QMS-223] Add additional filter properties
+[QMS-231] Improve English spelling
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/IMainWindow.ui
+++ b/src/qmapshack/IMainWindow.ui
@@ -429,7 +429,7 @@
      <normaloff>:/icons/32x32/ToolTip.png</normaloff>:/icons/32x32/ToolTip.png</iconset>
    </property>
    <property name="text">
-    <string>Map Tool Tip</string>
+    <string>Map Tooltip</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+I</string>
@@ -531,7 +531,7 @@
      <normaloff>:/icons/32x32/TimeZoneSetup.png</normaloff>:/icons/32x32/TimeZoneSetup.png</iconset>
    </property>
    <property name="text">
-    <string>Setup Time Zone</string>
+    <string>Setup Timezone</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -840,7 +840,7 @@
      <normaloff>:/icons/32x32/FullScreen.png</normaloff>:/icons/32x32/FullScreen.png</iconset>
    </property>
    <property name="text">
-    <string>Full Screen</string>
+    <string>Fullscreen</string>
    </property>
    <property name="shortcut">
     <string>F11</string>

--- a/src/qmapshack/gis/search/CSearchExplanationDialog.cpp
+++ b/src/qmapshack/gis/search/CSearchExplanationDialog.cpp
@@ -54,7 +54,7 @@ CSearchExplanationDialog::CSearchExplanationDialog(QWidget *parent)
     explanation += "</ul>";
     explanation += "</li>";
     explanation += "<li>";
-    explanation += tr(  "'Date equals' matches everything that is within the next 24h, if time is provided with date, if not, then everything on the day queried. Be aware that that the times are converted to UTC before comparison and you local time zone is taken for the query.");
+    explanation += tr(  "'Date equals' matches everything that is within the next 24h, if time is provided with date, if not, then everything on the day queried. Be aware that that the times are converted to UTC before comparison and you local timezone is taken for the query.");
     explanation += "</li>";
     explanation += "<li>";
     explanation += tr(  "If you enter no unit the default unit (what you see when viewing the property of the item) is used.");

--- a/src/qmapshack/gis/trk/IScrOptTrk.ui
+++ b/src/qmapshack/gis/trk/IScrOptTrk.ui
@@ -117,7 +117,7 @@
      <item>
       <widget class="QToolButton" name="toolRange">
        <property name="toolTip">
-        <string extracomment="use line breakes to keep a sensible tool tip width">Select a range of points. You can use that tool to:
+        <string extracomment="use line breaks to keep a sensible tooltip width">Select a range of points. You can use that tool to:
 
 * Hide or show points of a track. 
 * You can copy the selected range. 
@@ -139,7 +139,7 @@ this is the right tool. Simply select the section of bad points
      <item>
       <widget class="QToolButton" name="toolEdit">
        <property name="toolTip">
-        <string extracomment="use line breakes to keep a sensible tool tip width">Edit the position of track points and use automatic routing 
+        <string extracomment="use line breaks to keep a sensible tooltip width">Edit the position of track points and use automatic routing 
 to create new track points. This is used to create new tracks 
 to plan a tour.
 

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -281,7 +281,7 @@ void CMapIMG::setupTyp()
     polylineProperties[0x15].strings[0x00] = tr("Shoreline");
     polylineProperties[0x16].strings[0x00] = tr("Trail");
     polylineProperties[0x18].strings[0x00] = tr("Stream");
-    polylineProperties[0x19].strings[0x00] = tr("Time zone");
+    polylineProperties[0x19].strings[0x00] = tr("Timezone");
     polylineProperties[0x1a].strings[0x00] = tr("Ferry");
     polylineProperties[0x1b].strings[0x00] = tr("Ferry");
     polylineProperties[0x1c].strings[0x00] = tr("State/province border");

--- a/src/qmapshack/realtime/CRtSelectSource.cpp
+++ b/src/qmapshack/realtime/CRtSelectSource.cpp
@@ -60,7 +60,7 @@ CRtSelectSource::CRtSelectSource(CRtWorkspace &wks)
 
     connect(listWidget, &QListWidget::itemSelectionChanged, this, &CRtSelectSource::slotSelectionChanged);
 
-    labelHelp->setText(tr("Select a real time source from the list. "
+    labelHelp->setText(tr("Select a realtime source from the list. "
                           "Some sources can be added multiple times. "
                           "For others only a single instance can be added."
                           ));

--- a/src/qmapshack/realtime/CRtWorkspace.cpp
+++ b/src/qmapshack/realtime/CRtWorkspace.cpp
@@ -64,7 +64,7 @@ CRtWorkspace::CRtWorkspace(QWidget *parent)
 
     cfg.endGroup();
 
-    labelHelp->setText(tr("To add a real time source do a right click on the list above. "));
+    labelHelp->setText(tr("To add a realtime source do a right click on the list above. "));
     slotChanged();
 }
 

--- a/src/qmapshack/realtime/gpstether/CRtGpsTetherInfo.cpp
+++ b/src/qmapshack/realtime/gpstether/CRtGpsTetherInfo.cpp
@@ -99,7 +99,7 @@ void CRtGpsTetherInfo::slotHelp() const
                                 "The basic idea of this GPS source is to receive a NMEA stream "
                                 "via Ethernet connection. You can use the Android app \"GPS Tether\" "
                                 "to provide a host streaming NMEA data. Your Android device must be "
-                                "in the same network or provide a network as a hot spot.\n"
+                                "in the same network or provide a network as a hotspot.\n"
                                 "For configuration you need to know your Android device's IP address "
                                 "or it's host name provided by a DNS. The app will tell you the address. "
                                 "Additionally you need the port number as configured in the app."

--- a/src/qmapshack/setup/CLogHandler.cpp
+++ b/src/qmapshack/setup/CLogHandler.cpp
@@ -45,7 +45,7 @@ void CLogHandler::log(QtMsgType type, const QMessageLogContext &context, const Q
 
 void CLogHandler::printLoggerInfo()
 {
-    qDebug() << "Log configuration:" << "log file=" << logFile.fileName() << "write to file=" << writeToFile <<
+    qDebug() << "Log configuration:" << "logfile=" << logFile.fileName() << "write to file=" << writeToFile <<
         "debug output=" << debugOutput;
 }
 

--- a/src/qmapshack/units/ITimeZoneSetup.ui
+++ b/src/qmapshack/units/ITimeZoneSetup.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Setup Time Zone ...</string>
+   <string>Setup Timezone ...</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/qmaptool/setup/CLogHandler.cpp
+++ b/src/qmaptool/setup/CLogHandler.cpp
@@ -45,7 +45,7 @@ void CLogHandler::log(QtMsgType type, const QMessageLogContext &context, const Q
 
 void CLogHandler::printLoggerInfo()
 {
-    qDebug() << "Log configuration:" << "log file=" << logFile.fileName() << "write to file=" << writeToFile <<
+    qDebug() << "Log configuration:" << "logfile=" << logFile.fileName() << "write to file=" << writeToFile <<
         "debug output=" << debugOutput;
 }
 

--- a/src/qmaptool/units/ITimeZoneSetup.ui
+++ b/src/qmaptool/units/ITimeZoneSetup.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Setup Time Zone ...</string>
+   <string>Setup Timezone ...</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#231

**Describe roughly what you have done:**

Changed the spelling of some English terms, e.g. fullscreen, realtime, etc.

**What steps have to be done to perform a simple smoke test:**

1. Create new language files
1. See improved spelling of corrected terms

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
