### PR TITLE
[QMS-382] QMapTool: Allow customized GDAL parameters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ V1.XX.X
 [QMS-375] On-screen profile window has no close button
 [QMS-378] Add option to link map views
 [QMS-380] Toggle fullscreen does not work
+[QMS-382] QMapTool: Allow customized GDAL parameters
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmaptool/CMakeLists.txt
+++ b/src/qmaptool/CMakeLists.txt
@@ -61,7 +61,8 @@ set( SRCS
     tool/CToolAddOverview.cpp
     tool/CToolBox.cpp
     tool/CToolCutMap.cpp
-    tool/CToolExport.cpp    
+    tool/CToolExport.cpp
+    tool/CToolGDALGroupBox.cpp
     tool/CToolGrid.cpp
     tool/CToolOverviewGroupBox.cpp
     tool/CToolPalettize.cpp
@@ -130,7 +131,8 @@ set( HDRS
     tool/CToolAddOverview.h
     tool/CToolBox.h
     tool/CToolCutMap.h
-    tool/CToolExport.h    
+    tool/CToolExport.h
+    tool/CToolGDALGroupBox.h
     tool/CToolGrid.h
     tool/CToolOverviewGroupBox.h
     tool/CToolPalettize.h
@@ -171,7 +173,8 @@ set( UIS
     tool/export/IToolExportJnx.ui
     tool/IToolAddOverview.ui
     tool/IToolCutMap.ui
-    tool/IToolExport.ui    
+    tool/IToolExport.ui
+    tool/IToolGDALGroupBox.ui
     tool/IToolGrid.ui
     tool/IToolOverviewGroupBox.ui
     tool/IToolPalettize.ui

--- a/src/qmaptool/tool/CToolCutMap.cpp
+++ b/src/qmaptool/tool/CToolCutMap.cpp
@@ -23,7 +23,7 @@
 #include "setup/IAppSetup.h"
 #include "tool/CToolCutMap.h"
 
-CToolCutMap::CToolCutMap(QWidget *parent)
+CToolCutMap::CToolCutMap(QWidget* parent)
     : IToolGui(parent)
 {
     setupUi(this);
@@ -53,6 +53,7 @@ CToolCutMap::CToolCutMap(QWidget *parent)
     cfg.beginGroup("ToolCutMap");
     itemList->loadSettings(cfg);
     groupOverviews->loadSettings(cfg);
+    groupGDALParameters->loadSettings(cfg);
     checkAllFiles->setChecked(cfg.value("allFiles", false).toBool());
     lineSuffix->setText(cfg.value("suffix", "_cut").toString());
     cfg.endGroup();
@@ -67,6 +68,7 @@ CToolCutMap::~CToolCutMap()
     cfg.remove("");
     itemList->saveSettings(cfg);
     groupOverviews->saveSettings(cfg);
+    groupGDALParameters->saveSettings(cfg);
     cfg.setValue("allFiles", checkAllFiles->isChecked());
     cfg.setValue("suffix", lineSuffix->text());
     cfg.endGroup();
@@ -83,9 +85,9 @@ void CToolCutMap::setupChanged()
     frame->setVisible(hasGdalwarp && hasGdaladdo);
 }
 
-void CToolCutMap::slotAddItem(const QString& filename, QListWidget * list)
+void CToolCutMap::slotAddItem(const QString& filename, QListWidget* list)
 {
-    CItemCutMap * item = new CItemCutMap(filename, stackedWidget, list);
+    CItemCutMap* item = new CItemCutMap(filename, stackedWidget, list);
     connect(item, &CItemFile::sigChanged, itemList, &CItemListWidget::sigChanged);
 }
 
@@ -97,7 +99,7 @@ void CToolCutMap::slotMapSelectionChanged()
 
 void CToolCutMap::slotSomethingChanged()
 {
-    IItem * item = itemList->currentItem();
+    IItem* item = itemList->currentItem();
     if(item != nullptr)
     {
         bool ok = item->isOk();
@@ -114,16 +116,16 @@ void CToolCutMap::slotSomethingChanged()
 }
 
 
-void CToolCutMap::buildCmd(QList<CShellCmd>& cmds, const IItem *iitem)
+void CToolCutMap::buildCmd(QList<CShellCmd>& cmds, const IItem* iitem)
 {
-    const CItemCutMap * item = dynamic_cast<const CItemCutMap*>(iitem);
+    const CItemCutMap* item = dynamic_cast<const CItemCutMap*>(iitem);
     if(nullptr == item)
     {
         return;
     }
 
     // ---- command 1 ----------------------
-    const IDrawContext * context = item->getDrawContext();
+    const IDrawContext* context = item->getDrawContext();
     QStringList args;
     // --- overwrite last output file ---
     args << "-overwrite";
@@ -160,6 +162,8 @@ void CToolCutMap::buildCmd(QList<CShellCmd>& cmds, const IItem *iitem)
         // --- add alpha channel to files with just RGB ---
         args << "-dstalpha";
     }
+
+    args.append(groupGDALParameters->getArgs());
 
     QString wktFilename = createTempFile("csv");
     item->saveShape(wktFilename);

--- a/src/qmaptool/tool/CToolGDALGroupBox.cpp
+++ b/src/qmaptool/tool/CToolGDALGroupBox.cpp
@@ -1,0 +1,150 @@
+/**********************************************************************************************
+    Copyright (C) 2021 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#include "tool/CToolGDALGroupBox.h"
+
+#include <QtWidgets>
+
+CToolGDALGroupBox::CToolGDALGroupBox(QWidget* parent)
+    : QGroupBox(parent)
+{
+    setupUi(this);
+
+    comboResampling->insertItems(0, {
+        "near"
+        , "bilinear"
+        , "cubic"
+        , "cubicspline"
+        , "lanczos"
+        , "average"
+        , "rms"
+        , "mode"
+        , "max"
+        , "min"
+        , "med"
+        , "q1"
+        , "q3"
+        , "sum"
+    });
+
+    comboCompression->insertItems(0, {
+        "NONE"
+        , "LZMA"
+        , "JPEG"
+        , "LZW"
+        , "PACKBITS"
+        , "DEFLATE"
+        , "CCITTRLE"
+        , "CCITTFAX3"
+        , "CCITTFAX4"
+        , "ZSTD"
+        , "LERC"
+        , "LERC_DEFLATE"
+        , "LERC_ZSTD"
+        , "WEBP"
+    });
+
+    connect(checkResampling, &QCheckBox::toggled, comboResampling, &QComboBox::setEnabled);
+    connect(checkCompression, &QCheckBox::toggled, comboCompression, &QComboBox::setEnabled);
+    connect(checkTiled, &QCheckBox::toggled, spinTileX, &QSpinBox::setEnabled);
+    connect(checkTiled, &QCheckBox::toggled, spinTileY, &QSpinBox::setEnabled);
+
+    comboResampling->setEnabled(checkResampling->isChecked());
+    comboCompression->setEnabled(checkCompression->isChecked());
+    spinTileX->setEnabled(checkTiled->isChecked());
+    spinTileY->setEnabled(checkTiled->isChecked());
+}
+
+void CToolGDALGroupBox::saveSettings(QSettings& cfg)
+{
+    cfg.setValue("GDALParameters", isChecked());
+    cfg.setValue("resample", checkResampling->isChecked());
+    cfg.setValue("resample_idx", comboResampling->currentIndex());
+    cfg.setValue("compression", checkCompression->isChecked());
+    cfg.setValue("compression_idx", comboCompression->currentIndex());
+    cfg.setValue("tiled", checkTiled->isChecked());
+    cfg.setValue("tileX", spinTileX->value());
+    cfg.setValue("tileY", spinTileY->value());
+    cfg.setValue("commandline", lineCommands->text());
+}
+
+void CToolGDALGroupBox::loadSettings(QSettings& cfg)
+{
+    setChecked(cfg.value("GDALParameters", false).toBool());
+    checkResampling->setChecked(cfg.value("resample", false).toBool());
+    comboResampling->setCurrentIndex(cfg.value("resample_idx", 0).toInt());
+    checkCompression->setChecked(cfg.value("compression", false).toBool());
+    comboCompression->setCurrentIndex(cfg.value("compression_idx", 0).toInt());
+    checkTiled->setChecked(cfg.value("tiled", false).toBool());
+    spinTileX->setValue(cfg.value("tileX", 256).toInt());
+    spinTileY->setValue(cfg.value("tileY", 256).toInt());
+    lineCommands->setText(cfg.value("commandline", "").toString());
+}
+
+void CToolGDALGroupBox::enableParts(quint32 flags)
+{
+    frameResampling->setEnabled(flags & ePartResampling);
+    frameCompression->setEnabled(flags & ePartCompress);
+    frameTiled->setEnabled(flags & ePartTiled);
+    frameOther->setEnabled(flags & ePartLine);
+}
+
+QStringList CToolGDALGroupBox::getArgsResampling(const QStringList& defaultArgs)
+{
+    if(frameResampling->isEnabled() && checkResampling->isChecked())
+    {
+        return {"-r", comboResampling->currentText()};
+    }
+
+    return defaultArgs;
+}
+
+QStringList CToolGDALGroupBox::getArgsCompression(const QStringList& defaultArgs)
+{
+    if(frameCompression->isEnabled() && checkCompression->isChecked())
+    {
+        return {"-co", "COMPRESS=" + comboCompression->currentText()};
+    }
+
+    return defaultArgs;
+}
+
+QStringList CToolGDALGroupBox::getArgsTiled(const QStringList& defaultArgs)
+{
+    if(frameTiled->isEnabled() && checkTiled->isChecked())
+    {
+        return {
+                   "-co", "TILED=YES"
+                   , "-co", "BLOCKXSIZE=" + spinTileX->text()
+                   , "-co", "BLOCKYSIZE=" + spinTileY->text()
+        };
+    }
+
+    return defaultArgs;
+}
+
+
+QStringList CToolGDALGroupBox::getArgs()
+{
+    QStringList args;
+    args.append(getArgsResampling({}));
+    args.append(getArgsCompression({}));
+    args.append(getArgsTiled({}));
+    args.append(lineCommands->text().split(' ', QString::SkipEmptyParts));
+    return args;
+}

--- a/src/qmaptool/tool/CToolGDALGroupBox.h
+++ b/src/qmaptool/tool/CToolGDALGroupBox.h
@@ -1,0 +1,55 @@
+/**********************************************************************************************
+    Copyright (C) 2021 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CTOOLGDALGROUPBOX_H
+#define CTOOLGDALGROUPBOX_H
+
+#include "ui_IToolGDALGroupBox.h"
+
+class QSettings;
+
+class CToolGDALGroupBox : public QGroupBox, private Ui::IToolGDALGroupBox
+{
+    Q_OBJECT
+public:
+    CToolGDALGroupBox(QWidget* parent);
+    virtual ~CToolGDALGroupBox() = default;
+
+    void saveSettings(QSettings& cfg);
+    void loadSettings(QSettings& cfg);
+
+    enum part_e
+    {
+        ePartResampling = 0x01
+        , ePartCompress = 0x02
+        , ePartTiled = 0x04
+        , ePartLine = 0x08
+    };
+
+    void enableParts(quint32 flags);
+
+    QStringList getArgs();
+    QStringList getArgsResampling(const QStringList& defaultArgs);
+    QStringList getArgsCompression(const QStringList& defaultArgs);
+    QStringList getArgsTiled(const QStringList& defaultArgs);
+};
+
+
+
+#endif //CTOOLGDALGROUPBOX_H
+

--- a/src/qmaptool/tool/IToolCutMap.ui
+++ b/src/qmaptool/tool/IToolCutMap.ui
@@ -150,6 +150,13 @@
        </widget>
       </item>
       <item>
+       <widget class="CToolGDALGroupBox" name="groupGDALParameters">
+        <property name="title">
+         <string>GDAL Parameters</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -253,6 +260,12 @@
    <class>CToolOverviewGroupBox</class>
    <extends>QGroupBox</extends>
    <header>tool/CToolOverviewGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>CToolGDALGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>tool/CToolGDALGroupBox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/qmaptool/tool/IToolGDALGroupBox.ui
+++ b/src/qmaptool/tool/IToolGDALGroupBox.ui
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IToolGDALGroupBox</class>
+ <widget class="QGroupBox" name="IToolGDALGroupBox">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>457</width>
+    <height>168</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>GroupBox</string>
+  </property>
+  <property name="title">
+   <string>GDAL Parameters</string>
+  </property>
+  <property name="checkable">
+   <bool>true</bool>
+  </property>
+  <property name="checked">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="frameResampling">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="checkResampling">
+        <property name="text">
+         <string>Resampling</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="comboResampling"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frameCompression">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="checkCompression">
+        <property name="text">
+         <string>Compression</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="comboCompression"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frameTiled">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="checkTiled">
+        <property name="text">
+         <string>Tiled</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="spinTileX">
+        <property name="minimum">
+         <number>256</number>
+        </property>
+        <property name="maximum">
+         <number>4096</number>
+        </property>
+        <property name="singleStep">
+         <number>256</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>x</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="spinTileY">
+        <property name="minimum">
+         <number>256</number>
+        </property>
+        <property name="maximum">
+         <number>4096</number>
+        </property>
+        <property name="singleStep">
+         <number>256</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frameOther">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Other:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineCommands"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qmaptool/tool/IToolPalettize.ui
+++ b/src/qmaptool/tool/IToolPalettize.ui
@@ -144,6 +144,13 @@
        </widget>
       </item>
       <item>
+       <widget class="CToolGDALGroupBox" name="groupGDALParameters">
+        <property name="title">
+         <string>GDAL Parameter</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -170,7 +177,7 @@
            <string>Start</string>
           </property>
           <property name="icon">
-           <iconset resource="../../qmapshack/resources.qrc">
+           <iconset resource="../resources.qrc">
             <normaloff>:/icons/32x32/Apply.png</normaloff>:/icons/32x32/Apply.png</iconset>
           </property>
          </widget>
@@ -184,7 +191,7 @@
            <string>Cancel</string>
           </property>
           <property name="icon">
-           <iconset resource="../../qmapshack/resources.qrc">
+           <iconset resource="../resources.qrc">
             <normaloff>:/icons/32x32/Cancel.png</normaloff>:/icons/32x32/Cancel.png</iconset>
           </property>
          </widget>
@@ -240,7 +247,7 @@
   </layout>
   <action name="actionFilename">
    <property name="icon">
-    <iconset resource="../../qmapshack/resources.qrc">
+    <iconset resource="../resources.qrc">
      <normaloff>:/icons/32x32/PathBlue.png</normaloff>:/icons/32x32/PathBlue.png</iconset>
    </property>
    <property name="text">
@@ -261,9 +268,15 @@
    <header>tool/CToolOverviewGroupBox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>CToolGDALGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>tool/CToolGDALGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../qmapshack/resources.qrc"/>
+  <include location="../resources.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/qmaptool/tool/IToolRefMap.ui
+++ b/src/qmaptool/tool/IToolRefMap.ui
@@ -153,6 +153,13 @@
        </widget>
       </item>
       <item>
+       <widget class="CToolGDALGroupBox" name="groupGDALParameters">
+        <property name="title">
+         <string>GDAL Parameters</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -266,6 +273,12 @@
    <class>CToolOverviewGroupBox</class>
    <extends>QGroupBox</extends>
    <header>tool/CToolOverviewGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>CToolGDALGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>tool/CToolGDALGroupBox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#382

### What you have done:
[comment]: # (Describe roughly.)

* Add CToolGDALGroupBox for the options
* Add options to Cut, Reference and Palettize tool

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

You would need to use the tools and check the outcome.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
