### PR TITLE
[QMS-220]  "Select items from map" misses items

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-220] "Select items from map" misses items
 [QMS-275] Routino: Add Spanish and Czech as selectable languages for turn instructions
 [QMS-279] Track metrics not updated when using UNDO / REDO in Edit mode
 [QMS-282] Tags icons/rating disappear from workspace after saving and closing a project

--- a/src/qmapshack/gis/ovl/CGisItemOvlArea.cpp
+++ b/src/qmapshack/gis/ovl/CGisItemOvlArea.cpp
@@ -141,7 +141,9 @@ bool CGisItemOvlArea::isCloseTo(const QPointF& pos)
 
 bool CGisItemOvlArea::isWithin(const QRectF& area, selflags_t flags)
 {
-    return (flags & eSelectionOvl) ? IGisItem::isWithin(area, flags, polygonArea) : false;
+    QPolygonF l;
+    getPolylineDegFromData(l);
+    return (flags & eSelectionOvl) ? IGisItem::isWithin(area, flags, l) : false;
 }
 
 QPointF CGisItemOvlArea::getPointCloseBy(const QPoint& screenPos)

--- a/src/qmapshack/gis/rte/CGisItemRte.cpp
+++ b/src/qmapshack/gis/rte/CGisItemRte.cpp
@@ -529,7 +529,9 @@ bool CGisItemRte::isCloseTo(const QPointF& pos)
 
 bool CGisItemRte::isWithin(const QRectF& area, selflags_t flags)
 {
-    return (flags & eSelectionRte) ? IGisItem::isWithin(area, flags, line) : false;
+    QPolygonF l;
+    getPolylineDegFromData(l);
+    return (flags & eSelectionRte) ? IGisItem::isWithin(area, flags, l) : false;
 }
 
 

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -1442,7 +1442,9 @@ bool CGisItemTrk::isCloseTo(const QPointF& pos)
 
 bool CGisItemTrk::isWithin(const QRectF& area, selflags_t flags)
 {
-    return (flags & eSelectionTrk) ? IGisItem::isWithin(area, flags, lineSimple) : false;
+    QPolygonF l;
+    getPolylineDegFromData(l);
+    return (flags & eSelectionTrk) ? IGisItem::isWithin(area, flags, l) : false;
 }
 
 

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -600,7 +600,7 @@ bool CGisItemWpt::isCloseTo(const QPointF& pos)
 
 bool CGisItemWpt::isWithin(const QRectF& area, selflags_t flags)
 {
-    return (flags & eSelectionWpt) ? area.contains(posScreen) : false;
+    return (flags & eSelectionWpt) ? area.contains(QPointF(wpt.lon, wpt.lat)) : false;
 }
 
 

--- a/src/qmapshack/mouse/CMouseSelect.cpp
+++ b/src/qmapshack/mouse/CMouseSelect.cpp
@@ -70,7 +70,7 @@ void CMouseSelect::findItems(QList<IGisItem*>& items)
         itemKeys.clear();
 
         QRectF area;
-        rectRad2Px(rectSelection, area);
+        rectRad2Deg(rectSelection, area);
         CGisWorkspace::self().getItemsByArea(area, modeSelection, items);
 
         cntWpt = 0;

--- a/src/qmapshack/mouse/IMouseSelect.cpp
+++ b/src/qmapshack/mouse/IMouseSelect.cpp
@@ -47,6 +47,17 @@ void IMouseSelect::rectRad2Px(const QRectF& rectSrc, QRectF& rectTar) const
     rectTar = QRectF(pt1, pt2);
 }
 
+void IMouseSelect::rectRad2Deg(const QRectF& rectSrc, QRectF& rectTar) const
+{
+    QPointF pt1 = rectSrc.topLeft();
+    QPointF pt2 = rectSrc.bottomRight();
+
+    pt1 *= RAD_TO_DEG;
+    pt2 *= RAD_TO_DEG;
+
+    rectTar = QRectF(pt1, pt2);
+}
+
 void IMouseSelect::placeScrOpt()
 {
     if(scrOpt.isNull())

--- a/src/qmapshack/mouse/IMouseSelect.h
+++ b/src/qmapshack/mouse/IMouseSelect.h
@@ -41,6 +41,7 @@ public:
 
 protected:
     void rectRad2Px(const QRectF& rectSrc, QRectF& rectTar) const;
+    void rectRad2Deg(const QRectF& rectSrc, QRectF& rectTar) const;
     void placeScrOpt();
 
     QPointF offset;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#220

**Describe roughly what you have done:**

Root cause was using the pixel coordinates of the items. This is
quite fast as long as the item is in the visible map. However once
it is outside the visible part these coordinates are invalidated.
Therefore the compare will fail.

Using the real coordinates is a bit more effort especially for
tracks, routes and areas. As the coordinates of these items can be
changed (or points get hidden) at any time the resulting polylline
should be derived on-the-fly. To store a copy would need some
failsafe mechanism to update when needed.

This is a bit slower than before.  Tested with 393 tracks and 2624
waypoints the difference seems to be around factor 1.5. Updating
the GUI takes much more time. Therefore the GUI  lag is quite the
same.

**What steps have to be done to perform a simple smoke test:**

Perform the test as described in the ticket.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
