### PR TITLE
Replaced for-loop to fix empty sourceFiles problem.

### DIFF
--- a/src/qmapshack/tool/CRoutinoDatabaseBuilder.cpp
+++ b/src/qmapshack/tool/CRoutinoDatabaseBuilder.cpp
@@ -137,12 +137,10 @@ void CRoutinoDatabaseBuilder::enabelStartButton()
 
 void CRoutinoDatabaseBuilder::slotStart()
 {
-    pushStart->setDisabled(true);
-
-    sourceFiles.clear();
-    for(const QListWidgetItem * item : listWidget->findItems("*", Qt::MatchWildcard))
+    const int N = listWidget->count();
+    for(int n = 0; n < N; n++)
     {
-        sourceFiles << item->text();
+        sourceFiles << listWidget->item(n)->text();
     }
 
     targetPrefix    = lineTargetPrefix->text();


### PR DESCRIPTION
At least with Qt 5.15 it happened that sourceFiles was accidentially
empty. The new for-loop fixes that.

**What is the linked issue for this pull request (start with a `#`):** QMS-#
n/a

**Describe roughly what you have done:**

As proposed in the naviboard forum, I replaced the for-loop which fills sourceFiles.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X ] yes

**Is every user facing string in a tr() macro?**

- [ ] yes

**Is the change user facing?**

- [ ] yes,
- [ X] no

**If there are user facing changes did you add the ticket number and title into the changelog?**

- [ ] yes, I didn't forget to change changelog.txt
