### PR TITLE
[QMS-254] MySQL: QMapShack does not automatically reconnect

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-240] Fix negative courses in the ruler tool
 [QMS-244] Unable to create rotino database (planetsplitter: cannot open file)
 [QMS-247] Build error: "Target "qmapshack" links to target "Qt5::Positioning" but the target was not found"
+[QMS-254] MySQL: QMapShack does not automatically reconnect
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/gis/db/IDBMysql.cpp
+++ b/src/qmapshack/gis/db/IDBMysql.cpp
@@ -44,6 +44,7 @@ bool IDBMysql::setupDB(const QString& server, const QString& port, const QString
         db = QSqlDatabase::addDatabase("QMYSQL", connectionName);
         db.setDatabaseName(name);
         db.setHostName(server);
+        db.setConnectOptions("MYSQL_OPT_RECONNECT=1");
 
         if(!port.isEmpty())
         {


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#254

**Describe roughly what you have done:**

Simply added the option to reconnect to the MySQL connector.

**What steps have to be done to perform a simple smoke test:**

* Connect to a MySQL server with automatic disconnect
* Wait idle time
* Next database interaction should work without error.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
