### PR TITLE
[QMS-436] Store/restore name of map view

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-414] Last point information not fully displayed in the range tool window
 [QMS-421] Change of map view name is not taken into account in POI tab
 [QMS-427] Adding new map paths is broken
+[QMS-436] Store/restore name of map view  
 
 
 V1.16.0

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -184,7 +184,7 @@ CMainWindow::CMainWindow()
     connect(actionWiki, &QAction::triggered, this, &CMainWindow::slotWiki);
     connect(actionHelp, &QAction::triggered, this, &CMainWindow::slotHelp);
     connect(actionQuickstart, &QAction::triggered, this, &CMainWindow::slotQuickstart);
-    connect(actionAddMapView, &QAction::triggered, this, &CMainWindow::slotAddCanvas);
+    connect(actionAddMapView, &QAction::triggered, this, [this](){slotAddCanvas("");});
     connect(actionCloneMapView, &QAction::triggered, this, &CMainWindow::slotCloneCanvas);
     connect(actionShowGrid, &QAction::changed, this, [this](){this->update();});
     connect(actionShowScale, &QAction::changed, this, &CMainWindow::slotUpdateTabWidgets);
@@ -1008,9 +1008,9 @@ void CMainWindow::slotQuickstart()
 }
 
 
-void CMainWindow::slotAddCanvas()
+void CMainWindow::slotAddCanvas(const QString& name)
 {
-    CCanvas* view = addView(QString());
+    CCanvas* view = addView(name);
     tabWidget->setCurrentWidget(view);
 
     testForNoView();
@@ -1034,7 +1034,7 @@ void CMainWindow::slotCloneCanvas()
 
     source->saveConfig(view);
 
-    slotAddCanvas();
+    slotAddCanvas(source->objectName() + tr(" (Cloned)"));
 
     CCanvas* target = getVisibleCanvas();
     if(nullptr == target)
@@ -1441,6 +1441,7 @@ void CMainWindow::slotStoreView()
     view.clear();
 
     canvas->saveConfig(view);
+    view.setValue("name", canvas->objectName());
 
     path = fi.absolutePath();
     cfg.setValue("Paths/lastViewPath", path);
@@ -1456,8 +1457,10 @@ void CMainWindow::slotLoadView()
     {
         return;
     }
+    QSettings view(filename, QSettings::IniFormat);
 
-    slotAddCanvas();
+    const QString& name = view.value("name", QString()).toString();
+    slotAddCanvas(name);
 
     CCanvas* canvas = getVisibleCanvas();
     if(nullptr == canvas)
@@ -1465,7 +1468,6 @@ void CMainWindow::slotLoadView()
         return;
     }
 
-    QSettings view(filename, QSettings::IniFormat);
     canvas->loadConfig(view);
 
     cfg.beginGroup("Canvas");

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -172,7 +172,7 @@ private slots:
     void slotAbout();
     void slotWiki();
     void slotQuickstart();
-    void slotAddCanvas();
+    void slotAddCanvas(const QString& name);
     void slotCloneCanvas();
     void slotTabCloseRequest(int i);
     void slotCurrentTabCanvas(int i);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#436

### What you have done:
[comment]: # (Describe roughly.)

* Store name in file
* Restore name from file
* Additionally use view name for cloned view with suffix

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Give your view a name
2. Store view to file
3. Close view
4. Restore view from file
--> The view's name should be restored.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
