### PR TITLE
[QMS-353] "Select Items on Map" does not update when items are removed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-337] Upgrade to Proj 8 API
 [QMS-344] Better integration of new PROJ lib into cmake build system
 [QMS-349] Upgrade to Quazip Qt5 V1.x
+[QMS-353] "Select Items on Map" does not update when items are removed
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/mouse/CMouseSelect.cpp
+++ b/src/qmapshack/mouse/CMouseSelect.cpp
@@ -35,6 +35,7 @@ CMouseSelect::CMouseSelect(CGisDraw *gis, CCanvas *canvas, CMouseAdapter *mouse)
     CScrOptSelect * scrOptSelect;
     scrOpt = scrOptSelect = new CScrOptSelect(this);
 
+    connect(&CGisWorkspace::self(), &CGisWorkspace::sigChanged, this, &CMouseSelect::slotUpdate);
     connect(scrOptSelect->toolCopy,         &QToolButton::clicked, this, &CMouseSelect::slotCopy);
     connect(scrOptSelect->toolRoute,        &QToolButton::clicked, this, &CMouseSelect::slotRoute);
     connect(scrOptSelect->toolEditPrxWpt,   &QToolButton::clicked, this, &CMouseSelect::slotEditPrxWpt);
@@ -155,7 +156,11 @@ void CMouseSelect::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect 
     IMouseSelect::draw(p, needsRedraw, rect);
 }
 
-
+void CMouseSelect::slotUpdate()
+{
+    rectLastSel = {};
+    canvas->update();
+}
 
 void CMouseSelect::slotCopy() const
 {

--- a/src/qmapshack/mouse/CMouseSelect.h
+++ b/src/qmapshack/mouse/CMouseSelect.h
@@ -37,6 +37,7 @@ public:
     void draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRect &rect) override;
 
 private slots:
+    void slotUpdate();
     void slotCopy() const;
     void slotRoute() const;
     void slotEditPrxWpt() const;


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):**

QMS-#353

**Describe roughly what you have done:**

Simply add missing update handler

**What steps have to be done to perform a simple smoke test:**

* Load a couple of data into the workspace.
* Select the data with "Select Items on Map" .
* The on-screen message lists all items selected.
* Now remove the project from the workspace.

-> List of selected items should update. The same should happen if you hide/show the project.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
