### PR TITLE
[QMS-375] On-screen profile window has no close button

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,11 @@ V1.XX.X
 [QMS-362] Fit files containing more than one developer data ID cannot be opened. e.g. from a Garmin FR 935 and a connected Stryd footpod
 [QMS-363] GIS items missing in projects loaded from file or database
 [QMS-371] Crash while loading geocache from TwoNav device
+<<<<<<< HEAD
 [QMS-373] Refine templates to hide comments
+=======
+[QMS-375] On-screen profile window has no close button
+>>>>>>> ca51552c... [QMS-375] On-screen profile window has no close button
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/plot/IPlot.cpp
+++ b/src/qmapshack/plot/IPlot.cpp
@@ -88,7 +88,7 @@ IPlot::IPlot(CGisItemTrk *trk, CPlotData::axistype_e type, mode_e mode, QWidget 
 
     if(mode == eModeWindow)
     {
-        overrideWindowFlags(Qt::Tool);
+        setWindowFlags(Qt::Tool);
         setAttribute(Qt::WA_DeleteOnClose, true);
         QPalette pal = palette();
         pal.setColor(QPalette::Background, Qt::white);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#375

### What you have done:
[comment]: # (Describe roughly.)

overrideWindowFlags() is a bad idea. Use setWindowFlags()

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Perform the steps from the ticket.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
