### PR TITLE
[QMS-453] QMS crashes when first layer in TMS is <Layer idx="1">

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@ V1.XX.X
 [QMS-441] "Hide invalid points" does not hide anything when 1st trackpoint has no elevation data
 [QMS-444] Fix wrong link to POI path setup in Spanish translation file
 [QMS-449] Early call to abort() in CLogHandler.cpp (Windows version)
-
+[QMS-453] QMS crashes when first layer in TMS is <Layer idx="1">
 
 V1.16.0
 [QMS-220] "Select items from map" misses items

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -103,6 +103,16 @@ CMapTMS::CMapTMS(const QString& filename, CMapDraw* parent)
     {
         const QDomNode& xmlLayer = xmlLayers.item(n);
         int idx = xmlLayer.attributes().namedItem("idx").nodeValue().toInt();
+
+        if(idx >= layers.count())
+        {
+            QMessageBox::critical(CMainWindow::getBestWidgetForParent(), tr("Error..."), tr(
+                                      "Malformed TMS file. The layer numbers do not index "
+                                      "the available layers. Layer numbers start from index 0."
+                                      ), QMessageBox::Abort);
+            return;
+        }
+
         layers[idx].strUrl = xmlLayer.namedItem("ServerUrl").toElement().text();
         layers[idx].script = xmlLayer.namedItem("Script").toElement().text();
         layers[idx].minZoomLevel = minZoomLevel;


### PR DESCRIPTION
Check for layer index and abort with dialog.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#453

### What you have done:
[comment]: # (Describe roughly.)

Add range check for layer index.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Load TMS map with one layer and layer index 1.
* Message dialog should display a message.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
