### PR TITLE
[QMS-430] Replace 'exportToProj' by 'exportToWkt' in CMapWMTS.cpp. Th…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-414] Last point information not fully displayed in the range tool window
 [QMS-421] Change of map view name is not taken into account in POI tab
 [QMS-427] Adding new map paths is broken
+[QMS-430] Replace 'exportToProj' by 'exportToWkt' in CMapWMTS.cpp. This preserves the "towgs84" datum shift needed by some SRSs
 [QMS-436] Store/restore name of map view
 [QMS-439] Add number of tracks in a project in headline in detail project track
 [QMS-444] Fix wrong link to POI path setup in Spanish translation file

--- a/src/qmapshack/map/CMapWMTS.cpp
+++ b/src/qmapshack/map/CMapWMTS.cpp
@@ -218,7 +218,7 @@ CMapWMTS::CMapWMTS(const QString& filename, CMapDraw* parent)
         {
             oSRS.importFromURN(ptr1);
         }
-        oSRS.exportToProj4(&ptr2);
+        oSRS.exportToWkt(&ptr2);
 
         qDebug() << ptr1 << ptr2;
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#430

### What you have done:
[comment]: # (Describe roughly.)

Replace 'exportToProj' by 'exportToWkt' in CMapWMTS.cpp. This preserves the "towgs84" datum shift needed by some SRSs

For reference: 
There is a warning about the use of `exportToProj`function in GDAL documentation, 
[here](https://gdal.org/api/ogrspatialref.html#_CPPv4NK19OGRSpatialReference13exportToProj4EPPc) and [here](https://gdal.org/api/ogr_srs_api.html#_CPPv416OSRExportToProj420OGRSpatialReferenceHPPc)

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Download [this zip](https://mega.nz/file/RYVUnJYI#jODCgnsETN0vI8CSswRB_VLE412apzgYBfW9TUj1TNQ). It contains a WMTS file for Wallonia \([source here](https://geoservices.wallonie.be/arcgis/rest/services/IMAGERIE/ORTHO_LAST/MapServer/WMTS/1.0.0/WMTSCapabilities.xml)\) and a gpx file with a waypoint to land on Wallonia
2. Copy the WMTS file in your maps folder
3. Activate this WMTS map, and some other topo map.
4. Apply some transparence to the last map, and check if both Ortho and Topo map match.
5. (optional) Create a waypoint  in a crossroad, and check if it matches on WMTS ortho and on topo map.

### Important:

- For get it working you must first get Proj8 newer than 2021/09/26. Older versions of Proj8 come with a bug.  * *[reference here](https://github.com/OSGeo/PROJ/issues/2866)*

- If you can't get the latest version of PROJ8 you can still try it if you also merge [this PR made by kiozen](https://github.com/Maproom/qmapshack/pull/442), which provides its own functions instead of the buggy PROJ ones.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x ] yes.

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt