### PR TITLE
[QMS-307] Optimization of POI query

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-299] CEnergyCycling is storing it's configuration in the `General` section instead of it's own.
 [QMS-301] Load POI file
 [QMS-303] Add POI icons
+[QMS-307] Optimization of POI query
 [QMS-311] Automatically save projects to device
 [QMS-314] Fix/Add POI categories
 [QMS-315] Make POI Icons User-Selectable

--- a/src/qmapshack/poi/CPoiPOI.cpp
+++ b/src/qmapshack/poi/CPoiPOI.cpp
@@ -43,6 +43,38 @@ CPoiPOI::CPoiPOI(const QString &filename, CPoiDraw *parent)
     loadTimer->setSingleShot(true);
     loadTimer->setInterval(500);
     connect(loadTimer, &QTimer::timeout, poi, &CPoiDraw::emitSigCanvasUpdate);
+
+    // Open database here so it belongs to the right thread
+    if(!QSqlDatabase::contains(filename + "_bbox"))
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE", filename + "_bbox");
+        db.setDatabaseName(filename);
+        if(!db.open())
+        {
+            qDebug() << "failed to open database" << db.lastError();
+            isActivated = false;
+            return;
+        }
+    }
+
+    QSqlQuery query("SELECT value FROM main.metadata WHERE name='bounds'", QSqlDatabase::database(filename + "_bbox"));
+
+    if(query.next())
+    {
+        const QStringList& corners = query.value(0).toString().split(",");
+        qreal top = corners[2].toDouble();
+        qreal left = corners[1].toDouble();
+        qreal width = corners[3].toDouble() - left;
+        qreal height = corners[0].toDouble() - top;
+        bbox = QRectF(left, top, width, height);
+    }
+    else
+    {
+        qDebug() << "failed to retreive bounding box of " << filename;
+        isActivated = false;
+    }
+    //Database is no longer needed
+    QSqlDatabase::removeDatabase(filename + "_bbox");
 }
 
 
@@ -417,6 +449,12 @@ bool CPoiPOI::getPoiGroupCloseBy(const QPoint &px, CPoiPOI::poiGroup_t &poiItem)
 
 void CPoiPOI::loadPOIsFromFile(quint64 categoryID, int minLonM10, int minLatM10)
 {
+    // check if query is within bounds
+    if(!bbox.intersects({minLonM10 / 10.0, minLatM10 / 10.0, 0.1, 0.1}))
+    {
+        return;
+    }
+
     //Open Database here so it is owned by the right thread
     if(!QSqlDatabase::contains(filename))
     {

--- a/src/qmapshack/poi/CPoiPOI.h
+++ b/src/qmapshack/poi/CPoiPOI.h
@@ -95,6 +95,7 @@ private:
     QMap<quint64, QMap<int, QMap<int, QList<quint64> > > > loadedPoisByArea;
     QMap<quint64, CRawPoi> loadedPois;
     QList<poiGroup_t> displayedPois;
+    QRectF bbox;
 
 
     static QMap<QString, CPoiIconCategory> tagMap;


### PR DESCRIPTION
_**Note: Do not delete any of the sections Answer them all. Replace the descriptive text by your answer**_

**What is the linked issue for this pull request (start with a `#`):**

QMS-#307

**Describe roughly what you have done:**

I added checking for bounding box when fetching POIs.

Loading all categories at once (instead of querying the same area multiple times) would take some effort to do in a sensible way and at least on my machine it works relatively smoothly now as long as it is not zoomed out too far.

**What steps have to be done to perform a simple smoke test:**

1. Activate POI file
2. Move outside bounding box of loaded file
3. See that loading does not take any time (before it did)

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
