### PR TITLE
[QMS-400] Set focus in text field

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-400] Set focus in text field
+
 V1.16.0
 [QMS-220] "Select items from map" misses items
 [QMS-275] Routino: Add Spanish and Czech as selectable languages for turn instructions

--- a/src/qmapshack/gis/IGisItemRate.ui
+++ b/src/qmapshack/gis/IGisItemRate.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Rating and tags...</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -155,6 +155,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>keywordPlainTextEdit</tabstop>
+  <tabstop>pushButtonR1</tabstop>
+  <tabstop>pushButtonR2</tabstop>
+  <tabstop>pushButtonR3</tabstop>
+  <tabstop>pushButtonR4</tabstop>
+  <tabstop>pushButtonR5</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/qmapshack/locale/qmapshack_de.ts
+++ b/src/qmapshack/locale/qmapshack_de.ts
@@ -14978,7 +14978,7 @@ Wenn Sie das Wort &apos;wort&apos; eingeben, wird exakt nach dem Wort gesucht. W
     <message>
         <location filename="../gis/db/ISetupWorkspace.ui" line="131"/>
         <source>Show tags in workspace tree. Not recommended for small screens.</source>
-        <translation>Tags im Arbeitsplatz anzeigen. Nicht zu empfehlen für keine Bildschirme.</translation>
+        <translation>Tags im Arbeitsplatz anzeigen. Nicht zu empfehlen für kleine Bildschirme.</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#400

### What you have done:
[comment]: # (Describe roughly.)

* Set focus order in UI file
* Fix dialog title
* Fix typo in translation

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Open tags dialog and start typing. 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
