### PR TITLE
[QMS-438] Wrong height displayed

### DIFF
--- a/src/common/gis/proj_x.cpp
+++ b/src/common/gis/proj_x.cpp
@@ -111,8 +111,8 @@ void CProj::transform(QPolygonF& line, PJ_DIRECTION dir) const
         return;
     }
 
-    qreal factorPre = proj_degree_input(_pj, dir) ? RAD_TO_DEG : 1.0;
-    qreal factorPost = proj_degree_output(_pj, dir) ? DEG_TO_RAD : 1.0;
+    qreal factorPre = _proj_degree_input(dir) ? RAD_TO_DEG : 1.0;
+    qreal factorPost = _proj_degree_output(dir) ? DEG_TO_RAD : 1.0;
 
     for(QPointF& pt : line)
     {
@@ -129,18 +129,29 @@ void CProj::transform(QPointF& pt, PJ_DIRECTION dir) const
         return;
     }
 
-    if(proj_degree_input(_pj, dir))
+    if(_proj_degree_input(dir))
     {
         pt *= RAD_TO_DEG;
     }
 
     _transform(pt.rx(), pt.ry(), dir);
 
-    if(proj_degree_output(_pj, dir))
+    if(_proj_degree_output(dir))
     {
         pt *= DEG_TO_RAD;
     }
 }
+
+bool CProj::_proj_degree_input(PJ_DIRECTION dir) const
+{
+    return (dir == PJ_FWD) ? _isSrcLatLong : _isTarLatLong;
+}
+
+bool CProj::_proj_degree_output(PJ_DIRECTION dir) const
+{
+    return (dir == PJ_FWD) ? _isTarLatLong : _isSrcLatLong;
+}
+
 
 void CProj::transform(qreal& lon, qreal& lat, PJ_DIRECTION dir) const
 {
@@ -149,7 +160,7 @@ void CProj::transform(qreal& lon, qreal& lat, PJ_DIRECTION dir) const
         return;
     }
 
-    if(proj_degree_input(_pj, dir))
+    if(_proj_degree_input(dir))
     {
         lon *= RAD_TO_DEG;
         lat *= RAD_TO_DEG;
@@ -157,7 +168,7 @@ void CProj::transform(qreal& lon, qreal& lat, PJ_DIRECTION dir) const
 
     _transform(lon, lat, dir);
 
-    if(proj_degree_output(_pj, dir))
+    if(_proj_degree_output(dir))
     {
         lon *= DEG_TO_RAD;
         lat *= DEG_TO_RAD;

--- a/src/common/gis/proj_x.h
+++ b/src/common/gis/proj_x.h
@@ -55,6 +55,9 @@ private:
     void _transform(qreal& lon, qreal& lat, PJ_DIRECTION dir) const;
     bool _isLatLong(const QString& crs) const;
 
+    bool _proj_degree_input(PJ_DIRECTION dir) const;
+    bool _proj_degree_output(PJ_DIRECTION dir) const;
+
     PJ_CONTEXT * _ctx = nullptr;
     PJ * _pj = nullptr;
     bool _isSrcLatLong = false;

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -1895,23 +1895,24 @@ void CMainWindow::slotSanityTest()
     try
     {
         CProj proj;
-        proj.init("EPSG:4326", "EPSG:32661");
+//        proj.init("EPSG:4326", "EPSG:32661");
+        proj.init("EPSG:4326", "EPSG:31287");
 
         if(!proj.isValid())
         {
             throw QException();
         }
 
-        QPointF pt(11 * DEG_TO_RAD, 80 * DEG_TO_RAD);
+        QPointF pt(14 * DEG_TO_RAD, 47 * DEG_TO_RAD);
 
         proj.transform(pt, PJ_FWD);
-        if((qFloor(pt.x()) != 2212361) | (qFloor(pt.y()) != 907496))
+        if((qFloor(pt.x()) != 450741) | (qFloor(pt.y()) != 344703))
         {
             throw QException();
         }
 
         proj.transform(pt, PJ_INV);
-        if((qRound(pt.x() * RAD_TO_DEG) != 11) | (qRound(pt.y() * RAD_TO_DEG) != 80))
+        if((qRound(pt.x() * RAD_TO_DEG) != 14) | (qRound(pt.y() * RAD_TO_DEG) != 47))
         {
             throw QException();
         }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#438

### What you have done:
[comment]: # (Describe roughly.)

replaced proj_degree_output and proj_degree_input by own functions.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Using `EPSG:31287` as grid projection should result into a valid grid.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
