### PR TITLE
[QMS-321] Improve name selection for POI

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V1.XX.X
 [QMS-315] Make POI Icons User-Selectable
 [QMS-317] Enable user to add POI to project via right-click
 [QMS-318] Change poi_t to use radians
+[QMS-321] Improve name selection for POI
 [QMS-322] Make POIs show up in 'Select Items On Map'
 
 V1.15.2

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -910,10 +910,13 @@ void CCanvas::slotTriggerCompleteUpdate(CCanvas::redraw_e flags)
 void CCanvas::slotToolTip()
 {
     QString str;
-    map->getToolTip(posToolTip, str);
-    if(str.isEmpty())
+    if(!poi->getToolTip(posToolTip, str))
     {
-        return;
+        map->getToolTip(posToolTip, str);
+        if(str.isEmpty())
+        {
+            return;
+        }
     }
     QPoint p = mapToGlobal(posToolTip + QPoint(32, 0));
     QToolTip::showText(p, str);

--- a/src/qmapshack/poi/CPoiDraw.h
+++ b/src/qmapshack/poi/CPoiDraw.h
@@ -54,6 +54,7 @@ public:
 
     poi_t findPOICloseBy(const QPoint& px) const;
     void findPoisIn(const QRectF& degRect, QList<poi_t>& pois) const;
+    bool getToolTip(const QPoint& px, QString& str);
 protected:
     void drawt(buffer_t& currentBuffer) override;
 

--- a/src/qmapshack/poi/CPoiItem.h
+++ b/src/qmapshack/poi/CPoiItem.h
@@ -91,6 +91,10 @@ public:
     {
         getPoifile()->findPoisIn(degRect, pois);
     }
+    bool getToolTip(const QPoint& px, QString& str)
+    {
+        return getPoifile()->getToolTip(px, str);
+    }
 private:
     friend class CPoiDraw;
     CPoiDraw * poi;

--- a/src/qmapshack/poi/CPoiPOI.cpp
+++ b/src/qmapshack/poi/CPoiPOI.cpp
@@ -261,13 +261,17 @@ poi_t CPoiPOI::rawPoi_t::toPoi(const QString& defaultName) const
 {
     poi_t poi;
     poi.pos = coordinates;
-    for(const QString& tag : {"name=", "brand=", "operator="})
+    for(const QRegularExpression& regex : {QRegularExpression("name:" + QLocale::system().name() + "=(.+)", QRegularExpression::UseUnicodePropertiesOption),
+                                           QRegularExpression("name:en=(.+)", QRegularExpression::UseUnicodePropertiesOption),
+                                           QRegularExpression("name=(.+)", QRegularExpression::UseUnicodePropertiesOption),
+                                           QRegularExpression("name:\\w\\w=(.+)", QRegularExpression::UseUnicodePropertiesOption),
+                                           QRegularExpression("brand=(.+)", QRegularExpression::UseUnicodePropertiesOption),
+                                           QRegularExpression("operator=(.+)", QRegularExpression::UseUnicodePropertiesOption)})
     {
-        const QStringList& matches = data.filter(tag);
+        const QStringList& matches = data.filter(regex);
         if (!matches.isEmpty())
         {
-            poi.name = matches[0];
-            poi.name.replace(tag, "");
+            poi.name = regex.match(matches[0]).captured(1).trimmed();
             break;
         }
     }

--- a/src/qmapshack/poi/CPoiPOI.cpp
+++ b/src/qmapshack/poi/CPoiPOI.cpp
@@ -179,6 +179,18 @@ void CPoiPOI::findPoisIn(const QRectF &degRect, QList<poi_t> &pois)
     }
 }
 
+bool CPoiPOI::getToolTip(const QPoint &px, QString &str) const
+{
+    poi_t poiFound;
+    bool success = findPoiCloseBy(px, poiFound);
+    if(success)
+    {
+        str += "<b>" + poiFound.name + "</b><br>";
+        str += poiFound.desc;
+    }
+    return success;
+}
+
 void CPoiPOI::addTreeWidgetItems(QTreeWidget* widget)
 {
     QMap<QString, CPoiCategory*> parentMap;
@@ -279,6 +291,6 @@ poi_t CPoiPOI::rawPoi_t::toPoi(const QString& defaultName) const
     {
         poi.name = defaultName;
     }
-    poi.desc = data.join("</br>\n");
+    poi.desc = data.join("<br>\n");
     return poi;
 }

--- a/src/qmapshack/poi/CPoiPOI.h
+++ b/src/qmapshack/poi/CPoiPOI.h
@@ -39,6 +39,7 @@ public:
 
     virtual bool findPoiCloseBy(const QPoint& px, poi_t& poiItem) const override;
     virtual void findPoisIn(const QRectF& degRect, QList<poi_t>&pois) override;
+    virtual bool getToolTip(const QPoint& px, QString& str) const override;
 
     static void init()
     {

--- a/src/qmapshack/poi/IPoi.h
+++ b/src/qmapshack/poi/IPoi.h
@@ -52,6 +52,7 @@ public:
 
     virtual bool findPoiCloseBy(const QPoint& px, poi_t&) const = 0;
     virtual void findPoisIn(const QRectF& degRect, QList<poi_t>&pois) = 0;
+    virtual bool getToolTip(const QPoint& px, QString& str) const = 0;
 
 public slots:
     virtual void slotCheckedStateChanged(QTreeWidgetItem*item) = 0;


### PR DESCRIPTION
_**Note: Do not delete any of the sections**_
_**Answer them all. Replace the descriptive text**_
_**by your answer**_


**What is the linked issue for this pull request (start with a `#`):** QMS-#321

**Describe roughly what you have done:**

I improved the name selection process. The assumption is made that when there is an `alt_name` that there would be a better 'normal' name, if that is not the case, I can add alt names to the selection process, however there seems to be disagreement on how to add those in OSM (I've seen `alt_name=`, `alt_name1=` and `alt_name_1=`). Also there are `loc_name` `short_name` `official_name` `reg_name`

**What steps have to be done to perform a simple smoke test:**

1. Select POI with different name possibilities to copy to workspace
2. See that your locale is the first choice, then English, then the default name and then any other name. 

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
