### PR TITLE
[QMS-401] Crash when using "select items on map" with a large amount …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-400] Set focus in text field
+[QMS-401] Crash when using "select items on map" with a large amount of items
 
 V1.16.0
 [QMS-220] "Select items from map" misses items

--- a/src/qmapshack/helpers/CTryMutexLocker.h
+++ b/src/qmapshack/helpers/CTryMutexLocker.h
@@ -25,10 +25,21 @@ class CTryMutexLocker
 {
 public:
     CTryMutexLocker(QMutex& mutex) : m_mutex(mutex){}
-    ~CTryMutexLocker() {m_mutex.unlock();}
-    bool try_lock(){return m_mutex.tryLock();}
+    ~CTryMutexLocker()
+    {
+        if(needsUnlock)
+        {
+            m_mutex.unlock();
+        }
+    }
+    bool try_lock()
+    {
+        needsUnlock = m_mutex.tryLock();
+        return needsUnlock;
+    }
 private:
     QMutex& m_mutex;
+    bool needsUnlock {false};
 };
 
 #endif //CTRYMUTEXLOCKER_H

--- a/src/qmapshack/mouse/CMouseSelect.h
+++ b/src/qmapshack/mouse/CMouseSelect.h
@@ -60,7 +60,7 @@ private:
 
 
     QList<IGisItem::key_t> itemKeys;
-    static QMutex mutexPoisFound;
+    static QMutex mutex;
     QSet<poi_t> poisFound;
     ///The POIs can be clustered together, so the icon is not necessarily displayed where the POI is.
     /// Thus the location where to draw the highlight is separately given


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#401

### What you have done:
[comment]: # (Describe roughly.)

* Fix Bug in CTryMutexLocker
* Add non-recursive mutex to all slots and use a try
   mutex locker for findItems().



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Try sequence from ticket. -> no crash

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
