### PR TITLE
[QMS-414] CScrOptRangeTool: Fix layout for larger fonts.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-400] Set focus in text field
 [QMS-401] Crash when using "select items on map" with a large amount of items
+[QMS-414] Last point information not fully displayed in the range tool window
 
 V1.16.0
 [QMS-220] "Select items from map" misses items

--- a/src/qmapshack/mouse/range/IScrOptRangeTool.ui
+++ b/src/qmapshack/mouse/range/IScrOptRangeTool.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>

--- a/src/qmapshack/mouse/range/IScrOptRangeTool.ui
+++ b/src/qmapshack/mouse/range/IScrOptRangeTool.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>711</width>
+    <width>718</width>
     <height>90</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
@@ -337,12 +337,6 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>100</height>
-      </size>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Removed a minimum size so that the dialog resizes correctly on larger fonts.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#414

### What you have done:
[comment]: # (Describe roughly.)
Removed a minimum size so that the dialog resizes correctly on larger fonts.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. From the main menu select View->Set Map Font S
2. Select a font with size 14, for example Noto Sans Regular 14.
3. Select a track, select the range tool.
4. Select the last track point.
5. The last track point shall be fully visible.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [X] yes

### Is every user facing string in a tr() macro?

- [X] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [X] yes, I didn't forget to change changelog.txt
