### PR TITLE
Add support for HiDPI screens

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-275] Routino: Add Spanish and Czech as selectable languages for turn instructions
 [QMS-279] Track metrics not updated when using UNDO / REDO in Edit mode
 [QMS-282] Tags icons/rating disappear from workspace after saving and closing a project
+[QMS-289] Added suport for HiDPI screens
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -30,6 +30,9 @@ int main(int argc, char ** argv)
 {
     QApplication app(argc, argv);
 
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
     QCoreApplication::setApplicationName("QMapShack");
     QCoreApplication::setOrganizationName("QLandkarte");
     QCoreApplication::setOrganizationDomain("qlandkarte.org");

--- a/src/qmaptool/main.cpp
+++ b/src/qmaptool/main.cpp
@@ -28,6 +28,9 @@ int main(int argc, char ** argv)
 {
     QApplication app(argc, argv);
 
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
     QCoreApplication::setApplicationName("QMapTool");
     QCoreApplication::setOrganizationName("QLandkarte");
     QCoreApplication::setOrganizationDomain("qlandkarte.org");


### PR DESCRIPTION
Signed-off-by: Andreas Schneider <asn@cryptomilk.org>

_**Note: Do not delete any of the sections**_
_**Answer them all. Replace the descriptive text**_
_**by your answer**_


**What is the linked issue for this pull request (start with a `#`):** QMS-#289

**Describe roughly what you have done:**

I enabled support for HiDPI screens so that icons are rendered in the correct resolution.

**What steps have to be done to perform a simple smoke test:**

1. Open qmapshack
2. Check that icons are rendered nicely and are not looking pixelated.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [ ] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
