### PR TITLE
[QMS-360] Fix compile flags for Windows 64bit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-349] Upgrade to Quazip Qt5 V1.x
 [QMS-353] "Select Items on Map" does not update when items are removed
 [QMS-354] Refactor the code to get rid of clazy warnings
+[QMS-360] Fix compile flags for Windows 64bit
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -65,14 +65,14 @@
 #include <QtSql>
 #include <QtWidgets>
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
 #include "device/CDeviceWatcherWindows.h"
 #include <dbt.h>
 #include <guiddef.h>
 #include <initguid.h>
 #include <usbiodef.h>
 #include <windows.h>
-#endif // WIN32
+#endif // Q_OS_WIN64
 
 CMainWindow * CMainWindow::pSelf = nullptr;
 
@@ -1759,7 +1759,7 @@ void CMainWindow::displayFullscreen()
     actionFullScreen->setIcon(QIcon(":/icons/32x32/RegularScreen.png"));
 }
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
 
 static void sendDeviceEvent(DWORD unitmask, bool add)
 {
@@ -1820,7 +1820,7 @@ bool CMainWindow::nativeEvent(const QByteArray & eventType, void * message, long
 
     return QWidget::nativeEvent(eventType, message, result);
 }
-#endif // WIN32
+#endif // Q_OS_WIN64
 
 void CMainWindow::dragEnterEvent(QDragEnterEvent *event)
 {

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -154,9 +154,9 @@ public slots:
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event) override;
-#ifdef WIN32
+#ifdef Q_OS_WIN64
     bool CMainWindow::nativeEvent(const QByteArray & eventType, void * message, long * result);
-#endif // WIN32
+#endif // Q_OS_WIN64
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
 

--- a/src/qmapshack/gis/tnv/serialization.cpp
+++ b/src/qmapshack/gis/tnv/serialization.cpp
@@ -759,7 +759,7 @@ bool CTwoNavProject::loadWpts(const QString& filename, const QDir& dir)
 
             QString fn = values[0].simplified();
 
-#ifndef WIN32
+#ifndef Q_OS_WIN64
             fn = fn.replace("\\", "/");
 #endif
             QFileInfo fi(dir.absoluteFilePath(fn));

--- a/src/qmapshack/helpers/Platform.h
+++ b/src/qmapshack/helpers/Platform.h
@@ -99,7 +99,7 @@
 #  include <inttypes.h>
 #elif HAVE_STDINT_H
 #  include <stdint.h>
-#elif WIN32
+#elif Q_OS_WIN64
 #include <windows.h>
 
 typedef __int8 int8_t;

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -345,7 +345,7 @@ void CMapIMG::setupTyp()
     polygonProperties[0x47] = CGarminTyp::polygon_property(0x47, Qt::NoPen, 0xff0080ff, Qt::SolidPattern);
     polygonProperties[0x48] = CGarminTyp::polygon_property(0x48, Qt::NoPen, 0xff0080ff, Qt::SolidPattern);
     polygonProperties[0x49] = CGarminTyp::polygon_property(0x49, Qt::NoPen, 0xff0080ff, Qt::SolidPattern);
-#ifdef WIN32
+#ifdef Q_OS_WIN64
     polygonProperties[0x4a] = CGarminTyp::polygon_property(0x4a, 0xff000000, qRgba(255, 255, 255, 0), Qt::SolidPattern);
     polygonProperties[0x4b] = CGarminTyp::polygon_property(0x4b, 0xff000000, qRgba(255, 255, 255, 0), Qt::SolidPattern);
 #else

--- a/src/qmapshack/map/CMapIMG.h
+++ b/src/qmapshack/map/CMapIMG.h
@@ -437,7 +437,7 @@ private:
         quint8 btObjects;
     };
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
 #pragma pack()
 #else
 #pragma pack(0)

--- a/src/qmapshack/map/CMapJNX.h
+++ b/src/qmapshack/map/CMapJNX.h
@@ -52,7 +52,7 @@ private:
         qint32 zorder;       // byte 00000030..00000033
     };
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
 #pragma pack()
 #else
 #pragma pack(0)

--- a/src/qmapshack/tool/IToolShell.cpp
+++ b/src/qmapshack/tool/IToolShell.cpp
@@ -74,13 +74,13 @@ void IToolShell::slotStderr()
 
     if(str[0] == '\r')
     {
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         if(str.contains("\n"))
         {
             text->insertPlainText("\n");
         }
         else
-#endif // WIN32
+#endif // Q_OS_WIN64
         {
             text->moveCursor( QTextCursor::End, QTextCursor::MoveAnchor );
             text->moveCursor( QTextCursor::StartOfLine, QTextCursor::MoveAnchor );
@@ -89,7 +89,7 @@ void IToolShell::slotStderr()
         }
 
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         str = str.split("\r").last().remove("\r").remove("\n");
 #else
         str = str.split("\r").last();
@@ -113,13 +113,13 @@ void IToolShell::slotStdout()
 
     if(str[0] == '\r')
     {
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         if(str.contains("\n"))
         {
             text->insertPlainText("\n");
         }
         else
-#endif // WIN32
+#endif // Q_OS_WIN64
         {
             text->moveCursor( QTextCursor::End, QTextCursor::MoveAnchor );
             text->moveCursor( QTextCursor::StartOfLine, QTextCursor::MoveAnchor );
@@ -127,7 +127,7 @@ void IToolShell::slotStdout()
             text->textCursor().removeSelectedText();
         }
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         str = str.split("\r").last().remove("\r").remove("\n");
 #else
         str = str.split("\r").last();

--- a/src/qmaptool/shell/CShell.cpp
+++ b/src/qmaptool/shell/CShell.cpp
@@ -64,13 +64,13 @@ void CShell::slotStderr()
 
     if(str[0] == '\r')
     {
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         if(str.contains("\n"))
         {
             insertPlainText("\n");
         }
         else
-#endif // WIN32
+#endif // Q_OS_WIN64
         {
             moveCursor( QTextCursor::End, QTextCursor::MoveAnchor );
             moveCursor( QTextCursor::StartOfLine, QTextCursor::MoveAnchor );
@@ -79,7 +79,7 @@ void CShell::slotStderr()
         }
 
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         str = str.split("\r").last().remove("\r").remove("\n");
 #else
         str = str.split("\r").last();
@@ -98,13 +98,13 @@ void CShell::slotStdout()
 
     if(str[0] == '\r')
     {
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         if(str.contains("\n"))
         {
             insertPlainText("\n");
         }
         else
-#endif // WIN32
+#endif // Q_OS_WIN64
         {
             moveCursor( QTextCursor::End, QTextCursor::MoveAnchor );
             moveCursor( QTextCursor::StartOfLine, QTextCursor::MoveAnchor );
@@ -112,7 +112,7 @@ void CShell::slotStdout()
             textCursor().removeSelectedText();
         }
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
         str = str.split("\r").last().remove("\r").remove("\n");
 #else
         str = str.split("\r").last();

--- a/src/qmt_map2jnx/argv.cpp
+++ b/src/qmt_map2jnx/argv.cpp
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
 #include <windows.h>
 #endif
 
@@ -25,7 +25,7 @@ char* get_argv(const int index, char** argv)
     char* result = NULL;
     int len;
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
     int numargs;
     wchar_t** argw = CommandLineToArgvW(GetCommandLineW(), &numargs);
 

--- a/src/qmt_map2jnx/main.cpp
+++ b/src/qmt_map2jnx/main.cpp
@@ -107,7 +107,7 @@ struct jnx_tile_t
 };
 
 
-#ifdef WIN32
+#ifdef Q_OS_WIN64
 #pragma pack()
 #else
 #pragma pack(0)


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):**

QMS-#360

**Describe roughly what you have done:**

Replaced WIN32 define by Q_OS_WIN64

**What steps have to be done to perform a simple smoke test:**

Code should compile in Windows without problems.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
