### PR TITLE
[QMS-247] Build error: "Target "qmapshack" links to target "Qt5::Posi…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-235] Save track profile window's geometry when window gets closed
 [QMS-240] Fix negative courses in the ruler tool
 [QMS-244] Unable to create rotino database (planetsplitter: cannot open file)
+[QMS-247] Build error: "Target "qmapshack" links to target "Qt5::Positioning" but the target was not found"
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -939,7 +939,6 @@ target_link_libraries(${APPLICATION_NAME}
     Qt5::Network
     Qt5::WebEngineWidgets
     Qt5::Qml
-    Qt5::Positioning
     Qt5::Help
     ${DBUS_LIB}
     ${GDAL_LIBRARIES}

--- a/src/qmapshack/realtime/gpstether/CRtGpsTether.cpp
+++ b/src/qmapshack/realtime/gpstether/CRtGpsTether.cpp
@@ -23,7 +23,6 @@
 #include "realtime/gpstether/CRtGpsTetherInfo.h"
 #include "units/IUnit.h"
 
-#include <QtPositioning>
 #include <QtWidgets>
 
 #define GPS_TETHER "GPS Tether"


### PR DESCRIPTION
_**Note: Do not delete any of the sections**_
_**Answer them all. Replace the descriptive text**_
_**by your answer**_


**What is the linked issue for this pull request (start with a `#`):** QMS-#247

**Describe roughly what you have done:**

As QtPositioning is not really used this seems to be a left over from development. 
Removed it from the cmake file and removed the header include in the code.

**What steps have to be done to perform a simple smoke test:**

Should compile without error.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
