### PR TITLE
[QMS-265] Fix crash in CRouterBRouterTilesSelectLayout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-264] Windows: adapt build scripts for 1.15.1 release
+[QMS-265] Configuring BRouter offline on MacOS crashes
 [QMS-268] Crash after closing project where range is being selected
 [QMS-270] Windows: rename LICENSE file to 1LICENSE.txt
 [QMS-273] Windows: install Help search index files

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesPage.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesPage.cpp
@@ -26,6 +26,7 @@ CRouterBRouterTilesPage::CRouterBRouterTilesPage()
     : QWizardPage()
 {
     layout = new QVBoxLayout(this);
+    setLayout(layout);
     widgetLocalTilesSelect = new CRouterBRouterTilesSelect(this);
     widgetLocalTilesSelect->setObjectName("widgetLocalTilesSelect");
     QSizePolicy sizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelect.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelect.cpp
@@ -59,6 +59,7 @@ CRouterBRouterTilesSelect::CRouterBRouterTilesSelect(QWidget *parent)
     }
 
     outerLayout = new QVBoxLayout(this);
+    setLayout(outerLayout);
     outerLayout->setContentsMargins(0, 0, 0, 0);
     widgetSelect = new QWidget(this);
     widgetSelect->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -84,11 +85,12 @@ CRouterBRouterTilesSelect::CRouterBRouterTilesSelect(QWidget *parent)
     selectArea = new CRouterBRouterTilesSelectArea(widgetSelect, canvas);
 
     QLayout * selectLayout = new CRouterBRouterTilesSelectLayout(widgetSelect);
+    widgetSelect->setLayout(selectLayout);
     selectLayout->addWidget(canvas);
     selectLayout->addWidget(selectArea);
     canvas->lower();
     canvas->show();
-    selectArea->show();
+    selectArea->show();        
 
     QHBoxLayout * statusLayout = new QHBoxLayout();
     outerLayout->addLayout(statusLayout);

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelectLayout.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelectLayout.h
@@ -40,9 +40,9 @@ public:
 
     void setGeometry(const QRect & r) override { for (QLayoutItem *item : items) { item->setGeometry(r); }}
 
-    QLayoutItem * itemAt(int index) const override { return items.at(index); }
+    QLayoutItem * itemAt(int index) const override { return index < items.size() ? items.at(index) : nullptr; }
 
-    QLayoutItem * takeAt(int index) override { return items.takeAt(index); }
+    QLayoutItem * takeAt(int index) override { return index < items.size() ? items.takeAt(index) : nullptr; }
 
     int count() const override { return items.size(); }
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#265

**Describe roughly what you have done:**

Return nullptr in CRouterBRouterTilesSelectLayout::itemAt() and CRouterBRouterTilesSelectLayout::takeAt() if index is out of range.

**What steps have to be done to perform a simple smoke test:**

Go to the tile selection page of the BRouter setup wizard. No crash must occure.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
