### PR TITLE
[QMS-439] Add number of tracks in a project in headline in detail project track list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-414] Last point information not fully displayed in the range tool window
 [QMS-421] Change of map view name is not taken into account in POI tab
 [QMS-427] Adding new map paths is broken
+[QMS-439] Add number of tracks in a project in headline in detail project track
 
 
 V1.16.0

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -496,7 +496,7 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor,
 
     if(!wpts.isEmpty())
     {
-        QString htmlStr = QString("<h2>%1 ").arg(wpts.count()) + tr("Waypoints</h2>");
+        const QString& htmlStr = QString("<h2>%1 %2</h2>").arg(wpts.count()).arg(tr("Waypoints"));
         cursor.insertHtml(htmlStr);
         QTextTable* table = cursor.insertTable(wpts.count() + 1, eMax1, fmtTableStandard);
 
@@ -523,7 +523,7 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor,
 
     if(!trks.isEmpty())
     {
-        QString htmlStr = QString("<h2>%1 ").arg(trks.count()) + tr("Tracks</h2>");
+        const QString& htmlStr = QString("<h2>%1 %2</h2>").arg(trks.count()).arg(tr("Tracks"));
         cursor.insertHtml(htmlStr);
         QTextTable* table = cursor.insertTable(trks.count() + 1, eMax1, fmtTableStandard);
 
@@ -939,7 +939,7 @@ void CDetailsPrj::drawArea(QTextCursor& cursor, QList<CGisItemOvlArea*>& areas, 
     {
         return;
     }
-    QString htmlStr = QString("<h2>%1 ").arg(areas.count()) + tr("Areas</h2>");
+    const QString& htmlStr = QString("<h2>%1 %2</h2>").arg(areas.count()).arg(tr("Areas"));
     cursor.insertHtml(htmlStr);
     QTextTable* table = cursor.insertTable(areas.count() + 1, eMax1, fmtTableStandard);
 
@@ -970,7 +970,7 @@ void CDetailsPrj::drawRoute(QTextCursor& cursor, QList<CGisItemRte*>& rtes, CPro
     {
         return;
     }
-    QString htmlStr = QString("<h2>%1 ").arg(rtes.count()) + tr("Routes</h2>");
+    const QString& htmlStr = QString("<h2>%1 %2</h2>").arg(rtes.count()).arg(tr("Routes"));
     cursor.insertHtml(htmlStr);
     QTextTable* table = cursor.insertTable(rtes.count() + 1, eMax1, fmtTableStandard);
 

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -496,7 +496,8 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor,
 
     if(!wpts.isEmpty())
     {
-        cursor.insertHtml(tr("<h2>Waypoints</h2>"));
+        QString htmlStr = QString("<h2>%1 ").arg(wpts.count()) + tr("Waypoints</h2>");
+        cursor.insertHtml(htmlStr);
         QTextTable* table = cursor.insertTable(wpts.count() + 1, eMax1, fmtTableStandard);
 
         table->cellAt(0, eSym1).setFormat(fmtCharHeader);
@@ -938,7 +939,8 @@ void CDetailsPrj::drawArea(QTextCursor& cursor, QList<CGisItemOvlArea*>& areas, 
     {
         return;
     }
-    cursor.insertHtml(tr("<h2>Areas</h2>"));
+    QString htmlStr = QString("<h2>%1 ").arg(areas.count()) + tr("Areas</h2>");
+    cursor.insertHtml(htmlStr);
     QTextTable* table = cursor.insertTable(areas.count() + 1, eMax1, fmtTableStandard);
 
     table->cellAt(0, eSym1).setFormat(fmtCharHeader);
@@ -968,7 +970,8 @@ void CDetailsPrj::drawRoute(QTextCursor& cursor, QList<CGisItemRte*>& rtes, CPro
     {
         return;
     }
-    cursor.insertHtml(tr("<h2>Routes</h2>"));
+    QString htmlStr = QString("<h2>%1 ").arg(rtes.count()) + tr("Routes</h2>");
+    cursor.insertHtml(htmlStr);
     QTextTable* table = cursor.insertTable(rtes.count() + 1, eMax1, fmtTableStandard);
 
     table->cellAt(0, eSym1).setFormat(fmtCharHeader);

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -522,7 +522,8 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor,
 
     if(!trks.isEmpty())
     {
-        cursor.insertHtml(tr("<h2>Tracks</h2>"));
+        QString htmlStr = QString("<h2>%1 ").arg(trks.count()) + tr("Tracks</h2>");
+        cursor.insertHtml(htmlStr);
         QTextTable* table = cursor.insertTable(trks.count() + 1, eMax1, fmtTableStandard);
 
         table->cellAt(0, eSym1).setFormat(fmtCharHeader);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-[439](https://github.com/Maproom/qmapshack/issues/439)

### What you have done:
[comment]: # (Describe roughly.)
Add count of tracks prior to the string "Tracks" in headerline for tracks list in project edit dialog.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open some projects
2. Verify that the number of tracks is correct

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
