### PR TITLE
Early call to abort() in CLogHandler.cpp

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-439] Add number of tracks in a project in headline in detail project track
 [QMS-441] "Hide invalid points" does not hide anything when 1st trackpoint has no elevation data
 [QMS-444] Fix wrong link to POI path setup in Spanish translation file
+[QMS-449] Early call to abort() in CLogHandler.cpp (Windows version)
 
 
 V1.16.0

--- a/src/qmapshack/setup/CLogHandler.cpp
+++ b/src/qmapshack/setup/CLogHandler.cpp
@@ -39,8 +39,8 @@ void CLogHandler::log(QtMsgType type, const QMessageLogContext& context, const Q
 #else
     QString txt = msg;
 #endif
-    printToConsole(type, txt);
     appendToFile(type, txt);
+    printToConsole(type, txt);
 }
 
 void CLogHandler::printLoggerInfo()


### PR DESCRIPTION
Changed order of calls

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#449

### What you have done:
[comment]: # (Describe roughly.)

As suggested by the ticket swapped the two lines of code

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [X] yes

### Is every user facing string in a tr() macro?

- [X] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [X] yes, I didn't forget to change changelog.txt
