### PR TITLE
[QMS-389] Crash when loading/drawing POIs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,7 +33,9 @@ V1.XX.X
 [QMS-380] Toggle fullscreen does not work
 [QMS-382] QMapTool: Allow customized GDAL parameters
 [QMS-384] Add Garmin Fit power data to support powermeter pedals
+[QMS-389] Crash when loading/drawing POIs
 [QMS-391] Adapt Windows build scripts to PROJ.8/Quazip 1.x
+
 
 V1.15.2
 [QMS-264] Windows: adapt build scripts for 1.15.1 release

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -575,6 +575,7 @@ set( HDRS
     helpers/CSelectCopyAction.h
     helpers/CSelectProjectDialog.h
     helpers/CSettings.h
+    helpers/CTryMutexLocker.h
     helpers/CToolBarConfig.h
     helpers/CToolBarSetupDialog.h
     helpers/CValue.h
@@ -851,7 +852,7 @@ set( UIS
     poi/IPoiPathSetup.ui
     poi/IPoiPropSetup.ui
     print/IPrintDialog.ui
-    print/IScreenshotDialog.ui    
+    print/IScreenshotDialog.ui
     realtime/IRtSelectSource.ui
     realtime/IRtWorkspace.ui
     realtime/gpstether/IRtGpsTetherInfo.ui

--- a/src/qmapshack/helpers/CTryMutexLocker.h
+++ b/src/qmapshack/helpers/CTryMutexLocker.h
@@ -1,0 +1,35 @@
+/**********************************************************************************************
+    Copyright (C) 2021 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CTRYMUTEXLOCKER_H
+#define CTRYMUTEXLOCKER_H
+
+#include <QMutex>
+
+class CTryMutexLocker
+{
+public:
+    CTryMutexLocker(QMutex& mutex) : m_mutex(mutex){}
+    ~CTryMutexLocker() {m_mutex.unlock();}
+    bool try_lock(){return m_mutex.tryLock();}
+private:
+    QMutex& m_mutex;
+};
+
+#endif //CTRYMUTEXLOCKER_H
+

--- a/src/qmapshack/poi/CPoiPOI.h
+++ b/src/qmapshack/poi/CPoiPOI.h
@@ -88,13 +88,15 @@ private:
     bool overlapsWithIcon(const QRectF& rect) const;
     bool getPoiGroupCloseBy(const QPoint& px, poiGroup_t& poiItem) const;
 
-    QMutex mutex;
+    mutable QMutex mutex {QMutex::Recursive};
     QString filename;
     QTimer* loadTimer;
+
+
     QMap<quint64, Qt::CheckState> categoryActivated;
     QMap<quint64, QString> categoryNames;
     // category, minLon multiplied by 10, minLat multiplied by 10. POIs are loaded in squares of degrees (should be fine enough to not hang the system)
-    QMap<quint64, QMap<int, QMap<int, QList<quint64> > > > loadedPoisByArea;
+    QMap<quint64, QMap<int, QMap<int, QList<quint64>>>> loadedPoisByArea;
     QMap<quint64, CRawPoi> loadedPois;
     QList<poiGroup_t> displayedPois;
     QRectF bbox;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#389

### What you have done:
[comment]: # (Describe roughly.)

* Apply the mutex to all public methods of CPoiPOI.
* For all the find and tooltip methods test if the
  mutex would block. If it would block leave the
  method.

There is no sense in doing find and tooltip
while the draw thread is still gathering information.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Perform the test steps from the ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
