### PR TITLE
[QMS-444] Fix wrong link to POI path setup in Spanish translation file

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,9 +6,9 @@ V1.XX.X
 [QMS-414] Last point information not fully displayed in the range tool window
 [QMS-421] Change of map view name is not taken into account in POI tab
 [QMS-427] Adding new map paths is broken
-[QMS-436] Store/restore name of map view  
+[QMS-436] Store/restore name of map view
 [QMS-439] Add number of tracks in a project in headline in detail project track
-
+[QMS-444] Fix wrong link to POI path setup in Spanish translation file
 
 
 V1.16.0

--- a/src/qmapshack/locale/qmapshack_es.ts
+++ b/src/qmapshack/locale/qmapshack_es.ts
@@ -12506,7 +12506,7 @@ Pulse tecla ALT para hacer zoom sólo verticalmente</translation>
     <message>
         <location filename="../poi/IPoiList.ui" line="97"/>
         <source>To add POI collections use &lt;a href=&apos;PoiFolders&apos;&gt;File-&gt;Setup POI Paths&lt;/a&gt;.</source>
-        <translation>Para agregar archivos con POIs hacer clic en &lt;a href=&apos;DemFolders&apos;&gt;Archivo-&gt;Configurar rutas a los POi&lt;/a&gt;.</translation>
+        <translation type="unfinished">Para agregar archivos con POIs hacer clic en &lt;a href=&apos;PoiFolders&apos;&gt;Archivo-&gt;Configurar rutas a los POi&lt;/a&gt;.</translation>
     </message>
     <message>
         <location filename="../poi/IPoiList.ui" line="110"/>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#444

### What you have done:
[comment]: # (Describe roughly.)

Edit `qmapshack_es.ts` to fix the wrong link

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)
Assuming you are using qmapshack in spanish
1. Go to ' POI list panel' 
2. If any path to POI folders is configured you will see a help message with a link: ' Configurar rutas a los POI' 
3. Click on the link and the POI folders path configuration dialogue opens.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x ] yes

### Is every user facing string in a tr() macro?

- [ x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ x] yes, I didn't forget to change changelog.txt
