### PR TITLE
[QMS-275] Add languages in Routino widget.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-275] Routino: Add Spanish and Czech as selectable languages for turn instructions
+
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release
 [QMS-265] Configuring BRouter offline on MacOS crashes

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -88,6 +88,8 @@ CRouterRoutino::CRouterRoutino(QWidget *parent)
     comboLanguage->addItem(tr("Dutch"),     "nl");
     comboLanguage->addItem(tr("Russian"),   "ru");
     comboLanguage->addItem(tr("Polish"),    "pl");
+    comboLanguage->addItem(tr("Czech"),     "cs");
+    comboLanguage->addItem(tr("Spanish"),   "es");
 
     connect(toolSetupPaths, &QToolButton::clicked, this, &CRouterRoutino::slotSetupPaths);
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#275

**Describe roughly what you have done:**

In CRouterRoutino.cpp: Add two new lines for Spanish and Czech languages in the combolanguage.

**What steps have to be done to perform a simple smoke test:**

1. Open the Routing Panel- Select Routino offline as routing engine
2. Select your Profile, Mode,and Database. For language Select Spanish.
3. Go to the canvas. Add new route and save it.
4. On the canvas: Click on the new route and check the 'Route instructions' button
5. Click on a point marked in cyan and route instructions should be shown in Spanish

![instructions](https://i.ibb.co/5MM7fg3/QMS-turn2.jpg)

 *Remark: First line translation depends on your local language for QMS. Second and third line translations depend on the selected language by the user in the Routino widget*


**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] yes

**Is every user facing string in a tr() macro?**

- [X] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [X] yes, I didn't forget to change changelog.txt