### PR TITLE
[QMS-257] Import gpx file to group folder does not trigger update

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-244] Unable to create rotino database (planetsplitter: cannot open file)
 [QMS-247] Build error: "Target "qmapshack" links to target "Qt5::Positioning" but the target was not found"
 [QMS-254] MySQL: QMapShack does not automatically reconnect
+[QMS-257] Import gpx file to group folder does not trigger update
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/gis/CGisListDB.cpp
+++ b/src/qmapshack/gis/CGisListDB.cpp
@@ -1091,6 +1091,7 @@ void CGisListDB::slotImport()
     IDBFolderSql * dbfolder = folder->getDBFolder();
     if(dbfolder)
     {
+        dbfolder->update();
         dbfolder->announceChange();
     }
 


### PR DESCRIPTION
Added the missing update() call.

_**Note: Do not delete any of the sections**_
_**Answer them all. Replace the descriptive text**_
_**by your answer**_


**What is the linked issue for this pull request (start with a `#`):** QMS-#257

**Describe roughly what you have done:**

I added the missing update() call.

**What steps have to be done to perform a simple smoke test:**

1. Right-click on the root item of the database tree
2. Click on 'Add Folder'
3. Type in a folder name and select 'Group'.
4. Click 'OK' and the folder gets created.
5. Right-click on that folder.
6. Click on 'Import from Files…'
7. Select a gpx file and import it.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] yes

**Is every user facing string in a tr() macro?**

- [X] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [X] yes, I didn't forget to change changelog.txt
