### PR TITLE
[QMS-282] Tags icons/rating disappear from workspace after saving and closing a project

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-275] Routino: Add Spanish and Czech as selectable languages for turn instructions
 [QMS-279] Track metrics not updated when using UNDO / REDO in Edit mode
+[QMS-282] Tags icons/rating disappear from workspace after saving and closing a project
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/gis/IGisItem.cpp
+++ b/src/qmapshack/gis/IGisItem.cpp
@@ -381,7 +381,7 @@ void IGisItem::updateDecoration(quint32 enable, quint32 disable)
     setText(CGisListWks::eColumnDecoration, str);
     setToolTip(CGisListWks::eColumnDecoration, tt);
 
-    //Set Info column
+    //Set Rating column
     if(!keywords.isEmpty())
     {
         QTreeWidgetItem::setIcon(CGisListWks::eColumnRating, QPixmap("://icons/32x32/Tag.png"));

--- a/src/qmapshack/gis/qms/serialization.cpp
+++ b/src/qmapshack/gis/qms/serialization.cpp
@@ -1047,9 +1047,17 @@ QDataStream& IGisProject::operator<<(QDataStream& stream)
             ;
         }
 
-        if(item && changed)
+        //Update decoration always, to set possible rating and tag markers
+        if(item)
         {
-            item->updateDecoration(IGisItem::eMarkChanged, IGisItem::eMarkNone);
+            if(changed)
+            {
+                item->updateDecoration(IGisItem::eMarkChanged, IGisItem::eMarkNone);
+            }
+            else
+            {
+                item->updateDecoration(IGisItem::eMarkNone, IGisItem::eMarkNone);
+            }
         }
     }
 


### PR DESCRIPTION
_**Note: Do not delete any of the sections**_
_**Answer them all. Replace the descriptive text**_
_**by your answer**_


**What is the linked issue for this pull request (start with a `#`):** QMS-#282

**Describe roughly what you have done:**

* Fixed reported bug by always updating decorations on loading of
database
* Updated comment to better reflect what happens

**What steps have to be done to perform a simple smoke test:**

1. Open saved database project with items that have tags
2. See that those tags now appear

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
