### PR TITLE
[QMS-343] .fit files from Suunto app have many trackpoints with elevation = 0 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-299] CEnergyCycling is storing it's configuration in the `General` section instead of it's own.
 [QMS-311] Automatically save projects to device
 [QMS-337] Upgrade to Proj 8 API
+[QMS-343] .fit files from Suunto app have many trackpoints with elevation = 0
 [QMS-344] Better integration of new PROJ lib into cmake build system
 [QMS-349] Upgrade to Quazip Qt5 V1.x
 [QMS-353] "Select Items on Map" does not update when items are removed

--- a/src/qmapshack/gis/fit/serialization.cpp
+++ b/src/qmapshack/gis/fit/serialization.cpp
@@ -83,8 +83,10 @@ static bool readFitRecord(const CFitMessage &mesg, IGisItem::wpt_t &pt)
     {
         pt.lon = toDegree(mesg.getFieldValue(eRecordPositionLong).toInt());
         pt.lat = toDegree(mesg.getFieldValue(eRecordPositionLat).toInt());
-        // QVariant.toInt() does not convert double to int but return 0.
-        pt.ele = (int) mesg.getFieldValue(eRecordEnhancedAltitude).toDouble();
+        if(mesg.isFieldValueValid(eRecordEnhancedAltitude))
+        {
+            pt.ele = mesg.getFieldValue(eRecordEnhancedAltitude).toInt();
+        }
         pt.time = toDateTime(mesg.getFieldValue(eRecordTimestamp).toUInt());
 
         readKnownExtensions(pt.extensions, mesg);
@@ -172,7 +174,10 @@ static bool readFitSegmentPoint(const CFitMessage &mesg, CTrackData::trkpt_t &pt
     {
         pt.lon = toDegree(mesg.getFieldValue(eSegmentPointPositionLong).toInt());
         pt.lat = toDegree(mesg.getFieldValue(eSegmentPointPositionLat).toInt());
-        pt.ele = (int) mesg.getFieldValue(eSegmentPointAltitude).toDouble();
+        if(mesg.isFieldValueValid(eSegmentPointAltitude))
+        {
+            pt.ele = mesg.getFieldValue(eSegmentPointAltitude).toInt();
+        }
         // sum with file_id time_created
         pt.time = toDateTime(timeCreated + mesg.getFieldValue(eSegmentPointLeaderTime).toUInt());
         return true;


### PR DESCRIPTION
_**Note: Do not delete any of the sections Answer them all. Replace the descriptive text by your answer**_

**What is the linked issue for this pull request (start with a `#`):**

QMS-#343

**Describe roughly what you have done:**

I check if the fit message contains the altitude. If this is the case I will set it. If it is not set, it is invalid due to the constructor for the point.

**What steps have to be done to perform a simple smoke test:**

1. Loading the fit file from the ticket
2. Select hiding invalid point
3. Check the displayed accumulated elevation change.

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [X] yes

**Is every user facing string in a tr() macro?**

- [X] yes
I did not touch code like this

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [X] yes, I didn't forget to change changelog.txt
