### PR TITLE
[QMS-262] Wrong timestamp when loading FIT

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-254] MySQL: QMapShack does not automatically reconnect
 [QMS-257] Import gpx file to group folder does not trigger update
 [QMS-260] QMapTool: Enhance cut tool to work with files containig reference information
+[QMS-262] Wrong timestamp when loading FIT
 
 V1.15.0
 [QMS-68] Route Optimization

--- a/src/qmapshack/gis/fit/serialization.cpp
+++ b/src/qmapshack/gis/fit/serialization.cpp
@@ -45,7 +45,7 @@ static QDateTime toDateTime(quint32 timestamp)
 {
     QDateTime dateTime;
     dateTime.setTime_t(sec1970to1990 + timestamp);
-    return dateTime;
+    return dateTime.toUTC();
 }
 
 static QString dateTimeAsString(quint32 timestamp)


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#262

**Describe roughly what you have done:**

The helper function 
```
static QDateTime toDateTime(quint32 timestamp)
```
did not return the UTC timestamp but the local one. Used converting method.

**What steps have to be done to perform a simple smoke test:**

* Load the FIT file from the ticket.
* Copy the track into a gpx project
* Save the gpx project
* Convert the track with gpsbabel
* Compare timestamps in between both GPX
* Load both GPX into QMapShack
* All three tracks (FIT, QMS GPX, gpsbabel GPX) must start with the same timestamp

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
