### PR TITLE
[QMS-371] Crash while loading geocache from TwoNav device

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ V1.XX.X
 [QMS-360] Fix compile flags for Windows 64bit
 [QMS-362] Fit files containing more than one developer data ID cannot be opened. e.g. from a Garmin FR 935 and a connected Stryd footpod
 [QMS-363] GIS items missing in projects loaded from file or database
+[QMS-371] Crash while loading geocache from TwoNav device
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -623,21 +623,28 @@ void CGisItemWpt::save(QDomNode& gpx, bool strictGpx11)
 void CGisItemWpt::readGcExt(const QDomNode& xmlCache)
 {
     //Geocaches only have one link
-    if(wpt.links.first().uri.url(QUrl::RemovePath).contains("geocaching.com"))
+    if(wpt.links.isEmpty())
     {
-        geocache.service = eGcCom;
-    }
-    else if(wpt.links.first().uri.url(QUrl::RemovePath).contains("opencaching"))
-    {
-        geocache.service = eOc;
-    }
-    else if(wpt.links.first().uri.url(QUrl::RemovePath).contains("geocaching.su"))
-    {
-        geocache.service = eGcSu;
+        geocache.service = eUnknown;
     }
     else
     {
-        geocache.service = eUnknown;
+        if(wpt.links.first().uri.url(QUrl::RemovePath).contains("geocaching.com"))
+        {
+            geocache.service = eGcCom;
+        }
+        else if(wpt.links.first().uri.url(QUrl::RemovePath).contains("opencaching"))
+        {
+            geocache.service = eOc;
+        }
+        else if(wpt.links.first().uri.url(QUrl::RemovePath).contains("geocaching.su"))
+        {
+            geocache.service = eGcSu;
+        }
+        else
+        {
+            geocache.service = eUnknown;
+        }
     }
 
     const QDomNamedNodeMap& attr = xmlCache.attributes();


### PR DESCRIPTION
**What is the linked issue for this pull request (start with a `#`):**

QMS-#371

**Describe roughly what you have done:**

Test for empty list in `void CGisItemWpt::readGcExt(const QDomNode& xmlCache)`

**What steps have to be done to perform a simple smoke test:**

Use same files causing the crash. -> no crash

**Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):**

- [x] yes

**Is every user facing string in a tr() macro?**

- [x] yes

**Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.**

- [x] yes, I didn't forget to change changelog.txt
