### PR TITLE
[QMS-235] Save track profile window's geometry when window gets closed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V1.XX.X
 [QMS-217] Fix crash due to faulty profiles.xml
 [QMS-223] Add additional filter properties
 [QMS-231] Improve English spelling
+[QMS-235] Save track profile window's geometry when window gets closed
 [QMS-240] Fix negative courses in the ruler tool
 [QMS-244] Unable to create rotino database (planetsplitter: cannot open file)
 

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -166,6 +166,8 @@ CCanvas::CCanvas(QWidget *parent, const QString &name)
 
 CCanvas::~CCanvas()
 {
+    saveSizeTrackProfile();
+
     /* stop running drawing-threads and don't destroy unless they have finished*/
     for(IDrawContext * context : allDrawContext)
     {
@@ -182,7 +184,6 @@ CCanvas::~CCanvas()
         in CCanvas is destroyed.
      */
     delete mouse;
-    saveSizeTrackProfile();
 }
 
 void addHtmlRow(QString& text, const QString& col1, const QString& col2, const QString& td1, const QString& td2)
@@ -906,7 +907,6 @@ void CCanvas::slotCheckTrackOnFocus()
     // any changes?
     if(key != keyTrackOnFocus)
     {
-        saveSizeTrackProfile();
         // get access to current track object
         delete plotTrackProfile;
         delete colorLegend;

--- a/src/qmapshack/canvas/CCanvas.h
+++ b/src/qmapshack/canvas/CCanvas.h
@@ -173,11 +173,14 @@ public:
 
     void followPosition(const QPointF& pos);
 
-    //Allows showing the track overlays if they are set in CMainWindow
+    /// Allows showing the track overlays if they are set in CMainWindow
     void allowShowTrackOverlays(bool show)
     {
         showTrackOverlays = show;
     }
+
+    /// save the size of the track profile if it is in window mode
+    void saveSizeTrackProfile();
 
     static qreal gisLayerOpacity;
 
@@ -220,7 +223,6 @@ private:
     }
     void setZoom(bool in, redraw_e & needsRedraw);
     void setSizeTrackProfile();
-    void saveSizeTrackProfile();
     /**
        @brief Resize all registered drwa context objects
 

--- a/src/qmapshack/plot/IPlot.cpp
+++ b/src/qmapshack/plot/IPlot.cpp
@@ -130,6 +130,7 @@ IPlot::~IPlot()
             CCanvas * canvas = dynamic_cast<CCanvas*>(parent());
             if(canvas)
             {
+                canvas->saveSizeTrackProfile();
                 canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawGis);
             }
         }


### PR DESCRIPTION
Save size before it gets closed.

**What is the linked issue for this pull request (start with a `#`):** QMS-#235

**Describe roughly what you have done:**

Save the profile window size when the profile gets switched from window mode to on-screen mode.

**What steps have to be done to perform a simple smoke test:**

* Load a track
* Highlight the track to open the profile view
* Switch profile view to window mode
* Change size of profile window
* Toggle back to on-screen mode
* Toggle back to window mode 

-> now the profile window must have the exact same size as before.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Is the change user facing?**

- [x] yes,
- [ ] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [x] yes, I didn't forget to change changelog.txt
