### PR TITLE
[QMS-441] "Hide invalid points" does not hide anything when 1st track…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-427] Adding new map paths is broken
 [QMS-436] Store/restore name of map view
 [QMS-439] Add number of tracks in a project in headline in detail project track
+[QMS-441] "Hide invalid points" does not hide anything when 1st trackpoint has no elevation data
 [QMS-444] Fix wrong link to POI path setup in Spanish translation file
 
 

--- a/src/qmapshack/gis/trk/CInvalidTrk.cpp
+++ b/src/qmapshack/gis/trk/CInvalidTrk.cpp
@@ -42,7 +42,7 @@ CInvalidTrk::CInvalidTrk(CGisItemTrk& trk, QWidget* parent)
     }
 
     labelMsg->setText(tr("The track '%1' has %2 invalid points out of %3 visible points. "
-                         "Do you want to hide invalid points now?")
+                         "Do you want to remove invalid points now?")
                       .arg(trk.getName())
                       .arg(trk.getNumberOfInvalidPoints())
                       .arg(trk.getNumberOfVisiblePoints()));

--- a/src/qmapshack/gis/trk/filter/filter.cpp
+++ b/src/qmapshack/gis/trk/filter/filter.cpp
@@ -106,14 +106,23 @@ void CGisItemTrk::filterRemoveInvalidPoints()
     // invalid flags for properties with valid points count
     quint32 invalidMask = (getAllValidFlags() & CTrackData::trkpt_t::eValidMask) << 16;
 
-    for(CTrackData::trkpt_t& pt : trk)
+    for(CTrackData::trkseg_t& seg : trk.segs)
     {
-        if(pt.isInvalid(CTrackData::trkpt_t::invalid_e(invalidMask)))
+        QVector<CTrackData::trkpt_t> pts;
+        for(const CTrackData::trkpt_t& pt : qAsConst(seg.pts))
         {
-            pt.setFlag(CTrackData::trkpt_t::eFlagHidden);
-            nothingDone = false;
+            if(pt.isInvalid(CTrackData::trkpt_t::invalid_e(invalidMask)))
+            {
+                nothingDone = false;
+                continue;
+            }
+
+            pts << pt;
         }
+
+        seg.pts = pts;
     }
+
 
     if(nothingDone)
     {
@@ -121,7 +130,7 @@ void CGisItemTrk::filterRemoveInvalidPoints()
     }
 
     deriveSecondaryData();
-    changed(tr("Hide points with invalid data."), "://icons/48x48/PointHide.png");
+    changed(tr("Permanently removed points with invalid data."), "://icons/48x48/PointHide.png");
 }
 
 void CGisItemTrk::filterReset()


### PR DESCRIPTION
…point has no elevation data

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#441

### What you have done:
[comment]: # (Describe roughly.)

The first track point is also the start of the first activity section (default no activity). Activity start points can't be hidden. Anyways this point is invalid and shouldn't be part of the track at all. Therefore removing invalid points completely is the better way to go. As every change is stored in the histroy nothing is lost as long as the track is not stored as GPX.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Load the example track from the ticket
2. Choose to remove invalid points.
3. Check in the track details dialog for invalid points.
4. Restart QMapShack. It shouldn't complain anymore.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
