### PR TITLE
[QMS-268] Crash after closing project where range is being selected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ project(QMapShack VERSION 1.15.1)
 
 # FOR A RELEASE:
 # remove "development" for a release
-set(DEVELOPMENT_VERSION OFF)
+set(DEVELOPMENT_VERSION ON)
 
 
 ###############################################################################################

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-268] Crash after closing project where range is being selected
+
 V1.15.1
 [QMS-158] Change Routino Profiles search for [prefix-]profiles.xml
 [QMS-216] QMapShack does not compile with Qt-5.15

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -313,10 +313,15 @@ CGisItemTrk::~CGisItemTrk()
     /*
         Delete all registered INotifyTrk as they can't exist without the item.
         As the INotifyTrk objects will unregister via unregisterVisual() in their
-        destructor things will get a bit complicated here. Better create
-        a copy of the list before we start to delete.
+        destructor things will get a bit complicated here. Additionally visuals
+        can be parents of other visuals. Therefor destroying one might destroy
+        others. To cover that we destroy the first object in registeredVisuals
+        until there is none left
      */
-    qDeleteAll(registeredVisuals.toList());
+    while(registeredVisuals.size())
+    {
+        delete *registeredVisuals.begin();
+    }
 
     // now it is save to destroy the details dialog
     delete dlgDetails;

--- a/src/qmapshack/mouse/range/CScrOptRangeTool.cpp
+++ b/src/qmapshack/mouse/range/CScrOptRangeTool.cpp
@@ -99,6 +99,7 @@ CScrOptRangeTool::~CScrOptRangeTool()
     trk.unregisterVisual(this);
     canvas->allowShowTrackOverlays(true);
     canvas->slotUpdateTrackInfo(false);
+    canvas->resetMouse();
 }
 
 void CScrOptRangeTool::slotCanvasResize(const QSize& sizeCanvas)


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#268

**Describe roughly what you have done:**

The root cause is the track graph as child in the range select
tool. Both are registered visuals of the track. When destroying
the track the range select tool is destroyed first destroying it's
children. This renderes all pointers in the copied list of
registered visuals invalid.

To fix that we have to pick the first element in the list of
registered visuals and destroyi it. This has to be repeated
until the list is empty.

**What steps have to be done to perform a simple smoke test:**

* Load some gpx or fit file
* Right click on one of the tracks and select "Select Range"
* Right click on the associated project and close it.

-> no crash must occur. The mouse cursor must be in normal mode again.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
