### PR TITLE
Ruler tool: Don't show negative courses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V1.XX.X
 [QMS-217] Fix crash due to faulty profiles.xml
 [QMS-223] Add additional filter properties
 [QMS-231] Improve English spelling
+[QMS-240] Fix negative courses in the ruler tool
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/mouse/CMouseRuler.cpp
+++ b/src/qmapshack/mouse/CMouseRuler.cpp
@@ -374,7 +374,7 @@ void CMouseRuler::updateStatus(const QPolygonF &line)
             msg += "<td></td><td></td>";
         }
 
-        val.sprintf("%1.1f", a1);
+        val.sprintf("%1.1f", (a1 < 0) ? (a1 + 360) : a1);
         msg += QString("<td align=right>%1°</td>").arg(val);
 
         msg += "</tr>";
@@ -464,9 +464,10 @@ void CMouseRuler::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect &
                 str += QString(", %1 %2%3").arg(delta > 0 ? QChar(0x2197) : QChar(0x2198)).arg(val).arg(unit);
             }
 
+
             if(scrOptRuler->toolShowCourse->isChecked())
             {
-                val.sprintf("%1.1f", a1);
+                val.sprintf("%1.1f", (a1 < 0) ? (a1 + 360) : a1);
                 str += QString(", %1°").arg(val);
             }
 


### PR DESCRIPTION
Instead of showing courses like `-45°`, we now display `315°`.
This applies to the course displayed next to the line, and to the table.


**What is the linked issue for this pull request (start with a `#`):** QMS-#240

**Describe roughly what you have done:**

Fixed #240

Add a simple `?` expression in the table update function as in the line drawing function.


**What steps have to be done to perform a simple smoke test:**


1. Open a empty map view with an arbitrary map at an arbitrary position
2. Right click on the map and select 'Ruler' to open the distance ruler tool
3. Draw a rectangle or any other figure with courses > 180 degrees, e.g. north west
4. The courses are now displayed properly :-)


**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt