### PR TITLE
[QMS-264] Windows: adapt build scripts for 1.15.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if (APPLE)
 endif(APPLE)
 
 if(WIN32)
-    set(QT_DEV_PATH   "C:\\Qt5\\5.12.3\\msvc2017_64" CACHE PATH "Path to directory containing Qt5 include and lib, e.g. C:\\Qt5\\5.12.3\\msvc2017_64")
+    set(QT_DEV_PATH   "C:\\Qt\\5.12.10\\msvc2017_64" CACHE PATH "Path to directory containing Qt5 include and lib, e.g. C:\\Qt\\5.12.10\\msvc2017_64")
     set(GDAL_DEV_PATH "C:\\GDAL" CACHE PATH "Path to directory containing GDAL include and lib, e.g. M:\\lib\\gdal")
     set(PROJ4_DEV_PATH "C:\\PROJ6" CACHE PATH "Path to directory containing PROJ.4 include and lib, e.g. M:\\lib\\PROJ6")
     set(ROUTINO_DEV_PATH "C:\\routino" CACHE PATH "Path to directory containing routino include and lib, e.g. M:\\lib\\routino")

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 V1.XX.X
-[QMS-270] Windows: rename LICENSE file to 1LICENSE.txt
 [QMS-264] Windows: adapt build scripts for 1.15.1 release
 [QMS-268] Crash after closing project where range is being selected
+[QMS-270] Windows: rename LICENSE file to 1LICENSE.txt
+[QMS-273] Windows: install Help search index files
 
 V1.15.1
 [QMS-158] Change Routino Profiles search for [prefix-]profiles.xml

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-264] Windows: adapt build scripts for 1.15.1 release
 [QMS-268] Crash after closing project where range is being selected
 
 V1.15.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-270] Windows: rename LICENSE file to 1LICENSE.txt
 [QMS-264] Windows: adapt build scripts for 1.15.1 release
 [QMS-268] Crash after closing project where range is being selected
 

--- a/msvc_64/3rdparty.txt
+++ b/msvc_64/3rdparty.txt
@@ -2,10 +2,12 @@
 #         QMapShack for Windows dependencies                #
 #############################################################
 This installation of QMapShack for Windows (short: QMS) 
-has been build with Visual Studio 2013 as 64bit application.
+has been build with Visual Studio 2017 as 64bit application.
 
 If you want to build QMS on your own, have a look at
 https://github.com/Maproom/qmapshack/wiki/BuildWindowsVisualStudio
+
+The QMS source code is available at https://github.com/Maproom/qmapshack
 
 Dependencies
 ============
@@ -19,9 +21,9 @@ QMS depends on the 3rd party software listed below:
   Note: Those runtime libraries may already be contained in Windows 10 installations.
 
 2.) Qt5 runtime libraries
-  The Qt DLL's are deployed in the QMS installation directory. 
-  They are part of Qt which you can download here:
-    http://qt-project.org/downloads
+  The Qt libraries are deployed in the QMS installation directory.
+  Qt is used according the GPLv3 open source License
+    See https://www.qt.io/download-open-source and https://www.gnu.org/licenses/gpl-3.0.html
 
 3.) The GDAL library, http://www.gdal.org/
 
@@ -60,3 +62,6 @@ QMS depends on the 3rd party software listed below:
 
 12.) sqlite
   The source code can be downloaded from https://www.sqlite.org/download.html
+
+13.) QuaZIP
+  The source code can be downloaded from https://stachenov.github.io/quazip/

--- a/msvc_64/QMapShack_Installer.nsi
+++ b/msvc_64/QMapShack_Installer.nsi
@@ -129,6 +129,7 @@ Section "QMapShack" QMapShack
 
   ;BEGIN Qt Files
   SetOutPath $INSTDIR
+    File Files\assistant.exe
     File Files\Qt5Core.dll
     File Files\Qt5Gui.dll
     File Files\Qt5Help.dll
@@ -164,7 +165,7 @@ Section "QMapShack" QMapShack
 
   SetOutPath "$INSTDIR\sqldrivers\"
     File Files\sqldrivers\qsqlite.dll
-    File Files\sqldrivers\qsqlmysql.dll
+    ;File Files\sqldrivers\qsqlmysql.dll
     File Files\sqldrivers\qsqlodbc.dll
     File Files\sqldrivers\qsqlpsql.dll
 
@@ -197,7 +198,7 @@ Section "QMapShack" QMapShack
 
   ;BEGIN PROJ.4 Files    
   SetOutPath $INSTDIR
-    File Files\proj_6_2.dll
+    File Files\proj_6_3.dll
     File Files\proj.exe
     File Files\projinfo.exe
     File Files\cct.exe
@@ -247,12 +248,13 @@ Section "QMapShack" QMapShack
     File Files\libmysql.dll  
     File Files\3rdparty.txt
     File Files\qt.conf
+    File Files\LICENSE
   ;END additional Files
 
   ;BEGIN OpenSSL Files
-    ;File Files\libeay32.dll
-    ;File Files\ssleay32.dll
-    ;File Files\openssl.exe
+    File Files\libcrypto-1_1-x64.dll
+    File Files\libssl-1_1-x64.dll
+    File Files\openssl.exe
   ;END OpenSSL Files
 
 
@@ -278,14 +280,13 @@ Section "StartMenue" StartMenue
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
     ;Create shortcuts
     CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
-    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
+    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\qmapshack.org.lnk" "https://github.com/Maproom/qmapshack/wiki" "" "$INSTDIR\kfm_home.ico"
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\QMapShack.lnk" "$INSTDIR\qmapshack.exe" "--style fusion" "$INSTDIR\QMapShack.ico"
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\QMapTool.lnk" "$INSTDIR\qmaptool.exe" "--style fusion" "$INSTDIR\QMapTool.ico"
-    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\qmapshack.org.lnk" "https://github.com/Maproom/qmapshack/wiki" "" "$INSTDIR\kfm_home.ico"
-    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Help.lnk" "https://github.com/Maproom/qmapshack/wiki/DocMain" "" "$INSTDIR\Help.ico"
-    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\gdal.org.lnk" "http://www.gdal.org/" "" "$INSTDIR\gdalicon.ico"
     CreateShortCut "$SMPROGRAMS\$StartMenuFolder\GDAL shell.lnk" %COMSPEC% "/k $\"$INSTDIR\gdal_shell.bat$\"" "" "" "" "" "GDAL shell"
-   !insertmacro MUI_STARTMENU_WRITE_END
+    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
+
+    !insertmacro MUI_STARTMENU_WRITE_END
 
   ;Create registry entries
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\QMapShack" "DisplayName" "QMapShack (remove only)"
@@ -318,13 +319,13 @@ Section "Uninstall"
 
   !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
 
-  Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk"
-  Delete "$SMPROGRAMS\$StartMenuFolder\QMapShack.lnk"
-  Delete "$SMPROGRAMS\$StartMenuFolder\QMapTool.lnk"
   Delete "$SMPROGRAMS\$StartMenuFolder\qmapshack.org.lnk"
-  Delete "$SMPROGRAMS\$StartMenuFolder\Help.lnk"
-  Delete "$SMPROGRAMS\$StartMenuFolder\gdal.org.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\QMapShack.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\QMapShack Help.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\QMapTool.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\QMapTool Help.lnk"
   Delete "$SMPROGRAMS\$StartMenuFolder\GDAL shell.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk"
   
   RMDir "$SMPROGRAMS\$StartMenuFolder"
 

--- a/msvc_64/QMapShack_Installer.nsi
+++ b/msvc_64/QMapShack_Installer.nsi
@@ -248,7 +248,7 @@ Section "QMapShack" QMapShack
     File Files\libmysql.dll  
     File Files\3rdparty.txt
     File Files\qt.conf
-    File Files\LICENSE
+    File Files\1LICENSE.txt
   ;END additional Files
 
   ;BEGIN OpenSSL Files

--- a/msvc_64/QMapShack_Installer.nsi
+++ b/msvc_64/QMapShack_Installer.nsi
@@ -123,8 +123,14 @@ Section "QMapShack" QMapShack
     File Files\translations\qmapshack_*.qm
     File Files\translations\qmaptool_*.qm
   SetOutPath "$INSTDIR\doc\HTML"
-    File Files\doc\HTML\QMSHelp.*
-    File Files\doc\HTML\QMTHelp.*
+    File Files\doc\HTML\QMSHelp.qch
+    File Files\doc\HTML\QMSHelp.qhc
+    File Files\doc\HTML\QMTHelp.qch
+    File Files\doc\HTML\QMTHelp.qhc
+SetOutPath "$INSTDIR\doc\HTML\.QMSHelp"
+    File Files\doc\HTML\.QMSHelp\fts
+SetOutPath "$INSTDIR\doc\HTML\.QMTHelp"
+    File Files\doc\HTML\.QMTHelp\fts
   ;END QMapShack Files
 
   ;BEGIN Qt Files

--- a/msvc_64/cmake/FindPROJ4.cmake
+++ b/msvc_64/cmake/FindPROJ4.cmake
@@ -40,9 +40,11 @@ endif(WIN32)
 
   find_library(LIBPROJ4_LIBRARY
     NAMES
+        proj
         proj_6_0
         proj_6_1
         proj_6_2
+        proj_6_3
     PATHS
 if(WIN32)
       ${PROJ4_DEV_PATH}/lib

--- a/msvc_64/copyfiles.bat
+++ b/msvc_64/copyfiles.bat
@@ -156,7 +156,7 @@ cd ..
 
 rem section 2.5) 3rd party SW description and LICENSE
 copy ..\3rdparty.txt
-copy ..\..\LICENSE
+copy ..\..\LICENSE 1LICENSE.txt
 
 rem section 2.6) qt.conf
 copy ..\qt.conf

--- a/msvc_64/copyfiles.bat
+++ b/msvc_64/copyfiles.bat
@@ -3,7 +3,7 @@ rem Please adapt environment variables in section 1) to your system
 
 
 rem Section 1.) Define path to Qt, MSVC, .... installations
-set QMSI_QT_PATH="C:\Qt5\5.12.3\msvc2017_64"
+set QMSI_QT_PATH="C:\Qt\5.12.10\msvc2017_64"
 rem get the VC redistributable installer from https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads
 set QMSI_VCREDIST_PATH="M:\deploy_2017"
 set QMSI_GDAL_PATH="M:\lib2017\gdal"
@@ -18,7 +18,7 @@ set QMSI_MGW6_PATH="M:\lib2017\mingw64"
 rem runtime libraries from mysql/mariadb - see 3rdparty.txt from where to get - could this be optional?
 set QMSI_MSQL_PATH="M:\lib2017\mysql"
 rem uncomment the following line if you want OpenSSL
-rem set QMSI_OSSL_PATH="M:\deploy_2017"
+set QMSI_OSSL_PATH="M:\deploy_2017"
 rem And finally of course the path to your build directory!
 set QMSI_BUILD_PATH="..\..\build\"
 
@@ -29,6 +29,7 @@ cd Files
 
 rem Section 2.1) Copy Qt files
 rem Note: Qt5WebEngine deployment is super crazy - see https://doc.qt.io/qt-5.12/qtwebengine-deploying.html
+copy %QMSI_QT_PATH%\bin\assistant.exe
 copy %QMSI_QT_PATH%\bin\Qt5Core.dll
 copy %QMSI_QT_PATH%\bin\Qt5Gui.dll
 copy %QMSI_QT_PATH%\bin\Qt5Help.dll
@@ -39,6 +40,7 @@ copy %QMSI_QT_PATH%\bin\Qt5OpenGL.dll
 copy %QMSI_QT_PATH%\bin\Qt5Positioning.dll
 copy %QMSI_QT_PATH%\bin\Qt5PrintSupport.dll
 copy %QMSI_QT_PATH%\bin\Qt5Qml.dll
+copy %QMSI_QT_PATH%\bin\Qt5QmlModels.dll
 copy %QMSI_QT_PATH%\bin\Qt5Quick.dll
 copy %QMSI_QT_PATH%\bin\Qt5QuickWidgets.dll
 copy %QMSI_QT_PATH%\bin\Qt5Sensors.dll
@@ -65,7 +67,7 @@ cd ..
 mkdir sqldrivers
 cd sqldrivers
 copy %QMSI_QT_PATH%\plugins\sqldrivers\qsqlite.dll
-copy %QMSI_QT_PATH%\plugins\sqldrivers\qsqlmysql.dll
+rem copy %QMSI_QT_PATH%\plugins\sqldrivers\qsqlmysql.dll
 copy %QMSI_QT_PATH%\plugins\sqldrivers\qsqlodbc.dll
 copy %QMSI_QT_PATH%\plugins\sqldrivers\qsqlpsql.dll
 cd ..
@@ -98,7 +100,7 @@ copy %QMSI_GDAL_PATH%\bin\*.dll
 copy %QMSI_GDAL_PATH%\bin\*.exe
 rem section 2.2.4) PROJ.4
 xcopy %QMSI_PROJ_PATH%\share share /s /i
-copy %QMSI_PROJ_PATH%\bin\proj_6_2.dll
+copy %QMSI_PROJ_PATH%\bin\proj_6_3.dll
 copy %QMSI_PROJ_PATH%\bin\proj.exe
 copy %QMSI_PROJ_PATH%\bin\projinfo.exe
 copy %QMSI_PROJ_PATH%\bin\cct.exe
@@ -126,9 +128,9 @@ copy %QMSI_SQLI_PATH%\sqldiff.exe
 copy %QMSI_SQLI_PATH%\sqlite3.exe
 copy %QMSI_SQLI_PATH%\sqlite3_analyzer.exe
 rem uncomment the following line if you want OpenSSL
-rem copy %QMSI_OSSL_PATH%\libeay32.dll
-rem copy %QMSI_OSSL_PATH%\ssleay32.dll
-rem copy %QMSI_OSSL_PATH%\openssl.exe
+copy %QMSI_OSSL_PATH%\libcrypto-1_1-x64.dll
+copy %QMSI_OSSL_PATH%\libssl-1_1-x64.dll
+copy %QMSI_OSSL_PATH%\openssl.exe
 
 
 rem section 2.3) Copy MSVC Redist Files
@@ -152,8 +154,9 @@ copy ..\..\..\src\qmaptool\doc\QMTHelp.* HTML
 cd ..
 
 
-rem section 2.5) 3rd party SW description
+rem section 2.5) 3rd party SW description and LICENSE
 copy ..\3rdparty.txt
+copy ..\..\LICENSE
 
 rem section 2.6) qt.conf
 copy ..\qt.conf


### PR DESCRIPTION
_**Note: Do not delete any of the sections**_
_**Answer them all. Replace the descriptive text**_
_**by your answer**_


**What is the linked issue for this pull request (start with a `#`):** QMS-#264, QMS-#270, QMS-#273

**Describe roughly what you have done:**

Update the windows related build scripts as follows

CMakeLists.txt
  + adapt to using Qt5.12.10

FindPROJ4.cmake:
  + add support for proj 6.3

3rdparty.txt:
  + improve references to licenses

copyfiles.bat:
  + adapt to using Qt5.12.10
  + proj 6.3 support
  + improve references to licenses
  + copy LICENSE as 1LICENSE.txt

QMapShack_Installer.nsi: adapt to using Qt5.12.10
  + proj 6.3 support
  + improve references to licenses
  + instead of LICENSE: install 1LICENSE.txt
  + additionally install the help search index files (fts) for QMS and QMT

**What steps have to be done to perform a simple smoke test:**

1. Build QMS for Windows using VS2017 and Qt5.12.10
2. Create the Windows Installer
3. Run the Windows Installer
4. Start QMS as installed for a quick smoke test

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] N/A

**Is every user facing string in a tr() macro?**

- [X] N/A

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [X] yes, I didn't forget to change changelog.txt
