### PR TITLE
[QMS-285] WMTS-based maps aren't restored correctly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-275] Routino: Add Spanish and Czech as selectable languages for turn instructions
 [QMS-279] Track metrics not updated when using UNDO / REDO in Edit mode
 [QMS-282] Tags icons/rating disappear from workspace after saving and closing a project
+[QMS-285] WMTS-based maps aren't restored correctly
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/map/CMapDraw.cpp
+++ b/src/qmapshack/map/CMapDraw.cpp
@@ -142,7 +142,7 @@ void CMapDraw::getInfo(const QPoint& px, QString& str)
         {
             CMapItem * item = mapList->item(i);
 
-            if(!item || item->mapfile.isNull())
+            if(!item || item->getMapfile().isNull())
             {
                 // as all active maps have to be at the top of the list
                 // it is ok to break as soon as the first map with no
@@ -150,7 +150,7 @@ void CMapDraw::getInfo(const QPoint& px, QString& str)
                 break;
             }
 
-            item->mapfile->getInfo(px, str);
+            item->getMapfile()->getInfo(px, str);
         }
     }
     CMapItem::mutexActiveMaps.unlock();
@@ -169,7 +169,7 @@ void CMapDraw::getToolTip(const QPoint& px, QString& str)
         {
             CMapItem * item = mapList->item(i);
 
-            if(!item || item->mapfile.isNull())
+            if(!item || item->getMapfile().isNull())
             {
                 // as all active maps have to be at the top of the list
                 // it is ok to break as soon as the first map with no
@@ -177,7 +177,7 @@ void CMapDraw::getToolTip(const QPoint& px, QString& str)
                 break;
             }
 
-            item->mapfile->getToolTip(px, str);
+            item->getMapfile()->getToolTip(px, str);
         }
     }
     CMapItem::mutexActiveMaps.unlock();
@@ -198,7 +198,7 @@ poi_t CMapDraw::findPOICloseBy(const QPoint& px) const
         {
             CMapItem * item = mapList->item(i);
 
-            if(!item || item->mapfile.isNull())
+            if(!item || item->getMapfile().isNull())
             {
                 // as all active maps have to be at the top of the list
                 // it is ok to break as soon as the first map with no
@@ -206,7 +206,7 @@ poi_t CMapDraw::findPOICloseBy(const QPoint& px) const
                 break;
             }
 
-            item->mapfile->findPOICloseBy(px, poi);
+            item->getMapfile()->findPOICloseBy(px, poi);
             if(poi.pos != NOPOINTF)
             {
                 // stop at the 1st one found
@@ -233,7 +233,7 @@ bool CMapDraw::findPolylineCloseBy(const QPointF& pt1, const QPointF& pt2, qint3
         {
             CMapItem * item = mapList->item(i);
 
-            if(!item || item->mapfile.isNull())
+            if(!item || item->getMapfile().isNull())
             {
                 // as all active maps have to be at the top of the list
                 // it is ok to break as soon as the first map with no
@@ -241,7 +241,7 @@ bool CMapDraw::findPolylineCloseBy(const QPointF& pt1, const QPointF& pt2, qint3
                 break;
             }
 
-            res = item->mapfile->findPolylineCloseBy(pt1, pt2, threshold, polyline);
+            res = item->getMapfile()->findPolylineCloseBy(pt1, pt2, threshold, polyline);
             if(res)
             {
                 break;
@@ -293,17 +293,8 @@ CMapItem * CMapDraw::createMapItem(const QString& filename, QSet<QString>& maps)
     maps.insert(fi.completeBaseName());
 
     item->setText(0, fi.completeBaseName().replace("_", " "));
-    item->filename = filename;
+    item->setFilename(filename);
     item->updateIcon();
-
-    // calculate MD5 hash from the file's first 1024 bytes
-    QFile f(filename);
-    f.open(QIODevice::ReadOnly);
-    QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(f.read(1024));
-    item->key = md5.result().toHex();
-    f.close();
-
     return item;
 }
 
@@ -359,10 +350,10 @@ void CMapDraw::saveActiveMapsList(QStringList& keys, QSettings& cfg)
     for(int i = 0; i < mapList->count(); i++)
     {
         CMapItem * item = mapList->item(i);
-        if(item && !item->mapfile.isNull())
+        if(item && !item->getMapfile().isNull())
         {
             item->saveConfig(cfg);
-            keys << item->key;
+            keys << item->getKey();
         }
     }
 }
@@ -392,7 +383,7 @@ void CMapDraw::restoreActiveMapsList(const QStringList& keys)
         {
             CMapItem * item = mapList->item(i);
 
-            if(item && item->key == key)
+            if(item && item->getKey() == key)
             {
                 /**
                     @Note   the item will load it's configuration upon successful activation
@@ -417,7 +408,7 @@ void CMapDraw::restoreActiveMapsList(const QStringList& keys, QSettings& cfg)
         {
             CMapItem * item = mapList->item(i);
 
-            if(item && item->key == key)
+            if(item && item->getKey() == key)
             {
                 if(item->activate())
                 {
@@ -448,7 +439,7 @@ void CMapDraw::drawt(IDrawContext::buffer_t& currentBuffer) /* override */
         {
             CMapItem * item = mapList->item(i);
 
-            if(!item || item->mapfile.isNull())
+            if(!item || item->getMapfile().isNull())
             {
                 // as all active maps have to be at the top of the list
                 // it is ok to break as soon as the first map with no
@@ -456,7 +447,7 @@ void CMapDraw::drawt(IDrawContext::buffer_t& currentBuffer) /* override */
                 break;
             }
 
-            item->mapfile->draw(currentBuffer);
+            item->getMapfile()->draw(currentBuffer);
             seenActiveMap = true;
         }
     }

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -43,6 +43,17 @@ CMapItem::~CMapItem()
 {
 }
 
+void CMapItem::setFilename(const QString& name)
+{
+    filename = name;
+    QFile f(filename);
+    f.open(QIODevice::ReadOnly);
+    QCryptographicHash md5(QCryptographicHash::Md5);
+    md5.addData(f.read(1024));
+    key = md5.result().toHex();
+    f.close();
+}
+
 void CMapItem::saveConfig(QSettings& cfg) const
 {
     if(mapfile.isNull())

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -46,10 +46,11 @@ CMapItem::~CMapItem()
 void CMapItem::setFilename(const QString& name)
 {
     filename = name;
+
     QFile f(filename);
     f.open(QIODevice::ReadOnly);
     QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(f.read(1024));
+    md5.addData(f.read(qMin(0x1000LL, f.size())));
     key = md5.result().toHex();
     f.close();
 }

--- a/src/qmapshack/map/CMapItem.h
+++ b/src/qmapshack/map/CMapItem.h
@@ -34,6 +34,8 @@ public:
     CMapItem(QTreeWidget * parent, CMapDraw *map);
     virtual ~CMapItem();
 
+    void setFilename(const QString& name);
+
     void saveConfig(QSettings& cfg) const;
     void loadConfig(QSettings& cfg);
 
@@ -86,8 +88,11 @@ public:
         return text(0);
     }
 
+    QPointer<IMap>& getMapfile(){return mapfile;}
+
+    const QString& getKey(){return key;}
+
 private:
-    friend class CMapDraw;
     CMapDraw * map;
     /**
        @brief A MD5 hash over the first 1024 bytes of the map file, to identify the map


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#285

**Describe roughly what you have done:**

For each map a hash is calculated over the 1st 1024 bytes. For some WMTS maps this seems to low. Increased the amount of bytes to 4096

**What steps have to be done to perform a simple smoke test:**

See ticket for test.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
