### PR TITLE
[QMS-380] Toggle fullscreen does not work

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ V1.XX.X
 [QMS-371] Crash while loading geocache from TwoNav device
 [QMS-373] Refine templates to hide comments
 [QMS-375] On-screen profile window has no close button
+[QMS-380] Toggle fullscreen does not work
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -158,15 +158,6 @@ CMainWindow::CMainWindow()
         restoreState(cfg.value("state").toByteArray());
     }
 
-    if (cfg.contains("displaymode"))
-    {
-        displayMode = static_cast<Qt::WindowStates>(cfg.value("displaymode").toInt());
-        if (displayMode == Qt::WindowFullScreen)
-        {
-            displayMode = Qt::WindowMaximized;
-        }
-    }
-
     if (cfg.contains("dockstate"))
     {
         dockStates = cfg.value("dockstate").toByteArray();
@@ -174,12 +165,12 @@ CMainWindow::CMainWindow()
 
     menuVisible = cfg.value("menuvisible", false).toBool();
 
-    if(windowState() == Qt::WindowFullScreen)
+    if(windowState() & Qt::WindowFullScreen)
     {
+        setWindowState(windowState() | Qt::WindowMaximized);
         displayRegular();
     }
     cfg.endGroup();
-
     // end ---- restore window geometry -----
 
     connect(actionAbout,                 &QAction::triggered,            this,      &CMainWindow::slotAbout);
@@ -520,7 +511,6 @@ CMainWindow::~CMainWindow()
     }
     cfg.setValue("activedocks", activeDockNames);
 
-    cfg.setValue("displaymode", static_cast<int>(displayMode));
     cfg.setValue("dockstate", dockStates);
     cfg.setValue("menuvisible", menuVisible);
     cfg.endGroup();
@@ -1682,14 +1672,12 @@ void CMainWindow::slotFullScreen()
 {
     QMutexLocker lock(&CMainWindow::mutex);
 
-    Qt::WindowStates state = windowState();
-    if(state == Qt::WindowFullScreen)
+    if(windowState() & Qt::WindowFullScreen)
     {
         displayRegular();
     }
     else
     {
-        displayMode = state;
         displayFullscreen();
     }
 }
@@ -1732,13 +1720,13 @@ void CMainWindow::displayRegular()
         menuBar()->setVisible(true);
     }
     actionFullScreen->setIcon(QIcon(":/icons/32x32/FullScreen.png"));
-    setWindowState(displayMode);
+    setWindowState(windowState() ^ Qt::WindowFullScreen);
 }
 
 void CMainWindow::displayFullscreen()
 {
     dockStates = saveState();
-    setWindowState(Qt::WindowFullScreen);
+    setWindowState(windowState() | Qt::WindowFullScreen);
     statusBar()->setVisible(false);
     menuVisible = menuBar()->isVisible();
     // menu is handled dynamically as on some platforms (e.g. ubuntu with unity)

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -247,7 +247,6 @@ private:
 
     QList<QDockWidget *> docks;
     QList<QDockWidget *> activeDocks;
-    Qt::WindowStates displayMode = Qt::WindowMaximized;
     QByteArray dockStates;
     bool menuVisible = false;
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#380

### What you have done:
[comment]: # (Describe roughly.)

Switch window state by adding / removing
fullscreen flag from existing set of flags.

Removed old and over complicated code.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Repeat steps from the ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
