### PR TITLE
[QMS-314] Fix/Add POI categories (Resolve POIs to garmin symbols)

### DIFF
--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -583,6 +583,7 @@ set( HDRS
     helpers/CWptIconManager.h
     helpers/Platform.h
     helpers/Signals.h
+    helpers/Tristate.h
     map/CMapDraw.h
     map/CMapGEMF.h
     map/CMapIMG.h

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -925,6 +925,29 @@ void CGisWorkspace::addWptByPos(const QPointF& pt, const QString& name, const QS
 
 void CGisWorkspace::addPoisAsWpt(const QSet<poi_t> &pois, IGisProject * project) const
 {
+    if(nullptr == project)
+    {
+        project = CGisWorkspace::self().selectProject(false);
+    }
+    if(nullptr == project)
+    {
+        return;
+    }
+    tristate_e openEditWindow = eTristateUndefined;
+    for(const poi_t& poi: pois)
+    {
+        addPoiAsWpt(poi, openEditWindow, project);
+    }
+}
+
+void CGisWorkspace::addPoiAsWpt(const poi_t &poi, IGisProject *project) const
+{
+    tristate_e tmp = eTristateUndefined;
+    addPoiAsWpt(poi, tmp, project);
+}
+
+void CGisWorkspace::addPoiAsWpt(const poi_t &poi, tristate_e& openEditWindow, IGisProject *project) const
+{
     QMutexLocker lock(&IGisItem::mutexItems);
 
     if(nullptr == project)
@@ -935,10 +958,24 @@ void CGisWorkspace::addPoisAsWpt(const QSet<poi_t> &pois, IGisProject * project)
     {
         return;
     }
-    for(const poi_t& poi: pois)
+    if(openEditWindow == eTristateUndefined && poi.icon.isEmpty())
     {
-        CGisItemWpt::newWpt(poi.pos * RAD_TO_DEG, poi.name, poi.desc, project, false);
+        int answer = QMessageBox(QMessageBox::Icon::Question,
+                                 tr("Undefined Waypoint Symbol"),
+                                 tr("QMapShack couldn't automatically assign a waypoint icon to one of the POIs you want to convert to a waypoint.\n\n"
+                                    "Do you want to choose an icon for each new waypoint for which no icon could be found?\n"
+                                    "If you choose 'No' the respective last used waypoint icon is applied."),
+                                 QMessageBox::Yes | QMessageBox::No).exec();
+        if(answer == QMessageBox::Yes)
+        {
+            openEditWindow = eTristateTrue;
+        }
+        else
+        {
+            openEditWindow = eTristateFalse;
+        }
     }
+    CGisItemWpt::newWpt(poi.pos * RAD_TO_DEG, poi.name, poi.desc, project, poi.icon, openEditWindow == eTristateTrue && poi.icon.isEmpty());
 }
 
 void CGisWorkspace::focusTrkByKey(bool yes, const IGisItem::key_t& key)

--- a/src/qmapshack/gis/CGisWorkspace.h
+++ b/src/qmapshack/gis/CGisWorkspace.h
@@ -29,6 +29,7 @@
 #include "gis/IGisItem.h"
 #include "gis/rte/router/IRouter.h"
 #include "gis/search/CSearchLineEdit.h"
+#include "helpers/Tristate.h"
 
 
 class CGisDraw;
@@ -352,7 +353,10 @@ public:
        @param pt    the position in degrees
      */
     void addWptByPos(const QPointF& pt, const QString& name = QString::Null(), const QString& desc = QString::Null()) const;
+
     void addPoisAsWpt(const QSet<poi_t> &pois, IGisProject *project = nullptr) const;
+    void addPoiAsWpt(const poi_t &poi, IGisProject *project = nullptr) const;
+    void addPoiAsWpt(const poi_t &poi, tristate_e &openEditWindow, IGisProject *project = nullptr) const;
 
     void toggleWptBubble(const IGisItem::key_t &key);
 

--- a/src/qmapshack/gis/Poi.h
+++ b/src/qmapshack/gis/Poi.h
@@ -28,7 +28,9 @@ struct poi_t
     poi_t() : pos(NOPOINTF){}
     QString name;
     QString desc;
-    QPointF pos; // in radians!
+    /// in radians
+    QPointF pos;
+    QString icon;
 };
 
 inline bool operator==(const poi_t &poi1, const poi_t &poi2)

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -273,19 +273,13 @@ bool CGisItemWpt::getIconAndName(QString& icon, QString& name)
     return true;
 }
 
-void CGisItemWpt::newWpt(const QPointF& pt, const QString &name, const QString &desc, IGisProject * project, bool openEditWIndow)
+void CGisItemWpt::newWpt(const QPointF& pt, const QString &name, const QString &desc, IGisProject * project, const QString& icon, bool openEditWIndow)
 {
     SETTINGS;
-    QString icon = cfg.value("Waypoint/lastIcon", "Waypoint").toString();
+    const QString& _icon = icon.isEmpty() ? cfg.value("Waypoint/lastIcon", "Waypoint").toString() : icon;
+    const QString& _name = name.isEmpty() ? getLastName("") : name;
 
-    QString _name = name;
-
-    if(_name.isEmpty())
-    {
-        _name = getLastName("");
-    }
-
-    CGisItemWpt * wpt = new CGisItemWpt(pt, _name, icon, project);
+    CGisItemWpt * wpt = new CGisItemWpt(pt, _name, _icon, project);
     if(!desc.isEmpty())
     {
         wpt->setDescription(desc);

--- a/src/qmapshack/gis/wpt/CGisItemWpt.h
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.h
@@ -348,7 +348,7 @@ public:
     const searchValue_t getValueByKeyword(searchProperty_e keyword) override;
 
     static QString getLastName(const QString &name);
-    static void newWpt(const QPointF &pt, const QString& name, const QString& desc, IGisProject *project, bool openEditWIndow = true);
+    static void newWpt(const QPointF &pt, const QString& name, const QString& desc, IGisProject *project, const QString &icon = "", bool openEditWIndow = true);
     static bool getIconAndName(QString& icon, QString& name);
 
     static void drawCircle(QPainter& p, const QPointF& pos, const qreal& r, const bool &avoid, const bool &selected);

--- a/src/qmapshack/helpers/Tristate.h
+++ b/src/qmapshack/helpers/Tristate.h
@@ -16,35 +16,14 @@
 
 **********************************************************************************************/
 
-#ifndef CRAWPOI_H
-#define CRAWPOI_H
+#ifndef TRISTATE_H
+#define TRISTATE_H
 
-#include <QPointF>
-#include <QString>
-#include <QStringList>
-
-struct poi_t;
-
-class CRawPoi
+enum tristate_e
 {
-public:
-    //Dummy constructor for the usage of QMap
-    CRawPoi(){}
-    CRawPoi(const QStringList& data, const QPointF& coordinates, const quint64& key, const QString &category, const QString &garminIcon);
-    const QString& getCategory() const;
-    const QString& getName(bool replaceEmptyByCategory = true) const;
-    const QPointF &getCoordinates() const;
-    const quint64 &getKey() const;
-    const QStringList &getData() const;
-    poi_t toPoi() const;
-
-private:
-    QString category;
-    QPointF coordinates; // in radians
-    QStringList data;
-    QString garminIcon;
-    quint64 key;
-    QString name;
+    eTristateTrue,
+    eTristateFalse,
+    eTristateUndefined
 };
 
-#endif // CRAWPOI_H
+#endif // TRISTATE_H

--- a/src/qmapshack/mouse/CMouseNormal.cpp
+++ b/src/qmapshack/mouse/CMouseNormal.cpp
@@ -360,7 +360,7 @@ void CMouseNormal::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect 
 
 void CMouseNormal::slotAddPoi(const poi_t& poi) const
 {
-    CGisWorkspace::self().addWptByPos(poi.pos * RAD_TO_DEG, poi.name, poi.desc);
+    CGisWorkspace::self().addPoiAsWpt(poi);
     canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawGis);
 }
 

--- a/src/qmapshack/poi/CPoiIconCategory.h
+++ b/src/qmapshack/poi/CPoiIconCategory.h
@@ -26,10 +26,19 @@ class CPoiIconCategory
 public:
     //Only to avoid compiler errors due to maps assignment
     CPoiIconCategory(){}
-    CPoiIconCategory(const QPixmap& baseIcon, const QMap<QString, QPixmap>& subCategories = QMap<QString, QPixmap>()) : baseIcon(baseIcon), subCategories(subCategories){}
+    CPoiIconCategory(const QPixmap& baseIcon, const QString& garminSym = "", const QMap<QString, QPixmap>& subCategories = QMap<QString, QPixmap>())
+        : baseIcon(baseIcon), garminSym(garminSym), subCategories(subCategories){}
+    //Convenience constructor to be able to omit garminSym when specifying child categories
+    CPoiIconCategory(const QPixmap& baseIcon, const QMap<QString, QPixmap>& subCategories)
+        : baseIcon(baseIcon), garminSym(""), subCategories(subCategories){}
     QPixmap getIcon(const QStringList &additionalTags) const;
+    const QString& getGarminSym() const
+    {
+        return garminSym;
+    }
 private:
     QPixmap baseIcon;
+    QString garminSym;
     QMap<QString, QPixmap> subCategories;
 };
 

--- a/src/qmapshack/poi/CPoiPOI.cpp
+++ b/src/qmapshack/poi/CPoiPOI.cpp
@@ -458,13 +458,23 @@ void CPoiPOI::loadPOIsFromFile(quint64 categoryID, int minLonM10, int minLatM10)
     while (query.next())
     {
         quint64 key = query.value(eSqlColumnPoiId).toUInt();
+        const QStringList& data = query.value(eSqlColumnPoiData).toString().split("\r");
+        QString garminIcon;
+        for(const QString& tag : data)
+        {
+            if(tagMap.contains(tag))
+            {
+                garminIcon = tagMap[tag].getGarminSym();
+                break;
+            }
+        }
         mutex.lock();
         loadedPoisByArea[categoryID][minLonM10][minLatM10].append(key);
         // TODO: this overwrites a POI if it already was loaded. The difference between those will be the category. Some better handling should be done
-        loadedPois[key] = CRawPoi(query.value(eSqlColumnPoiData).toString().split("\r"),
+        loadedPois[key] = CRawPoi(data,
                                   QPointF((query.value(eSqlColumnPoiMaxLon).toDouble() + query.value(eSqlColumnPoiMinLon).toDouble()) / 2 * DEG_TO_RAD,
                                           (query.value(eSqlColumnPoiMaxLat).toDouble() + query.value(eSqlColumnPoiMinLat).toDouble()) / 2 * DEG_TO_RAD),
-                                  key, categoryNames[categoryID]);
+                                  key, categoryNames[categoryID], garminIcon);
         mutex.unlock();
     }
 }

--- a/src/qmapshack/poi/CPoiPOI_TagMap.cpp
+++ b/src/qmapshack/poi/CPoiPOI_TagMap.cpp
@@ -19,7 +19,6 @@
 #include "poi/CPoiIconCategory.h"
 #include "poi/CPoiPOI.h"
 
-#define SQLQUERY(TAG) "main.poi_data.data LIKE '%" TAG "%'"
 QMap<QString, CPoiIconCategory> CPoiPOI::tagMap;
 QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
 {
@@ -27,9 +26,9 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
     /*
        map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_youth_hostel.n.32.png"));
        map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_public_building.n.32.png"));
-       map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_college_vocational.n.32.png"));
-       map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_school_primary.n.32.png"));
-       map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_school_secondary.n.32.png"));
+       map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_college_vocational.n.32.png"), "School");
+       map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_school_primary.n.32.png"), "School");
+       map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_school_secondary.n.32.png"), "School");
        map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_grass.n.32.png"));
        map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_hills.n.32.png"));
        map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_point_of_interest.n.32.png"));
@@ -57,37 +56,37 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
        map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_walking.n.32.png"));
        map["MISSING"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_zebra_crossing.n.32.png"));
      */
-    map["aeroway=aerodrome"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_aerodrome.n.32.png"));
-    map["aeroway=airport"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_airport.n.32.png"));
-    map["aeroway=gate"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_airport_gate.n.32.png"));
-    map["aeroway=terminal"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_airport_terminal.n.32.png"));
-    map["aeroway=helipad"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_helicopter_pad.n.32.png"));
-    map["amenity=atm"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/money_atm.n.32.png"));
-    map["amenity=bank"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/money_bank.n.32.png"));
-    map["amenity=bar"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_bar.n.32.png"));
+    map["aeroway=aerodrome"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_aerodrome.n.32.png"), "Airport");
+    map["aeroway=airport"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_airport.n.32.png"), "Airport");
+    map["aeroway=gate"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_airport_gate.n.32.png"), "Airport");
+    map["aeroway=terminal"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_airport_terminal.n.32.png"), "Airport");
+    map["aeroway=helipad"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_helicopter_pad.n.32.png"), "Heliport");
+    map["amenity=atm"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/money_atm.n.32.png"), "Bank");
+    map["amenity=bank"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/money_bank.n.32.png"), "Bank");
+    map["amenity=bar"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_bar.n.32.png"), "Bar");
     map["amenity=beer_garden'"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_biergarten.n.32.png"));
     map["amenity=bench"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_bench.n.32.png"));
     map["amenity=bicycle_parking"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_parking_bicycle.n.32.png"));
     map["amenity=bicycle_rental"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_rental_bicycle.n.32.png"));
-    map["amenity=biergarten"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_biergarten.n.32.png"));
+    map["amenity=biergarten"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_biergarten.n.32.png"), "Bar");
     map["amenity=bureau_de_change"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/money_currency_exchange.n.32.png"));
     map["amenity=bus_station"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png"));
-    map["amenity=cafe"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_cafe.n.32.png"));
-    map["amenity=car_rental"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_rental_car.n.32.png"));
+    map["amenity=cafe"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_cafe.n.32.png"), "Restaurant");
+    map["amenity=car_rental"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_rental_car.n.32.png"), "Car Rental");
     map["amenity=car_sharing"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_car_share.n.32.png"));
     map["amenity=casino"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_casino.n.32.png"));
     map["amenity=cinema"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_cinema.n.32.png"));
     map["amenity=clock"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_clock.n.32.png"));
     map["amenity=clinic"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_hospital.n.32.png"));
-    map["amenity=college"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_college.n.32.png"));
-    map["amenity=courthouse"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_court.n.32.png"));
-    map["amenity=court_house"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_court.n.32.png"));
-    map["amenity=dentist"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_dentist.n.32.png"));
-    map["amenity=doctors"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_doctors.n.32.png"));
-    map["amenity=drinking_water"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_drinkingtap.n.32.png"));
+    map["amenity=college"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_college.n.32.png"), "School");
+    map["amenity=courthouse"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_court.n.32.png"), "Scale");
+    map["amenity=court_house"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_court.n.32.png"), "Scale");
+    map["amenity=dentist"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_dentist.n.32.png"), "Medical Facility");
+    map["amenity=doctors"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_doctors.n.32.png"), "Medical Facility");
+    map["amenity=drinking_water"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_drinkingtap.n.32.png"), "Drinking Water");
     map["amenity=embassy"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_embassy.n.32.png"));
     map["amenity=emergency_phone"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_emergency_phone.n.32.png"));
-    map["amenity=fast_food"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_fastfood.n.32.png"),
+    map["amenity=fast_food"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_fastfood.n.32.png"), "Fast Food",
     {
         {"cuisine=pizza", QPixmap("://icons/poi/SJJB/png/food_fastfood_pizza.n.32.png")}
     });
@@ -98,23 +97,23 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
     {
         {"fuel:lpg=yes", QPixmap("://icons/poi/SJJB/png/transport_fuel_lpg.n.32.png")}
     });
-    map["amenity=hospital"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_hospital.n.32.png"),
+    map["amenity=hospital"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_hospital.n.32.png"), "Medical Facility",
     {
         {"emergency=yes", QPixmap("://icons/poi/SJJB/png/health_hospital_emergency.n.32.png")}
     });
-    map["amenity=ice_cream"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_ice_cream.n.32.png"));
-    map["amenity=kindergarten"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_nursery.n.32.png"));
-    map["amenity=library"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_library.n.32.png"));
+    map["amenity=ice_cream"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_ice_cream.n.32.png"), "Fast Food");
+    map["amenity=kindergarten"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_nursery.n.32.png"), "School");
+    map["amenity=library"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_library.n.32.png"), "Library");
     map["amenity=marketplace"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_marketplace.n.32.png"));
-    map["amenity=parking"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_parking_car.n.32.png"),
+    map["amenity=parking"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_parking_car.n.32.png"), "Parking Area",
     {
         {"fee=yes", QPixmap("://icons/poi/SJJB/png/transport_parking_car_paid.n.32.png")}
     });
-    map["amenity=pharmacy"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_pharmacy.n.32.png"),
+    map["amenity=pharmacy"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_pharmacy.n.32.png"), "Pharmacy",
     {
         {"dispensing=yes", QPixmap("://icons/poi/SJJB/png/health_pharmacy_dispencing.n.32.png")}
     });
-    map["amenity=place_of_worship"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/place_of_worship_unknown.n.32.png"),
+    map["amenity=place_of_worship"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/place_of_worship_unknown.n.32.png"), "Church",
     {
         {"religion=bahai", QPixmap("://icons/poi/SJJB/png/place_of_worship_bahai.n.32.png")},
         {"religion=buddhist", QPixmap("://icons/poi/SJJB/png/place_of_worship_buddhist.n.32.png")},
@@ -127,28 +126,28 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
         {"religion=sikh", QPixmap("://icons/poi/SJJB/png/place_of_worship_sikh.n.32.png")}
     });
     map["amenity=police"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_police.n.32.png"));
-    map["amenity=post_box"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_post_box.n.32.png"));
-    map["amenity=post_office"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_post_office.n.32.png"));
+    map["amenity=post_box"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_post_box.n.32.png"), "Post Office");
+    map["amenity=post_office"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_post_office.n.32.png"), "Post Office");
     map["amenity=prison"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_prison.n.32.png"));
-    map["amenity=pub"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_pub.n.32.png"));
+    map["amenity=pub"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_pub.n.32.png"), "Bar");
     map["amenity=recycling"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_recycling.n.32.png"));
-    map["amenity=restaurant"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_restaurant.n.32.png"),
+    map["amenity=restaurant"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_restaurant.n.32.png"), "Restaurant",
     {
         {"cuisine=pizza", QPixmap("://icons/poi/SJJB/png/food_pizza.n.32.png")}
     });
-    map["amenity=school"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_school.n.32.png"));
-    map["amenity=shelter"] = CPoiIconCategory(QPixmap("://icons/poi/png/accommodation_shelter_r_n32.png"));
+    map["amenity=school"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_school.n.32.png"), "School");
+    map["amenity=shelter"] = CPoiIconCategory(QPixmap("://icons/poi/png/accommodation_shelter_r_n32.png"), "Lodge");
     map["amenity=taxi"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_taxi_rank.n.32.png"));
-    map["amenity=telephone"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_telephone.n.32.png"));
-    map["amenity=theatre"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_theatre.n.32.png"));
-    map["amenity=toilets"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_toilets.n.32.png"),
+    map["amenity=telephone"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_telephone.n.32.png"), "Telephone");
+    map["amenity=theatre"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_theatre.n.32.png"), "Live Theater");
+    map["amenity=toilets"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_toilets.n.32.png"), "Restroom",
     {
         {"wheelchair=yes", QPixmap("://icons/poi/SJJB/png/amenity_toilets_disabled.n.32.png")},
         {"male=yes", QPixmap("://icons/poi/SJJB/png/amenity_toilets_men.n.32.png")},
         {"female=yes", QPixmap("://icons/poi/SJJB/png/amenity_toilets_women.n.32.png")}
     });
-    map["amenity=townhall"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_town_hall.n.32.png"));
-    map["amenity=university"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_university.n.32.png"));
+    map["amenity=townhall"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_town_hall.n.32.png"), "City Hall");
+    map["amenity=university"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/education_university.n.32.png"), "School");
     map["amenity=vending_machine"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_vending_machine.n.32.png"));
     map["amenity=veterinary"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_veterinary.n.32.png"));
     map["amenity=water_point"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_drinkingtap.n.32.png"));
@@ -169,66 +168,66 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
     map["entrance=main"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/barrier_entrance.n.32.png"));
     map["entrance=yes"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/barrier_entrance.n.32.png"));
     map["ford=yes"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_ford.n.32.png"));
-    map["healthcare=optometrist"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_opticians.n.32.png"));
+    map["healthcare=optometrist"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/health_opticians.n.32.png"), "Medical Facility");
     map["highway=bus_stop"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_stop.n.32.png"));
     map["highway=steps"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/barrier_steps.n.32.png"));
     map["historic=archaeological_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_archaeological.n.32.png"));
     map["historic=battlefield"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_battlefield.n.32.png"));
     map["historic=castle"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_castle.n.32.png"));
     map["historic=memorial"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_memorial.n.32.png"));
-    map["historic=mine"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine_abandoned.n.32.png"));
+    map["historic=mine"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine_abandoned.n.32.png"), "Mine");
     map["historic=monument"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_monument.n.32.png"));
-    map["historic=ruins"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_ruin.n.32.png"));
+    map["historic=ruins"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_ruin.n.32.png"), "Ghost Town");
     map["historic=wayside_cross"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_wayside_cross.n.32.png"));
     map["historic=wayside_shrine"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_wayside_shrine.n.32.png"));
-    map["historic=wreck"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_wreck.n.32.png"));
-    map["industrial=mine"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine.n.32.png"),
+    map["historic=wreck"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_wreck.n.32.png"), "Shipwreck");
+    map["industrial=mine"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine.n.32.png"), "Mine",
     {
         {"disused=yes", QPixmap("://icons/poi/SJJB/png/poi_mine_abandoned.n.32.png")}
     });
     map["industrial=port"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_port.n.32.png"));
     map["information=guidepost"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_guidepost.n.32.png"));
-    map["landuse=forest"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous_and_deciduous.n.32.png"));
+    map["landuse=forest"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous_and_deciduous.n.32.png"), "Forest");
     map["landuse=harbour"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_port.n.32.png"));
     map["landuse=port"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_port.n.32.png"));
     map["landuse=quarry"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_quary.n.32.png"));
     map["landuse=recreation_ground"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_leisure_centre.n.32.png"));
-    map["leaf_cycle=deciduous"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_deciduous.n.32.png"));
-    map["leaf_cycle=evergreen"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous.n.32.png"));
-    map["leisure=fitness_centre"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_gym.n.32.png"));
+    map["leaf_cycle=deciduous"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_deciduous.n.32.png"), "Forest");
+    map["leaf_cycle=evergreen"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous.n.32.png"), "Forest");
+    map["leisure=fitness_centre"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_gym.n.32.png"), "Fitness Center");
     map["leisure=golf_course"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_golf.n.32.png"));
     map["leisure=marina"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_marina.n.32.png"));
     map["leisure=park"] = CPoiIconCategory(QPixmap("://icons/poi/png/amenity_leisure_park_n32.png"));
-    map["leisure=picnic_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_picnic.n.32.png"));
-    map["leisure=picnic_table"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_picnic.n.32.png"));
+    map["leisure=picnic_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_picnic.n.32.png"), "Picnic Area");
+    map["leisure=picnic_table"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_picnic.n.32.png"), "Picnic Area");
     map["leisure=playground"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_playground.n.32.png"));
     map["leisure=playground"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_playground.n.32.png"));
-    map["leisure=slipway"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_slipway.n.32.png"));
-    map["leisure=sports_centre"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_gymnasium.n.32.png"));
-    map["leisure=sports_hall"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_gymnasium.n.32.png"));
+    map["leisure=slipway"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_slipway.n.32.png"), "Boat Ramp");
+    map["leisure=sports_centre"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_gymnasium.n.32.png"), "Fitness Center");
+    map["leisure=sports_hall"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_gymnasium.n.32.png"), "Fitness Center");
     map["leisure=stadium"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_stadium.n.32.png"));
     map["leisure=swimming_pool"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_swimming_indoor.n.32.png"));
     map["leisure=water_park"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_swimming_outdoor.n.32.png"));
     map["man_made=adit"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_cave.n.32.png"));
-    map["man_made=adit"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine.n.32.png"),
+    map["man_made=adit"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine.n.32.png"), "Mine",
     {
         {"disused=yes", QPixmap("://icons/poi/SJJB/png/poi_mine_abandoned.n.32.png")}
     });
     map["man_made=crane"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_crane.n.32.png"));
     map["man_made=lighthouse"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_lighthouse.n.32.png"));
-    map["man_made=mast"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_communications.n.32.png"));
-    map["man_made=mineshaft"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine.n.32.png"),
+    map["man_made=mast"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_communications.n.32.png"), "Tall Tower");
+    map["man_made=mineshaft"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mine.n.32.png"), "Mine",
     {
         {"disused=yes", QPixmap("://icons/poi/SJJB/png/poi_mine_abandoned.n.32.png")}
     });
     map["man_made=survey_point"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/amenity_survey_point.n.32.png"));
-    map["man_made=tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_lookout.n.32.png"),
+    map["man_made=tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_lookout.n.32.png"), "Small Tower",
     {
         {"tower:type=communication", QPixmap("://icons/poi/SJJB/png/poi_tower_communications.n.32.png")},
         {"tower=communication", QPixmap("://icons/poi/SJJB/png/poi_tower_communications.n.32.png")}
     });
-    map["man_made=water_tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_water.n.32.png"));
-    map["man_made=water_tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/water_tower.n.32.png"));
+    map["man_made=water_tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_water.n.32.png"), "Small Tower");
+    //map["man_made=water_tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/water_tower.n.32.png"),  "Small Tower");
     map["man_made=water_well"] = CPoiIconCategory(QPixmap("://icons/poi/png/man_made_water_well.png"));
     map["man_made=watermill"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_waterwheel.n.32.png"));
     map["man_made=windmill"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_windmill.n.32.png"));
@@ -236,38 +235,38 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
     map["military=bunker"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_military_bunker.n.32.png"));
     map["military=range"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_shooting.n.32.png"));
     map["mountain_pass=yes"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_mountain_pass.n.32.png"));
-    map["natural=beach"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_beach.n.32.png"));
+    map["natural=beach"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_beach.n.32.png"), "Beach");
     map["natural=cave_entrance"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_cave.n.32.png"));
-    map["natural=peak"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_peak.n.32.png"));
+    map["natural=peak"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_peak.n.32.png"), "Summit");
     map["natural=scrub"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_scrub.n.32.png"));
     map["natural=spring"] = CPoiIconCategory(QPixmap("://icons/poi/png/water_spring_n32.png"));
-    map["natural=tree"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous_and_deciduous.n.32.png"));
+    map["natural=tree"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous_and_deciduous.n.32.png"), "Forest");
     map["natural=volcano"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_peak.n.32.png"));
     map["natural=waterfall"] = CPoiIconCategory(QPixmap("://icons/poi/png/water_waterfall_n32.png"));
     map["natural=wetland"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_swamp.n.32.png"));
-    map["natural=wood"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous_and_deciduous.n.32.png"));
+    map["natural=wood"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/landuse_coniferous_and_deciduous.n.32.png"), "Forest");
     map["office=estateagent"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_estateagent.n.32.png"));
     map["piste:type=downhill"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_skiing_downhill.n.32.png"));
     map["piste:type=nordic"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_skiing_crosscountry.n.32.png"));
-    map["place=city"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_city.n.32.png"));
-    map["place=hamlet"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_hamlet.n.32.png"));
-    map["place=suburb"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_suburb.n.32.png"));
-    map["place=town"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_town.n.32.png"));
-    map["place=village"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_village.n.32.png"));
-    map["power=tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_power.n.32.png"));
-    map["public_transport=platform"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png"),
+    map["place=city"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_city.n.32.png"), "City (Large)");
+    map["place=hamlet"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_hamlet.n.32.png"), "City (Small)");
+    map["place=suburb"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_suburb.n.32.png"), "City (Small)");
+    map["place=town"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_town.n.32.png"), "City (Medium)");
+    map["place=village"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_place_village.n.32.png"), "City (Small)");
+    map["power=tower"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/poi_tower_power.n.32.png"), "Tall Tower");
+    map["public_transport=platform"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png"), "Ground Transportation",
     {
         {"railway=yes", QPixmap("://icons/poi/SJJB/png/transport_train_station.n.32.png")},
         {"tram=yes", QPixmap("://icons/poi/SJJB/png/transport_tram_stop.n.32.png")},
         {"bus=yes", QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png")},
     });
-    map["public_transport=station"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png"),
+    map["public_transport=station"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png"), "Ground Transportation",
     {
         {"railway=yes", QPixmap("://icons/poi/SJJB/png/transport_train_station.n.32.png")},
         {"tram=yes", QPixmap("://icons/poi/SJJB/png/transport_tram_stop.n.32.png")},
         {"bus=yes", QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png")},
     });
-    map["public_transport=stop_position"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png"),
+    map["public_transport=stop_position"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_bus_station.n.32.png"), "Ground Transportation",
     {
         {"railway=yes", QPixmap("://icons/poi/SJJB/png/transport_train_station.n.32.png")},
         {"tram=yes", QPixmap("://icons/poi/SJJB/png/transport_tram_stop.n.32.png")},
@@ -275,22 +274,22 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
     });
     map["railway:preserved=yes"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_steam_train.n.32.png"));
     map["railway=preserved"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_steam_train.n.32.png"));
-    map["railway=station"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_train_station.n.32.png"));
+    map["railway=station"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_train_station.n.32.png"), "Railway");
     map["railway=tram_stop"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_tram_stop.n.32.png"));
-    map["shop=alcohol"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_alcohol.n.32.png"));
+    map["shop=alcohol"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_alcohol.n.32.png"), "Winery");
     map["shop=bakery"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_bakery.n.32.png"));
     map["shop=bicycle"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_bicycle.n.32.png"));
     map["shop=books"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_book.n.32.png"));
     map["shop=butcher"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_butcher.n.32.png"));
     map["shop=car"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_car.n.32.png"));
-    map["shop=car_repair"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_car_repair.n.32.png"));
+    map["shop=car_repair"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_car_repair.n.32.png"), "Car Repair");
     map["shop=clothes"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_clothes.n.32.png"));
     map["shop=computer"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_computer.n.32.png"));
     map["shop=confectionery"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_confectionery.n.32.png"));
-    map["shop=convenience"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_convenience.n.32.png"));
+    map["shop=convenience"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_convenience.n.32.png"), "Convenience Store");
     map["shop=copyshop"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_copyshop.n.32.png"));
     map["shop=craft"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_diy.n.32.png"));
-    map["shop=department_store"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_department_store.n.32.png"));
+    map["shop=department_store"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_department_store.n.32.png"), "Department Store");
     map["shop=fishing"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_tackle.n.32.png"));
     map["shop=florist"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_florist.n.32.png"));
     map["shop=garden_centre"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/shopping_garden_centre.n.32.png"));
@@ -331,37 +330,37 @@ QMap<QString, CPoiIconCategory> CPoiPOI::initTagMap()
     map["sport=snooker"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_snooker.n.32.png"));
     map["sport=soccer"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_soccer.n.32.png"));
     map["sport=surfing"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_windsurfing.n.32.png"));
-    map["sport=swimming"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_swimming_outdoor.n.32.png"),
+    map["sport=swimming"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_swimming_outdoor.n.32.png"), "Swimming Area",
     {
         {"building=yes", QPixmap("://icons/poi/SJJB/png/sport_swimming_indoor.n.32.png")}
     });
     map["sport=tennis"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/sport_tennis.n.32.png"));
-    map["station=subway"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_subway.n.32.png"));
-    map["tourism=alpine_hut"] = CPoiIconCategory(QPixmap("://icons/poi/png/accommodation_alpinehut_r_n32.png"));
+    map["station=subway"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/transport_subway.n.32.png"), "Ground Transportation");
+    map["tourism=alpine_hut"] = CPoiIconCategory(QPixmap("://icons/poi/png/accommodation_alpinehut_r_n32.png"), "Lodge");
     map["tourism=attraction"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_attraction.n.32.png"));
-    map["tourism=camp_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_camping.n.32.png"));
-    map["tourism=caravan_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_caravan_park.n.32.png"));
-    map["tourism=chalet"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_chalet.n.32.png"));
+    map["tourism=camp_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_camping.n.32.png"), "Campground");
+    map["tourism=caravan_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_caravan_park.n.32.png"), "RV Park");
+    map["tourism=chalet"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_chalet.n.32.png"), "Lodging");
     map["tourism=gallery"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_art_gallery.n.32.png"));
-    map["tourism=guest_house"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_bed_and_breakfast.n.32.png"));
-    map["tourism=hostel"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_hostel.n.32.png"));
-    map["tourism=hotel"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_hotel.n.32.png"));
-    map["tourism=information"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_information.n.32.png"),
+    map["tourism=guest_house"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_bed_and_breakfast.n.32.png"), "Lodging");
+    map["tourism=hostel"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_hostel.n.32.png"), "Lodging");
+    map["tourism=hotel"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_hotel.n.32.png"), "Lodging");
+    map["tourism=information"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_information.n.32.png"), "Information",
     {
         {"information=board", QPixmap("://icons/poi/SJJB/png/tourist_map.n.32.png")},
         {"information=map", QPixmap("://icons/poi/SJJB/png/tourist_map.n.32.png")}
     });
-    map["tourism=motel"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_motel.n.32.png"));
-    map["tourism=museum"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_museum.n.32.png"));
-    map["tourism=picnic_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_picnic.n.32.png"));
+    map["tourism=motel"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/accommodation_motel.n.32.png"), "Lodging");
+    map["tourism=museum"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_museum.n.32.png"), "Museum");
+    map["tourism=picnic_site"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_picnic.n.32.png"), "Picnic Area");
     map["tourism=theme_park"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_theme_park.n.32.png"));
-    map["tourism=viewpoint"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_view_point.n.32.png"));
-    map["tourism=wilderness_hut"] = CPoiIconCategory(QPixmap("://icons/poi/png/accommodation_wilderness_hut_r_n32.png"));
-    map["tourism=zoo"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_zoo.n.32.png"));
-    map["waterway=dam"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/water_dam.n.32.png"));
+    map["tourism=viewpoint"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_view_point.n.32.png"), "Scenic Area");
+    map["tourism=wilderness_hut"] = CPoiIconCategory(QPixmap("://icons/poi/png/accommodation_wilderness_hut_r_n32.png"), "Lodge");
+    map["tourism=zoo"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/tourist_zoo.n.32.png"), "Zoo");
+    map["waterway=dam"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/water_dam.n.32.png"), "Dam");
     map["waterway=water_point"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/food_drinkingtap.n.32.png"));
     map["waterway=waterfall"] = CPoiIconCategory(QPixmap("://icons/poi/png/water_waterfall_n32.png"));
-    map["waterway=weir"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/water_weir.n.32.png"));
+    map["waterway=weir"] = CPoiIconCategory(QPixmap("://icons/poi/SJJB/png/water_weir.n.32.png"), "Dam");
 
     return map;
 }

--- a/src/qmapshack/poi/CRawPoi.cpp
+++ b/src/qmapshack/poi/CRawPoi.cpp
@@ -21,8 +21,8 @@
 
 #include <QRegularExpression>
 
-CRawPoi::CRawPoi(const QStringList &data, const QPointF &coordinates, const quint64 &key, const QString& category)
-    : category(category), coordinates(coordinates), data(data), key(key)
+CRawPoi::CRawPoi(const QStringList &data, const QPointF &coordinates, const quint64 &key, const QString& category, const QString& garminIcon)
+    : category(category), coordinates(coordinates), data(data), garminIcon(garminIcon), key(key)
 {
     for(const QRegularExpression& regex : {QRegularExpression("name:" + QLocale::system().name() + "=(.+)", QRegularExpression::UseUnicodePropertiesOption),
                                            QRegularExpression("name:en=(.+)", QRegularExpression::UseUnicodePropertiesOption),
@@ -75,6 +75,7 @@ poi_t CRawPoi::toPoi() const
     poi.pos = coordinates;
     poi.name = getName();
     poi.desc = data.join("<br>\n");
+    poi.icon = garminIcon;
     return poi;
 }
 


### PR DESCRIPTION
_**Note: Do not delete any of the sections Answer them all. Replace the descriptive text by your answer**_

**What is the linked issue for this pull request (start with a `#`):**

QMS-#314

**Describe roughly what you have done:**

I added that the POIs when copied over to a project now get a symbol that match their type, if available.

**What steps have to be done to perform a simple smoke test:**

1. Open a *.poi file
2. Copy POIs over to a project via right-click or 'Select Items On Map'
3. See that you are asked if there is no symbol to choose one.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
