### PR TITLE
[QMS-421]  Change of map view name is not taken into account in POI tab

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,8 @@ V1.XX.X
 [QMS-401] Crash when using "select items on map" with a large amount of items
 [QMS-412] Track: Endless loop for user defined limits min 0.
 [QMS-414] Last point information not fully displayed in the range tool window
+[QMS-421] Change of map view name is not taken into account in POI tab
+
 
 V1.16.0
 [QMS-220] "Select items from map" misses items

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -1753,6 +1753,7 @@ void CMainWindow::slotRenameView()
     tabWidget->setTabText(idx, name);
     tabMaps->setTabText(idx, name);
     tabDem->setTabText(idx, name);
+    tabPoi->setTabText(idx, name);
 }
 
 void CMainWindow::displayRegular()


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#421

### What you have done:
[comment]: # (Describe roughly.)

Added the missing line

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Rename map view
* POI tab must change name

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
