### PR TITLE
[QMS-311] Automatically save projects to device

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-282] Tags icons/rating disappear from workspace after saving and closing a project
 [QMS-285] WMTS-based maps aren't restored correctly
 [QMS-299] CEnergyCycling is storing it's configuration in the `General` section instead of it's own.
+[QMS-311] Automatically save projects to device
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -128,7 +128,10 @@ private slots:
     void slotEleWptTrk();
     void slotAutoSaveProject(bool on);
     void slotUserFocusPrj(bool yes);
-    void slotAddProjectFilter();
+    void slotAutoSyncProject(bool yes);
+    void slotAddProjectFilter();    
+    void slotNewDevice();
+    void slotSyncPrjToDevices();
 
 private:
     void configDB();
@@ -149,6 +152,9 @@ private:
     void showMenuItemRte(const QPoint &p);
     void showMenuItemOvl(const QPoint &p);
     void showMenuItem(const QPoint &p, const QList<IGisItem::key_t> &keysTrks, const QList<IGisItem::key_t> &keysWpts);
+
+    void syncPrjToDevices(IGisProject * project, const QSet<QString>& keys);
+    QSet<QString> getAllDeviceKeys() const;
 
     template<typename T>
     QList<IGisItem::key_t> selectedItems2Keys()
@@ -173,6 +179,7 @@ private:
     QAction * actionSaveAsStrict;
     QAction * actionAutoSave;
     QAction * actionUserFocusPrj;
+    QAction * actionAutoSyncToDev;
     QAction * actionCopyPrj;
     QAction * actionEditPrj;
     QAction * actionCloseProj;

--- a/src/qmapshack/gis/CGisWorkspace.h
+++ b/src/qmapshack/gis/CGisWorkspace.h
@@ -51,6 +51,7 @@ enum event_types_e
 
     , eEvtA2WCutTrk      = QEvent::User + 200
     , eEvtA2WSave        = QEvent::User + 201
+    , eEvtA2WSync        = QEvent::User + 202
 };
 
 struct evt_item_t
@@ -217,6 +218,16 @@ class CEvtA2WSave : public QEvent
 {
 public:
     CEvtA2WSave(const QString& key) : QEvent(QEvent::Type(eEvtA2WSave)), key(key)
+    {
+    }
+
+    const QString key;
+};
+
+class CEvtA2WSync : public QEvent
+{
+public:
+    CEvtA2WSync(const QString& key) : QEvent(QEvent::Type(eEvtA2WSync)), key(key)
     {
     }
 

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -63,6 +63,7 @@ public:
         eFlagNoCorrelation      = 0x1
         , eFlagAutoSave         = 0x2
         , eFlagInvalidDataOk    = 0x4
+        , eFlagAutoSyncToDev    = 0x8
     };
 
     enum sorting_roadbook_e
@@ -535,6 +536,10 @@ public:
     {
         autoSavePending = false;
     }
+    void confirmPendingAutoSyncToDev()
+    {
+        autoSyncToDevPending = false;
+    }
 
     bool findPolylineCloseBy(const QPointF& pt1, const QPointF& pt2, qint32& threshold, QPolygonF& polyline);
 
@@ -550,6 +555,13 @@ public:
         return keyUserFocus;
     }
 
+    void setAutoSyncToDevice(bool yes);
+
+    bool doAutoSyncToDevice() const
+    {
+        return autoSyncToDev;
+    }
+
     CProjectFilterItem* filterProject(bool filter);
     CProjectFilterItem* getProjectFilterItem()
     {
@@ -563,6 +575,7 @@ protected:
     void updateItems();
     void updateItemCounters();
     void updateDecoration();
+    void updateDecoration(bool saved);
     void sortItems();
     void sortItems(QList<IGisItem*>& items) const;
 
@@ -603,6 +616,8 @@ protected:
     bool autoSave               = false; ///< flag to show if auto save is on or off
     bool autoSavePending        = false; ///< flag to show if auto save event has been sent. will be reset by save()
     bool invalidDataOk          = false; ///< if set invalid data in GIS items will not raise any dialog
+    bool autoSyncToDev          = false; ///< if set true sync the project with every device connected
+    bool autoSyncToDevPending   = false; ///< flag to show that a sync to device is already pending
 
     metadata_t metadata;
     QString nameSuffix;

--- a/src/qmapshack/gis/qms/serialization.cpp
+++ b/src/qmapshack/gis/qms/serialization.cpp
@@ -995,6 +995,8 @@ QDataStream& IGisProject::operator<<(QDataStream& stream)
         noCorrelation   = (tmp & eFlagNoCorrelation) != 0;
         autoSave        = (tmp & eFlagAutoSave) != 0;
         invalidDataOk   = (tmp & eFlagInvalidDataOk) != 0;
+        autoSyncToDev   = (tmp & eFlagAutoSyncToDev) != 0;
+        updateDecoration();
     }
 
     if(version > 4)
@@ -1083,7 +1085,11 @@ QDataStream& IGisProject::operator>>(QDataStream& stream) const
     stream << metadata.bounds;
     stream << key;
     stream << qint32(sortingRoadbook);
-    stream << qint8((noCorrelation ? eFlagNoCorrelation : 0) | (autoSave ? eFlagAutoSave : 0) | (invalidDataOk ? eFlagInvalidDataOk : 0)); // collect trivial flags in one field.
+    stream << qint8(
+        (noCorrelation ? eFlagNoCorrelation : 0) |
+        (autoSave ? eFlagAutoSave : 0) |
+        (invalidDataOk ? eFlagInvalidDataOk : 0) |
+        (autoSyncToDev ? eFlagAutoSyncToDev : 0));       // collect trivial flags in one field.
     stream << qint32(sortingFolder);
 
     for(int i = 0; i < childCount(); i++)
@@ -1184,7 +1190,10 @@ QDataStream& CDBProject::operator<<(QDataStream& stream)
         noCorrelation   = (tmp & eFlagNoCorrelation) != 0;
         autoSave        = (tmp & eFlagAutoSave) != 0;
         invalidDataOk   = (tmp & eFlagInvalidDataOk) != 0;
+        autoSyncToDev   = (tmp & eFlagAutoSyncToDev) != 0;
+        updateDecoration();
     }
+
     if(version > 4)
     {
         qint32 tmp;
@@ -1211,7 +1220,11 @@ QDataStream& CDBProject::operator>>(QDataStream& stream) const
     stream << metadata.bounds;
     stream << key;
     stream << qint32(sortingRoadbook);
-    stream << qint8((noCorrelation ? eFlagNoCorrelation : 0) | (autoSave ? eFlagAutoSave : 0) | (invalidDataOk ? eFlagInvalidDataOk : 0)); // collect trivial flags in one field.
+    stream << qint8(
+        (noCorrelation ? eFlagNoCorrelation : 0) |
+        (autoSave ? eFlagAutoSave : 0) |
+        (invalidDataOk ? eFlagInvalidDataOk : 0) |
+        (autoSyncToDev ? eFlagAutoSyncToDev : 0)); // collect trivial flags in one field.
     stream << qint32(sortingFolder);
 
     return stream;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):** QMS-#311

**Describe roughly what you have done:**

* Add automatic sync. with device option to project item's
  workspace menu.
* Add all necessary hooks to trigger a sync. on a new device or
  project change

**What steps have to be done to perform a simple smoke test:**

1. Load a project into the workspace
2. Right mouse button context menu in the workspace list
3. select `Autom. sync. w. Device` -> a `S` should appear in the decorations coulmn
4. Attach your device to the PC
5. When the device shows up the project should be synced with the device
6. If you change the project it should be synced with the device

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
