### PR TITLE
[QMS-363] GIS items missing in projects loaded from file or database

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ V1.XX.X
 [QMS-354] Refactor the code to get rid of clazy warnings
 [QMS-360] Fix compile flags for Windows 64bit
 [QMS-362] Fit files containing more than one developer data ID cannot be opened. e.g. from a Garmin FR 935 and a connected Stryd footpod
+[QMS-363] GIS items missing in projects loaded from file or database
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/gis/search/CSearch.h
+++ b/src/qmapshack/gis/search/CSearch.h
@@ -135,8 +135,8 @@ public:
 
     struct search_t
     {
-        searchProperty_e property;
-        search_type_e searchType;
+        searchProperty_e property = eSearchPropertyNoMatch;
+        search_type_e searchType = eSearchTypeNone;
         searchValue_t searchValue;
     };
 


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):**

QMS-#363

**Describe roughly what you have done:**

This is dues to missing default initializers for CSearch::serach_t.
Applied default values.

**What steps have to be done to perform a simple smoke test:**

Repeat the test from the ticket. -> Projects should load with items

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
