### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/qmapshack/poi/CPoiPOI.cpp
+++ b/src/qmapshack/poi/CPoiPOI.cpp
@@ -71,7 +71,7 @@ CPoiPOI::CPoiPOI(const QString& filename, CPoiDraw* parent)
     }
     else
     {
-        qDebug() << "failed to retreive bounding box of " << filename;
+        qDebug() << "failed to retrieve bounding box of " << filename;
         isActivated = false;
     }
     //Database is no longer needed


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * retreive -> retrieve