### PR TITLE
[QMS-279] Track metrics not updated when using UNDO / REDO in Edit mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-275] Routino: Add Spanish and Czech as selectable languages for turn instructions
+[QMS-279] Track metrics not updated when using UNDO / REDO in Edit mode
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/mouse/line/IMouseEditLine.cpp
+++ b/src/qmapshack/mouse/line/IMouseEditLine.cpp
@@ -474,6 +474,7 @@ void IMouseEditLine::slotUndo()
     scrOptEditLine->toolRedo->setEnabled(true);
     scrOptEditLine->toolUndo->setEnabled(idxHistory > 0);
     canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
+    updateStatus();
 }
 
 void IMouseEditLine::slotRedo()
@@ -494,6 +495,7 @@ void IMouseEditLine::slotRedo()
     scrOptEditLine->toolRedo->setEnabled(idxHistory < (history.size() - 1));
     scrOptEditLine->toolUndo->setEnabled(true);
     canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
+    updateStatus();
 }
 
 void IMouseEditLine::updateStatus()


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#279

**Describe roughly what you have done:**

Added missing `updateStatus()` call to undo/redo handler.

**What steps have to be done to perform a simple smoke test:**

Create a track as described in the ticket. The track metric should update now when you do an undo/redo

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
