### PR TITLE
[QMS-260] Enhance cut tool to work with files containig reference inf…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V1.XX.X
 [QMS-247] Build error: "Target "qmapshack" links to target "Qt5::Positioning" but the target was not found"
 [QMS-254] MySQL: QMapShack does not automatically reconnect
 [QMS-257] Import gpx file to group folder does not trigger update
+[QMS-260] QMapTool: Enhance cut tool to work with files containig reference information
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmaptool/canvas/CDrawContextPixel.cpp
+++ b/src/qmaptool/canvas/CDrawContextPixel.cpp
@@ -25,6 +25,7 @@
 
 CDrawContextPixel::CDrawContextPixel(CCanvas *canvas, QObject * parent)
     : IDrawContext(canvas, parent)
+    , CGdalFile(CGdalFile::eTypePixel)
 {
     scale = QPointF(1.0, 1.0);
 }
@@ -44,6 +45,15 @@ void CDrawContextPixel::convertCoord2Map(QPointF &pt) const
     pt = trInv.map(pt);
 }
 
+void CDrawContextPixel::convertMap2Proj(QPointF &pt) const
+{
+    pt = trFwdProj.map(pt);
+}
+
+void CDrawContextPixel::convertProj2Map(QPointF &pt) const
+{
+    pt = trInvProj.map(pt);
+}
 
 void CDrawContextPixel::setSourceFile(const QString& filename, bool resetContext)
 {
@@ -51,7 +61,7 @@ void CDrawContextPixel::setSourceFile(const QString& filename, bool resetContext
 
     if(resetContext)
     {
-        focus = QPointF(0,0);
+        focus = QPointF(0, 0);
         zoom(6);
     }
 
@@ -116,7 +126,7 @@ void CDrawContextPixel::drawt(buffer_t& buf)
         GDALRasterBand * pBand;
         pBand = dataset->GetRasterBand(1);
 
-        img = QImage(screenWidth,screenHeight,QImage::Format_Indexed8);
+        img = QImage(screenWidth, screenHeight, QImage::Format_Indexed8);
         img.setColorTable(colortable);
 
         mutex.lock();

--- a/src/qmaptool/canvas/CDrawContextPixel.h
+++ b/src/qmaptool/canvas/CDrawContextPixel.h
@@ -77,11 +77,13 @@ public:
 
     QRectF getMapArea() const override
     {
-        return QRectF(0,0, xsize_px, ysize_px);
+        return QRectF(0, 0, xsize_px, ysize_px);
     }
 
     void convertMap2Coord(QPointF &pt) const override;
     void convertCoord2Map(QPointF &pt) const override;
+    void convertMap2Proj(QPointF &pt) const override;
+    void convertProj2Map(QPointF &pt) const override;
 
 protected:
     void drawt(buffer_t& buf) override;

--- a/src/qmaptool/canvas/CDrawContextProj.cpp
+++ b/src/qmaptool/canvas/CDrawContextProj.cpp
@@ -24,6 +24,7 @@
 
 CDrawContextProj::CDrawContextProj(CCanvas *canvas, QObject *parent)
     : IDrawContext(canvas, parent)
+    , CGdalFile(CGdalFile::eTypeProj)
 {
 }
 

--- a/src/qmaptool/canvas/IDrawContext.h
+++ b/src/qmaptool/canvas/IDrawContext.h
@@ -69,8 +69,37 @@ public:
     void convertMap2Screen(QPolygonF& line) const;
     void convertMap2Screen(QRectF &rect) const;
 
+    /**
+       @brief Convert point in map to coordinates
+
+        Depending on the type and the reference information
+        of the map the result can be:
+
+        * CGdalFile::eTypePixel: Pixel coordinates
+        * CGdalFile::eTypeProj: Geo coordinates, if the file
+          is referenced else pixel coordinates
+     */
     virtual void convertMap2Coord(QPointF &pt) const = 0;
     virtual void convertCoord2Map(QPointF &pt) const = 0;
+
+    /** Convert point in map to coordinates
+
+      Depending on the reference information of the map
+      the result can be:
+
+      * Referenced map: Geo coordinates
+      * Un-referenced map: Pixel coordinates
+
+    */
+    virtual void convertMap2Proj(QPointF &pt) const
+    {
+        convertMap2Coord(pt);
+    }
+
+    virtual void convertProj2Map(QPointF &pt) const
+    {
+        convertCoord2Map(pt);
+    }
 
     /**
        @brief draw
@@ -102,8 +131,8 @@ protected:
     {
         QImage image;
 
-        QPointF zoomFactor {1.0,1.0}; //< the zoomfactor used to draw the canvas
-        QPointF scale {1.0,1.0}; //< the scale of the global viewport
+        QPointF zoomFactor {1.0, 1.0}; //< the zoomfactor used to draw the canvas
+        QPointF scale {1.0, 1.0}; //< the scale of the global viewport
 
         QPointF ref1;  //< top left corner
         QPointF ref2;  //< top right corner

--- a/src/qmaptool/helpers/CGdalFile.cpp
+++ b/src/qmaptool/helpers/CGdalFile.cpp
@@ -25,7 +25,8 @@
 
 #include <QtWidgets>
 
-CGdalFile::CGdalFile()
+CGdalFile::CGdalFile(type_e type)
+    : type(type)
 {
 }
 
@@ -46,7 +47,7 @@ void CGdalFile::load(const QString& filename)
     qDebug() << filename;
     CCanvas * canvas = CMainWindow::self().getCanvas();
 
-    dataset = (GDALDataset*)GDALOpenShared(filename.toUtf8(),GA_ReadOnly);
+    dataset = (GDALDataset*)GDALOpenShared(filename.toUtf8(), GA_ReadOnly);
 
     if(nullptr == dataset)
     {
@@ -91,7 +92,7 @@ void CGdalFile::load(const QString& filename)
         if(pBand->GetColorInterpretation() ==  GCI_PaletteIndex )
         {
             GDALColorTable * pct = pBand->GetColorTable();
-            for(int i=0; i < pct->GetColorEntryCount(); ++i)
+            for(int i = 0; i < pct->GetColorEntryCount(); ++i)
             {
                 const GDALColorEntry& e = *pct->GetColorEntry(i);
                 colortable << qRgba(e.c1, e.c2, e.c3, e.c4);
@@ -99,7 +100,7 @@ void CGdalFile::load(const QString& filename)
         }
         else if(pBand->GetColorInterpretation() ==  GCI_GrayIndex )
         {
-            for(int i=0; i < 256; ++i)
+            for(int i = 0; i < 256; ++i)
             {
                 colortable << qRgba(i, i, i, 255);
             }
@@ -135,29 +136,54 @@ void CGdalFile::load(const QString& filename)
     xsize_px = dataset->GetRasterXSize();
     ysize_px = dataset->GetRasterYSize();
 
-    qreal adfGeoTransform[6];
-    dataset->GetGeoTransform( adfGeoTransform );
+    qreal adfGeoTransform[6] = {0, 1, 0, 0, 0, 1};
+    if(type == eTypeProj)
+    {
+        dataset->GetGeoTransform( adfGeoTransform );
+    }
 
     xscale  = adfGeoTransform[1];
     yscale  = adfGeoTransform[5];
     xrot    = adfGeoTransform[4];
     yrot    = adfGeoTransform[2];
 
+    // Setup the basic transformation. Depending on the type this
+    // can be the transformation into pixel coordinates or into
+    // geo coordinates if the file is referenced.
     trFwd = QTransform();
     trFwd.translate(adfGeoTransform[0], adfGeoTransform[3]);
-    trFwd.scale(adfGeoTransform[1], adfGeoTransform[5]);
+    trFwd.scale(xscale, yscale);
 
     if(adfGeoTransform[4] != 0.0)
     {
-        trFwd.rotate(qAtan(adfGeoTransform[2]/adfGeoTransform[4]));
+        trFwd.rotate(qAtan(xrot / yrot));
     }
 
     trInv = trFwd.inverted();
 
-    ref1 = trFwd.map(QPointF(0,0));
-    ref2 = trFwd.map(QPointF(xsize_px,0));
-    ref3 = trFwd.map(QPointF(xsize_px,ysize_px));
-    ref4 = trFwd.map(QPointF(0,ysize_px));
+    ref1 = trFwd.map(QPointF(0, 0));
+    ref2 = trFwd.map(QPointF(xsize_px, 0));
+    ref3 = trFwd.map(QPointF(xsize_px, ysize_px));
+    ref4 = trFwd.map(QPointF(0, ysize_px));
+
+    {
+        // Setup the geo transformation. If the file is referenced
+        // this will be the transformation between points and geo
+        // coordinates. If not this will be point to pixel transformation
+        qreal adfGeoTransform[6] = {0, 1, 0, 0, 0, 1};
+        dataset->GetGeoTransform( adfGeoTransform );
+
+        trFwdProj = QTransform();
+        trFwdProj.translate(adfGeoTransform[0], adfGeoTransform[3]);
+        trFwdProj.scale(adfGeoTransform[1], adfGeoTransform[5]);
+
+        if(adfGeoTransform[4] != 0.0)
+        {
+            trFwdProj.rotate(qAtan(adfGeoTransform[4] / adfGeoTransform[2]));
+        }
+
+        trInvProj = trFwdProj.inverted();
+    }
 
     isValid = true;
 }

--- a/src/qmaptool/helpers/CGdalFile.h
+++ b/src/qmaptool/helpers/CGdalFile.h
@@ -33,7 +33,13 @@ class CGdalFile
 {
     Q_DECLARE_TR_FUNCTIONS(CGdalFile)
 public:
-    CGdalFile();
+    enum type_e
+    {
+        eTypePixel,
+        eTypeProj
+    };
+
+    CGdalFile(type_e type);
     virtual ~CGdalFile() = default;
 
     bool getIsValid() const
@@ -47,6 +53,8 @@ protected:
     virtual QString getInfo() const;
     virtual void load(const QString& filename);
     virtual void unload();
+
+    type_e type;
 
     GDALDataset * dataset = nullptr;
 
@@ -83,6 +91,9 @@ protected:
 
     QTransform trFwd;
     QTransform trInv;
+
+    QTransform trFwdProj;
+    QTransform trInvProj;
 
     QString proj4str;
 

--- a/src/qmaptool/items/CItemMap.cpp
+++ b/src/qmaptool/items/CItemMap.cpp
@@ -26,7 +26,8 @@
 #include <QtWidgets>
 
 CItemMap::CItemMap(const QString &filename)
-    : IItem(filename)
+    : CGdalFile(CGdalFile::eTypeProj)
+    , IItem(filename)
 {
     setText(CItemTreeWidget::eColumnName, QFileInfo(filename).completeBaseName());
     setIcon(CItemTreeWidget::eColumnName, QIcon("://icons/32x32/FolderMap.png"));

--- a/src/qmaptool/overlay/COverlayCutMap.cpp
+++ b/src/qmaptool/overlay/COverlayCutMap.cpp
@@ -268,7 +268,7 @@ void COverlayCutMap::saveShape(const QString& filename)
     for(const QPointF& pt : line)
     {
         QPointF pt1 = pt;
-        context->convertMap2Coord(pt1);
+        context->convertMap2Proj(pt1);
 
         if(!first)
         {
@@ -320,7 +320,7 @@ void COverlayCutMap::slotLoadShape()
                 in2 >> x >> y;
 
                 QPointF pt(x, y);
-                context->convertCoord2Map(pt);
+                context->convertProj2Map(pt);
 
                 region << pt;
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#260

**Describe roughly what you have done:**

Added another set of conversion methods to make use of
projection information if there is any. These methods are now
used by the cut tool to produce and read coordinates of the shape file.

**What steps have to be done to perform a simple smoke test:**

In the cut tool:
1. Open a referenced file and add a cut mask
1.1. Save the mask
1.2. Restore the saved mask
1.3. Apply the mask -> result should be a referenced and cut map

2. Open an un-referenced file and add a cut mask
2.1. Save the mask
2.2. Restore the saved mask
2.3. Apply the mask -> result should be a cut map

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
