### PR TITLE
[QMS-427] Adding new map paths is broken 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-412] Track: Endless loop for user defined limits min 0.
 [QMS-414] Last point information not fully displayed in the range tool window
 [QMS-421] Change of map view name is not taken into account in POI tab
+[QMS-427] Adding new map paths is broken
 
 
 V1.16.0

--- a/src/qmapshack/dem/CDemPathSetup.cpp
+++ b/src/qmapshack/dem/CDemPathSetup.cpp
@@ -55,7 +55,7 @@ void CDemPathSetup::slotItemSelectionChanged()
 
 void CDemPathSetup::slotAddPath()
 {
-    QString path = QFileDialog::getExistingDirectory(this, tr("Select DEM file path..."), QDir::homePath(), 0);
+    QString path = QFileDialog::getExistingDirectory(this, tr("Select DEM file path..."), QDir::homePath());
     if(!path.isEmpty())
     {
         if(!paths.contains(path))

--- a/src/qmapshack/gis/rte/router/routino/CRouterRoutinoPathSetup.cpp
+++ b/src/qmapshack/gis/rte/router/routino/CRouterRoutinoPathSetup.cpp
@@ -52,7 +52,7 @@ void CRouterRoutinoPathSetup::slotItemSelectionChanged()
 
 void CRouterRoutinoPathSetup::slotAddPath()
 {
-    QString path = QFileDialog::getExistingDirectory(this, tr("Select routing data file path..."), QDir::homePath(), 0);
+    QString path = QFileDialog::getExistingDirectory(this, tr("Select routing data file path..."), QDir::homePath());
     if(!path.isEmpty())
     {
         QListWidgetItem* item = new QListWidgetItem(listWidget);

--- a/src/qmapshack/map/CMapPathSetup.cpp
+++ b/src/qmapshack/map/CMapPathSetup.cpp
@@ -59,7 +59,7 @@ void CMapPathSetup::slotItemSelectionChanged()
 
 void CMapPathSetup::slotAddPath()
 {
-    QString path = QFileDialog::getExistingDirectory(this, tr("Select map path..."), QDir::homePath(), 0);
+    QString path = QFileDialog::getExistingDirectory(this, tr("Select map path..."), QDir::homePath());
     if(!path.isEmpty())
     {
         if(!paths.contains(path))

--- a/src/qmapshack/poi/CPoiPathSetup.cpp
+++ b/src/qmapshack/poi/CPoiPathSetup.cpp
@@ -62,7 +62,7 @@ void CPoiPathSetup::accept()
 
 void CPoiPathSetup::slotAddPath()
 {
-    QString path = QFileDialog::getExistingDirectory(this, tr("Select POI file path..."), QDir::homePath(), 0);
+    QString path = QFileDialog::getExistingDirectory(this, tr("Select POI file path..."), QDir::homePath());
     if(!path.isEmpty())
     {
         if(!paths.contains(path))


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#427

### What you have done:
[comment]: # (Describe roughly.)

The last argument of getExistingDirectory function is a flag and cannot
be zero according to Qt documentation. I think the default value
QFileDialog::ShowDirsOnly should work. It fixes the issue for me.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Click RMB in the maps panel and select "Setup map paths"
2. Press the "plus" button.
3. Select any directory and press OK.
4. A directory is now added to the list of map paths.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
