### PR TITLE
[QMS-244] Unable to create routino database

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-223] Add additional filter properties
 [QMS-231] Improve English spelling
 [QMS-240] Fix negative courses in the ruler tool
+[QMS-244] Unable to create rotino database (planetsplitter: cannot open file)
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/tool/CMapVrtBuilder.cpp
+++ b/src/qmapshack/tool/CMapVrtBuilder.cpp
@@ -173,9 +173,10 @@ void CMapVrtBuilder::slotStart()
     tempFile->open();
     tempFile->resize(0);
     QTextStream stream(tempFile);
-    for(const QListWidgetItem * item : listWidget->findItems("*", Qt::MatchWildcard))
+    const int N = listWidget->count();
+    for(int n = 0; n < N; n++)
     {
-        stream << item->text() << endl;
+        stream << listWidget->item(n)->text() << endl;
     }
     tempFile->close();
     args << "-input_file_list" << tempFile->fileName();

--- a/src/qmapshack/tool/CRoutinoDatabaseBuilder.cpp
+++ b/src/qmapshack/tool/CRoutinoDatabaseBuilder.cpp
@@ -140,9 +140,10 @@ void CRoutinoDatabaseBuilder::slotStart()
     pushStart->setDisabled(true);
 
     sourceFiles.clear();
-    for(const QListWidgetItem * item : listWidget->findItems("*", Qt::MatchWildcard))
+    const int N = listWidget->count();
+    for(int n = 0; n < N; n++)
     {
-        sourceFiles << item->text();
+        sourceFiles << listWidget->item(n)->text();
     }
 
     targetPrefix    = lineTargetPrefix->text();


### PR DESCRIPTION
At least with Qt 5.15 it happened that QListWidget::findItems
accidentially returned an empty list. The new for-loop fixes that.

_**Note: Do not delete any of the sections**_
_**Answer them all. Replace the descriptive text**_
_**by your answer**_


**What is the linked issue for this pull request (start with a `#`):** QMS-#244

**Describe roughly what you have done:**

I changed the for-loop so that it can't miss list items anymore.

**What steps have to be done to perform a simple smoke test:**

1. Go to 'Tool -> Create Routino Database
2. Select a *.pbf file
3. Select a path for your Routino database
4. Select a prefix
5. Press 'Start' button

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] yes

**Is every user facing string in a tr() macro?**

- [X] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [X] yes, I didn't forget to change changelog.txt
