### PR TITLE
[QMS-438] Replace 'exportToProj4' by 'exportToWkt' 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-421] Change of map view name is not taken into account in POI tab
 [QMS-427] Adding new map paths is broken
 [QMS-436] Store/restore name of map view
+[QMS-438] Replace 'exportToProj4' by 'exportToWkt' to preserve "towgs84" datum shift when needed.
 [QMS-439] Add number of tracks in a project in headline in detail project track
 [QMS-444] Fix wrong link to POI path setup in Spanish translation file
 

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -25,7 +25,6 @@
 #include "units/IUnit.h"
 
 #include <gdal_priv.h>
-#include <ogr_spatialref.h>
 #include <QtWidgets>
 
 #define TILELIMIT 30000
@@ -70,19 +69,7 @@ CDemVRT::CDemVRT(const QString& filename, CDemDraw* parent)
     qDebug() << "no data:" << hasNoData << noData;
 
     // ------- setup projection ---------------
-    char str[1025] = {0};
-    if(dataset->GetProjectionRef())
-    {
-        strncpy(str, dataset->GetProjectionRef(), sizeof(str) - 1);
-    }
-    OGRSpatialReference oSRS;
-    const char* wkt = str;
-    oSRS.importFromWkt(&wkt);
-
-    char* proj4 = nullptr;
-    oSRS.exportToProj4(&proj4);
-    proj.init(proj4, "EPSG:4326");
-    free(proj4);
+    proj.init(dataset->GetProjectionRef(), "EPSG:4326");
 
     if(!proj.isValid())
     {

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -30,8 +30,6 @@
 #include <QtWidgets>
 #include <QtXml>
 
-#include <ogr_spatialref.h>
-
 
 inline int lon2tile(double lon, int z)
 {

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -23,7 +23,6 @@
 #include "units/IUnit.h"
 
 #include <gdal_priv.h>
-#include <ogr_spatialref.h>
 #include <QtWidgets>
 
 #define TILELIMIT 2500
@@ -118,21 +117,7 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent)
 
 
     // ------- setup projection ---------------
-    char str[1025] = {0};
-    if(dataset->GetProjectionRef())
-    {
-        strncpy(str, dataset->GetProjectionRef(), sizeof(str) - 1);
-    }
-
-    OGRSpatialReference oSRS;
-    const char* wkt = str;
-    oSRS.importFromWkt(&wkt);
-
-    char* proj4 = nullptr;
-    oSRS.exportToProj4(&proj4);
-
-    proj.init(proj4, "EPSG:4326");
-    free(proj4);
+    proj.init(dataset->GetProjectionRef(), "EPSG:4326");
 
     if(!proj.isValid())
     {

--- a/src/qmapshack/map/CMapWMTS.cpp
+++ b/src/qmapshack/map/CMapWMTS.cpp
@@ -218,7 +218,7 @@ CMapWMTS::CMapWMTS(const QString& filename, CMapDraw* parent)
         {
             oSRS.importFromURN(ptr1);
         }
-        oSRS.exportToProj4(&ptr2);
+        oSRS.exportToWkt(&ptr2);
 
         qDebug() << ptr1 << ptr2;
 

--- a/src/qmaptool/canvas/CDrawContextPixel.cpp
+++ b/src/qmaptool/canvas/CDrawContextPixel.cpp
@@ -20,7 +20,6 @@
 #include "helpers/CDraw.h"
 
 #include <gdal_priv.h>
-#include <ogr_spatialref.h>
 #include <QtWidgets>
 
 CDrawContextPixel::CDrawContextPixel(CCanvas* canvas, QObject* parent)

--- a/src/qmaptool/helpers/CGdalFile.cpp
+++ b/src/qmaptool/helpers/CGdalFile.cpp
@@ -21,7 +21,6 @@
 #include "helpers/CGdalFile.h"
 
 #include <gdal_priv.h>
-#include <ogr_spatialref.h>
 
 #include <QtWidgets>
 
@@ -55,23 +54,7 @@ void CGdalFile::load(const QString& filename)
         return;
     }
 
-    char str[1025] = {0};
-    if(dataset->GetProjectionRef())
-    {
-        strncpy(str, dataset->GetProjectionRef(), sizeof(str) - 1);
-    }
-
-    {
-        OGRSpatialReference oSRS;
-        const char* wkt = str;
-        oSRS.importFromWkt(&wkt);
-
-        char* proj4 = nullptr;
-        oSRS.exportToProj4(&proj4);
-
-        proj.init(proj4, "EPSG:4326");
-        free(proj4);
-    }
+    proj.init(dataset->GetProjectionRef(), "EPSG:4326");
 
     GDALRasterBand* pBand = dataset->GetRasterBand(1);
 

--- a/src/qmt_map2jnx/main.cpp
+++ b/src/qmt_map2jnx/main.cpp
@@ -37,7 +37,6 @@
 #include <vector>
 
 #include <gdal_priv.h>
-#include <ogr_spatialref.h>
 
 extern "C"
 {
@@ -519,7 +518,6 @@ int main(int argc, char** argv)
     uint32_t tileTableStart = 0;
     uint32_t tileCnt = 0;
     uint32_t tilesTotal = 0;
-    char projstr[1024];
     OGRSpatialReference oSRS;
     int quality = -1;
     int subsampling = -1;
@@ -677,18 +675,6 @@ int main(int argc, char** argv)
             exit(-1);
         }
 
-        const char* wkt = projstr;
-
-        if(dataset->GetProjectionRef())
-        {
-            strncpy(projstr, dataset->GetProjectionRef(), sizeof(projstr));
-        }
-        oSRS.importFromWkt(&wkt);
-
-        char* proj4 = nullptr;
-        oSRS.exportToProj4(&proj4);
-
-
         double adfGeoTransform[6];
         dataset->GetGeoTransform( adfGeoTransform );
 
@@ -698,7 +684,7 @@ int main(int argc, char** argv)
         file_t& file = *f;
         file.filename = argv[i];
         file.dataset = dataset;
-        file.proj.init(proj4, "EPSG:4326");
+        file.proj.init(dataset->GetProjectionRef(), "EPSG:4326");
         file.width = dataset->GetRasterXSize();
         file.height = dataset->GetRasterYSize();
         file.xscale = adfGeoTransform[1];


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#438

### What you have done:
[comment]: # (Describe roughly.)

Replace 'exportToProj4' by 'exportToWkt' in CDemVRT.cpp and CMapVRT.cpp. This preserves the "towgs84" datum shift needed by some SRSs

For reference: 
There is a warning about the use of `exportToProj`function in GDAL documentation, 
[here](https://gdal.org/api/ogrspatialref.html#_CPPv4NK19OGRSpatialReference13exportToProj4EPPc) and [here](https://gdal.org/api/ogr_srs_api.html#_CPPv416OSRExportToProj420OGRSpatialReferenceHPPc)

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)
#### For VRT DEMs (issue #438)

1. Download [this zip](https://mega.nz/file/BFdDFSbA#0VR7Vb7G2-V65ZzTP03mMrr3LFZwmnheO5YTXxd1p-w). It is only 135 Kb and contains a sample DEM for testing and a gpx file with a waypoint to land on the sample DEM area (Klosterwappen in Austria)
2. Activate some map for this area
2. Build a new VRT with this DEM and activate it. Then activate the `elevation limit` feature and set it to 2060m
3. Check if the pink colored area above 2060 matches the basemap.


- **Match:**

![](https://i.ibb.co/zNqc269/DHM10-tunned.jpg)

- **Don't match:**
 
![](https://i.ibb.co/X8VQw9X/DHM10-ori.jpg)


#### For WMTS (issue #430)

1. Download [this zip](https://mega.nz/file/BFdDFSbA#0VR7Vb7G2-V65ZzTP03mMrr3LFZwmnheO5YTXxd1p-w). It contains a WMTS file for Wallonia \([source here](https://geoservices.wallonie.be/arcgis/rest/services/IMAGERIE/ORTHO_LAST/MapServer/WMTS/1.0.0/WMTSCapabilities.xml)\) and a gpx file with a waypoint to land on Wallonia
2. Copy the WMTS file in your maps folder
3. Activate this WMTS map, and some other topo map.
4. Apply some transparence to the last map, and check if both Ortho and Topo map match.
5. (optional) Create a waypoint  in a crossroad, and check if it matches on WMTS ortho and on topo map.


#### For qmaptool:

1. Download [this zip](https://mega.nz/file/BFdDFSbA#0VR7Vb7G2-V65ZzTP03mMrr3LFZwmnheO5YTXxd1p-w). It contains a sample Tiff map for testing (EPSG:23030) and a gpx file with a waypoint to land on the sample map area. (Orio in Basque Country)
2. Start qmaptool from the build/bin folder. `./qmaptool -d`
2. Go to the `Cut Map`panel and load Orio_23030.tiff. Draw a cut polyline and export the cutted map.
3. Start qmapshack from the build/bin folder `./qmapshack -d`. Build the VRT for the new cutted map,load it and check if it matches with the WorldSat map.


#### For qmt_map2jnx:

1. Open a terminal in the build/bin folder and do:
`./qmt_map2jnx -q 75 -s 411 -p 0 -m BirdsEye -n None -c None -z 50 /your_maps_folder/Orio_23030.tiff /your_maps_folder/Orio_23030.jnx`

2. Start qmapshack from the build/bin folder `./qmapshack -d`. Load Orio_23030.jnx and check if it matches with the WorldSat map.



### Important:

- For get it working you must first get Proj8 newer than 2021/09/26. Older versions of Proj8 come with a bug.  * *[reference here](https://github.com/OSGeo/PROJ/issues/2866)*

- If you can't get the latest version of PROJ8 you can still try it if you also merge [this PR made by kiozen](https://github.com/Maproom/qmapshack/pull/442), which provides its own functions instead of the buggy PROJ ones.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes.

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
