### PR TITLE
[QMS-362] Fit files containing more than one developer data ID cannot be opened. e.g. from a Garmin FR 935 and a connected Stryd footpod

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V1.XX.X
 [QMS-353] "Select Items on Map" does not update when items are removed
 [QMS-354] Refactor the code to get rid of clazy warnings
 [QMS-360] Fix compile flags for Windows 64bit
+[QMS-362] Fit files containing more than one developer data ID cannot be opened. e.g. from a Garmin FR 935 and a connected Stryd footpod
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/gis/fit/decoder/CFitDevFieldDefinitionState.cpp
+++ b/src/qmapshack/gis/fit/decoder/CFitDevFieldDefinitionState.cpp
@@ -51,10 +51,10 @@ decode_state_e CFitDevFieldDefinitionState::process(quint8 &dataByte)
         devDataIndex = dataByte;
         // get the previously (in RecordHeaderState) added definition message
         CFitDefinitionMessage* def = latestDefinition();
-        CFitFieldProfile* profile = devFieldProfile(fieldNr);
+        CFitFieldProfile* profile = devFieldProfile(qMakePair(devDataIndex,fieldNr));
 
         // add the new field definition
-        def->addDevField(CFitFieldDefinition(def, profile, fieldNr, size, profile->getBaseType().baseTypeField()));
+        def->addDevField(CFitFieldDefinition(def, profile, fieldNr, devDataIndex, size, profile->getBaseType().baseTypeField()));
         reset();
         if (def->getDevFields().size() >= def->getNrOfDevFields())
         {

--- a/src/qmapshack/gis/fit/decoder/CFitFieldDataState.cpp
+++ b/src/qmapshack/gis/fit/decoder/CFitFieldDataState.cpp
@@ -109,7 +109,7 @@ bool CFitFieldDataState::handleDevField()
         {
             // handling developer data for mapping the field data to its definitions:
             // part 2, reading field data and attach dynamic profile
-            CFitFieldProfile* fieldProfile = devFieldProfile(fieldDef.getDefNr());
+            CFitFieldProfile* fieldProfile = devFieldProfile(fieldDef.getDevProfileId());
             if (fieldProfile->getBaseType().nr() == eBaseTypeNrInvalid)
             {
                 // test if profile exists
@@ -133,7 +133,21 @@ void CFitFieldDataState::devProfile(CFitMessage& mesg)
     // part 1, dynamic profiles creation
     if (mesg.getGlobalMesgNr() == eMesgNumDeveloperDataId)
     {
-        clearDevFieldProfiles();
+        // Get developer ID
+        quint8 devDataIdx = fitDevDataIndexInvalid;
+        const QList<CFitField>& fields = mesg.getFields();
+        for (const CFitField &field : fields)
+        {
+            if (field.isValidValue() && field.getFieldDefNr() == eDeveloperDataIdDeveloperDataIndex) {
+                devDataIdx = (quint8) field.getValue().toUInt();
+                break;
+            }
+        }
+        // Delete all developer field profiles for this ID
+        if ( devDataIdx != fitDevDataIndexInvalid )
+        {
+            clearDevFieldProfiles(devDataIdx);
+        }
     }
     if (mesg.getGlobalMesgNr() == eMesgNumFieldDescription)
     {
@@ -231,7 +245,6 @@ CFitFieldProfile CFitFieldDataState::buildDevFieldProfile(CFitMessage& mesg)
         }
     }
 
-    Q_UNUSED(devDataIdx)
     Q_UNUSED(array)
     Q_UNUSED(baseUnitId)
 
@@ -251,7 +264,7 @@ CFitFieldProfile CFitFieldDataState::buildDevFieldProfile(CFitMessage& mesg)
         offset = 0;
     }
 
-    CFitFieldProfile devFieldProfile = CFitFieldProfile(nullptr, fieldName, *CFitBaseTypeMap::get(baseType), fieldDefNr,
+    CFitFieldProfile devFieldProfile = CFitFieldProfile(nullptr, fieldName, *CFitBaseTypeMap::get(baseType), fieldDefNr, devDataIdx,
                                                         scale, offset, units, eFieldTypeDevelopment);
     // for documentation: the development field profile may contain more fields in the future as can be adumbrated by
     // the description field enumeration. According to the FIT specification Rev 2.3  table 4-9 - Field Description Messages

--- a/src/qmapshack/gis/fit/decoder/CFitFieldDefinition.cpp
+++ b/src/qmapshack/gis/fit/decoder/CFitFieldDefinition.cpp
@@ -26,14 +26,15 @@
 static const quint8 fitEndianFlagMask = 0x80;
 
 
-CFitFieldDefinition::CFitFieldDefinition(CFitDefinitionMessage* parent, CFitFieldProfile* fieldProfile, quint8 defNr, quint8 size, quint8 type)
-    : defNr(defNr), size(size), type(type), baseType(CFitBaseTypeMap::get(type)), parentDefintion(parent), fieldProfile(fieldProfile)
+CFitFieldDefinition::CFitFieldDefinition(CFitDefinitionMessage* parent, CFitFieldProfile* fieldProfile, quint8 defNr, quint8 devDataIdx,
+                                         quint8 size, quint8 type)
+    : defNr(defNr), devDataIdx(devDataIdx), size(size), type(type), baseType(CFitBaseTypeMap::get(type)),
+      parentDefintion(parent), fieldProfile(fieldProfile)
 {
 }
 
 CFitFieldDefinition::CFitFieldDefinition(CFitDefinitionMessage* parent, quint8 defNr, quint8 size, quint8 type)
-    : CFitFieldDefinition(parent, nullptr, defNr, size, type)
-
+    : CFitFieldDefinition(parent, nullptr, defNr, fitDevDataIndexInvalid, size, type)
 {
     fieldProfile = CFitProfileLookup::getFieldForProfile(parentDefintion ? parentDefintion->getGlobalMesgNr() : fitGlobalMesgNrInvalid, defNr);
 }
@@ -45,10 +46,11 @@ CFitFieldDefinition::CFitFieldDefinition()
 
 QString CFitFieldDefinition::fieldInfo() const
 {
-    QString fstr = QString("%1 %2 %3 (%4): %5, type %6, size %7, endian %8")
+    QString fstr = QString("%1 %2 %3 (%4): %5 %6, type %7, size %8, endian %9")
                    .arg(profile().hasSubfields() ? "dynamic" : profile().hasComponents() ? "component" : "field",
                         profile().getName(),
                         profile().getFieldType() == eFieldTypeDevelopment ? " DEV" : "")
+                   .arg(getDevDataIdx())
                    .arg(getDefNr())
                    .arg(getBaseType().name())
                    .arg(getType(),
@@ -60,6 +62,16 @@ QString CFitFieldDefinition::fieldInfo() const
 quint8 CFitFieldDefinition::getDefNr() const
 {
     return defNr;
+}
+
+quint8 CFitFieldDefinition::getDevDataIdx() const
+{
+    return devDataIdx;
+}
+
+QPair<quint8,quint8> CFitFieldDefinition::getDevProfileId() const
+{
+    return qMakePair<quint8,quint8>(devDataIdx,defNr);
 }
 
 quint8 CFitFieldDefinition::getSize() const

--- a/src/qmapshack/gis/fit/decoder/CFitFieldDefinition.h
+++ b/src/qmapshack/gis/fit/decoder/CFitFieldDefinition.h
@@ -29,13 +29,16 @@ class CFitFieldProfile;
 class CFitFieldDefinition final
 {
 public:
-    CFitFieldDefinition(CFitDefinitionMessage* parent, CFitFieldProfile* fieldProfile, quint8 defNr, quint8 size, quint8 type);
+    CFitFieldDefinition(CFitDefinitionMessage* parent, CFitFieldProfile* fieldProfile, quint8 defNr, quint8 devDataIdx, quint8 size, quint8 type);
     CFitFieldDefinition(CFitDefinitionMessage* parent, quint8 defNr, quint8 size, quint8 type);
     CFitFieldDefinition();
 
     QString fieldInfo() const;
 
     quint8 getDefNr() const;
+    quint8 getDevDataIdx() const;
+    /// First element in the pair is the devDataIdx, second is the DefNr
+    QPair<quint8,quint8> getDevProfileId() const;
     quint8 getSize() const;
     quint8 getType() const;
     const CFitBaseType& getBaseType() const;
@@ -48,6 +51,7 @@ public:
 
 private:
     quint8 defNr;
+    quint8 devDataIdx;
     quint8 size;
     quint8 type;
     CFitBaseType* baseType;

--- a/src/qmapshack/gis/fit/decoder/IFitDecoderState.cpp
+++ b/src/qmapshack/gis/fit/decoder/IFitDecoderState.cpp
@@ -117,23 +117,22 @@ void IFitDecoderState::incFileBytesRead()
 
 void IFitDecoderState::addDevFieldProfile(const CFitFieldProfile &fieldProfile)
 {
-    // for documentation: a development field definition is linked to an developer data ID. Only the tuple developer data index
-    // and field definition number must be unique. So far no fit file with more than one developer data ID has been created.
-    if(devFieldProfile(fieldProfile.getFieldDefNum())->getFieldDefNum() ==  fieldProfile.getFieldDefNum())
-    {
+    // for documentation: a development field definition is linked to an developer data ID. The tuple developer data index
+    // and field definition number must be unique.
+    if(devFieldProfile(fieldProfile.getDevProfileId())->getDevProfileId() ==  fieldProfile.getDevProfileId())    {
         throw tr("FIT decoding error: a development field with the field_definition_number %1 already exists.")
               .arg(fieldProfile.getFieldDefNum());
     }
     data.devFieldProfiles.append(fieldProfile);
 }
 
-CFitFieldProfile* IFitDecoderState::devFieldProfile(quint32 fieldNr)
+CFitFieldProfile* IFitDecoderState::devFieldProfile(const QPair<quint8,quint8> &devProfileId)
 {
-    for (int i = 0; i < data.devFieldProfiles.size(); i++)
+    for(CFitFieldProfile &devFieldPro : data.devFieldProfiles)
     {
-        if (fieldNr == data.devFieldProfiles[i].getFieldDefNum())
+        if (devProfileId == devFieldPro.getDevProfileId())
         {
-            return &data.devFieldProfiles[i];
+            return &devFieldPro;
         }
     }
     // dummy field for unknown field nr.
@@ -143,7 +142,17 @@ CFitFieldProfile* IFitDecoderState::devFieldProfile(quint32 fieldNr)
     //return data.devFieldProfiles[fieldNr];
 }
 
-void IFitDecoderState::clearDevFieldProfiles()
+void IFitDecoderState::clearDevFieldProfiles(quint8 devDataIdx)
 {
-    data.devFieldProfiles.clear();
+    for (QList<CFitFieldProfile>::iterator it = data.devFieldProfiles.begin(); it != data.devFieldProfiles.end();)
+    {
+        if (it->getDevDataIdx() == devDataIdx)
+        {
+            it = data.devFieldProfiles.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
 }

--- a/src/qmapshack/gis/fit/decoder/IFitDecoderState.h
+++ b/src/qmapshack/gis/fit/decoder/IFitDecoderState.h
@@ -84,8 +84,9 @@ protected:
     quint32 getTimestamp() const { return data.timestamp; }
     quint16 getCrc() const { return data.crc; }
     void addDevFieldProfile(const CFitFieldProfile &fieldProfile);
-    CFitFieldProfile* devFieldProfile(quint32 fieldNr);
-    void clearDevFieldProfiles();
+    CFitFieldProfile* devFieldProfile(const QPair<quint8,quint8> &devProfileId);
+    /// Delete local developer profiles with the developer data index devDataIdx
+    void clearDevFieldProfiles(quint8 devDataIdx);
 
 
 private:

--- a/src/qmapshack/gis/fit/defs/CFitFieldProfile.cpp
+++ b/src/qmapshack/gis/fit/defs/CFitFieldProfile.cpp
@@ -21,9 +21,16 @@
 #include "gis/fit/defs/CFitProfile.h"
 #include "gis/fit/defs/fit_const.h"
 
-CFitFieldProfile::CFitFieldProfile(CFitProfile* parent, QString name, const CFitBaseType& baseType, quint8 fieldDefNr, qreal scale, qint16 offset, QString units, field_type_e fieldType )
-    : name(name), fieldDefNr(fieldDefNr), scale(scale), offset(offset), units(units), fieldType(fieldType),
-    baseType(&baseType), profile(parent), subfields(), components()
+CFitFieldProfile::CFitFieldProfile(CFitProfile* parent, QString name, const CFitBaseType& baseType, quint8 fieldDefNr, quint8 devDataIdx,
+                                   qreal scale, qint16 offset, QString units, field_type_e fieldType )
+    : name(name), fieldDefNr(fieldDefNr), devDataIdx(devDataIdx), scale(scale), offset(offset), units(units), fieldType(fieldType),
+      baseType(&baseType), profile(parent), subfields(), components()
+{
+}
+
+CFitFieldProfile::CFitFieldProfile(CFitProfile* parent, QString name, const CFitBaseType& baseType, quint8 fieldDefNr,
+                                   qreal scale, qint16 offset, QString units, field_type_e fieldType )
+    :  CFitFieldProfile(parent, name, baseType, fieldDefNr, fitDevDataIndexInvalid, scale, offset, units, fieldType)
 {
 }
 
@@ -32,8 +39,9 @@ CFitFieldProfile::CFitFieldProfile() : CFitFieldProfile(nullptr, "unknown", fit:
 }
 
 CFitFieldProfile::CFitFieldProfile(const CFitFieldProfile& copy)
-    : name(copy.name), fieldDefNr(copy.fieldDefNr), scale(copy.scale), offset(copy.offset), units(copy.units), fieldType(copy.fieldType),
-    baseType(copy.baseType), profile(copy.profile), subfields(copy.subfields), components(copy.components)
+    : name(copy.name), fieldDefNr(copy.fieldDefNr), devDataIdx(copy.devDataIdx),scale(copy.scale), offset(copy.offset),
+      units(copy.units), fieldType(copy.fieldType), baseType(copy.baseType), profile(copy.profile), subfields(copy.subfields),
+      components(copy.components)
 {
 }
 
@@ -76,6 +84,16 @@ QString CFitFieldProfile::getName() const
 quint8 CFitFieldProfile::getFieldDefNum() const
 {
     return fieldDefNr;
+}
+
+quint8 CFitFieldProfile::getDevDataIdx() const
+{
+    return devDataIdx;
+}
+
+QPair<quint8,quint8> CFitFieldProfile::getDevProfileId() const
+{
+    return qMakePair(devDataIdx,fieldDefNr);
 }
 
 qreal CFitFieldProfile::getScale() const
@@ -124,9 +142,10 @@ QList<CFitComponentfieldProfile*> CFitFieldProfile::getComponents() const
 
 QString CFitFieldProfile::fieldProfileInfo()
 {
-    QString str = QString("%1 %2 (%3): %4 %5")
+    QString str = QString("%1 %2 (%3 %4): %5 %6")
                   .arg(QString("field profile"),
                        getName())
+                  .arg(getDevDataIdx())
                   .arg(getFieldDefNum())
                   .arg(getUnits(),
                        getBaseType().name());

--- a/src/qmapshack/gis/fit/defs/CFitFieldProfile.h
+++ b/src/qmapshack/gis/fit/defs/CFitFieldProfile.h
@@ -37,7 +37,10 @@ class CFitFieldProfile
 public:
     CFitFieldProfile();
     CFitFieldProfile(const CFitFieldProfile& copy);
-    CFitFieldProfile(CFitProfile* parent, QString name, const CFitBaseType& baseType, quint8 fieldDefNr, qreal scale, qint16 offset, QString units, field_type_e fieldType = eFieldTypeFit);
+    CFitFieldProfile(CFitProfile* parent, QString name, const CFitBaseType& baseType, quint8 fieldDefNr,
+                     qreal scale, qint16 offset, QString units, field_type_e fieldType = eFieldTypeFit);
+    CFitFieldProfile(CFitProfile* parent, QString name, const CFitBaseType& baseType, quint8 fieldDefNr, quint8 devDataIdx,
+                     qreal scale, qint16 offset, QString units, field_type_e fieldType = eFieldTypeFit);
     virtual ~CFitFieldProfile();
 
     void addSubfield(CFitSubfieldProfile* subfield);
@@ -49,6 +52,9 @@ public:
 
     virtual QString getName() const;
     virtual quint8 getFieldDefNum() const;
+    virtual quint8 getDevDataIdx() const;
+    /// First element in the pair is the devDataIdx, second is the fieldDefNr
+    virtual QPair<quint8,quint8> getDevProfileId() const;
     virtual qreal getScale() const;
     virtual qint16 getOffset() const;
     virtual bool hasScaleAndOffset() const;
@@ -65,6 +71,7 @@ public:
 private:
     QString name;
     quint8 fieldDefNr;
+    quint8 devDataIdx;
     qreal scale;
     qint16 offset;
     QString units;

--- a/src/qmapshack/gis/fit/defs/fit_const.h
+++ b/src/qmapshack/gis/fit/defs/fit_const.h
@@ -33,6 +33,7 @@
 static const quint8 fitLocalMesgNrInvalid = 255;
 static const quint16 fitGlobalMesgNrInvalid = 0xffff;
 static const quint8 fitFieldDefNrInvalid = 255;
+static const quint8 fitDevDataIndexInvalid = 255;
 
 typedef enum
 {


### PR DESCRIPTION
_**Note: Do not delete any of the sections Answer them all. Replace the descriptive text by your answer**_

**What is the linked issue for this pull request (start with a `#`):**

QMS-#362

**Describe roughly what you have done:**
More than one active developer data id is supported now.

-  Adding a developer data index field to the
CFitFieldProfile

-  Adding a developer data index field to the
CFitFieldDefinition

-  If a local developer field profile is created
the developer data index is used, not only the
field number

- If a eMesgNumDeveloperDataId (developer_data_id)
mesg arrives only the local developer field
profiles for this ID are deleted

-  A field definition is now always searched by
his field number and its developer data index, see
CFitFieldDataState::handleDevField()

-  A file f2.fit was added to the ticket. This
contains a test for redefining an existing
eMesgNumDeveloperDataId and its fields.


**What steps have to be done to perform a simple smoke test:**

1. Used the fit files f1.fit and f2.fit from the ticket to test the changes.
2. Load old large fit files manually and checked if it worked as expected.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] yes

**Is every user facing string in a tr() macro?**

- [X] yes I did not touch such code segments

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [X] yes, I didn't forget to change changelog.txt
