### PR TITLE
[QMS-299] Store config of CEnergyCycling in own section

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-279] Track metrics not updated when using UNDO / REDO in Edit mode
 [QMS-282] Tags icons/rating disappear from workspace after saving and closing a project
 [QMS-285] WMTS-based maps aren't restored correctly
+[QMS-299] CEnergyCycling is storing it's configuration in the `General` section instead of it's own.
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/gis/trk/CEnergyCycling.cpp
+++ b/src/qmapshack/gis/trk/CEnergyCycling.cpp
@@ -59,6 +59,7 @@ CEnergyCycling::CEnergyCycling(CGisItemTrk &trk) :
 void CEnergyCycling::loadSettings(CEnergyCycling::energy_set_t &energySet)
 {
     SETTINGS;
+    cfg.beginGroup("EnergyCycling");
 
     energy_set_t energyDefaultSet; // to get the default values defined in header
 
@@ -73,6 +74,8 @@ void CEnergyCycling::loadSettings(CEnergyCycling::energy_set_t &energySet)
     energySet.groundIndex = cfg.value("groundIndex", energyDefaultSet.groundIndex).toInt();
     energySet.rollingCoeff = cfg.value("rollingCoeff", energyDefaultSet.rollingCoeff).toDouble();
     energySet.pedalCadence = cfg.value("pedalCadence", energyDefaultSet.pedalCadence).toDouble();
+
+    cfg.endGroup();
 }
 
 /** @brief Saves parameters to SETTINGS
@@ -82,6 +85,7 @@ void CEnergyCycling::loadSettings(CEnergyCycling::energy_set_t &energySet)
 void CEnergyCycling::saveSettings()
 {
     SETTINGS;
+    cfg.beginGroup("EnergyCycling");
 
     cfg.setValue("personalWeight", energyTrkSet.driverWeight);
     cfg.setValue("bikeWeight", energyTrkSet.bikeWeight);
@@ -94,6 +98,8 @@ void CEnergyCycling::saveSettings()
     cfg.setValue("groundIndex", energyTrkSet.groundIndex);
     cfg.setValue("rollingCoeff", energyTrkSet.rollingCoeff);
     cfg.setValue("pedalCadence", energyTrkSet.pedalCadence);
+
+    cfg.endGroup();
 }
 
 /** @brief Computes the "Energy Use Cycling" value


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#299

**Describe roughly what you have done:**

Simply added the `beginGroup()` and `endGroup()` calls. The section name is `EnergyCycling`

**What steps have to be done to perform a simple smoke test:**

1. Use energy calculator
2. Check config for section `EnergyCycling`

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
