### PR TITLE
[QM-476] Color the map by elevation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 [QMS-470] Windows build scripts: adapt for release v1.16.1
-
+|QMS-476] Color the map by elevation
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing
 [QMS-400] Set focus in text field

--- a/src/qmapshack/dem/CDemPropSetup.cpp
+++ b/src/qmapshack/dem/CDemPropSetup.cpp
@@ -57,7 +57,14 @@ CDemPropSetup::CDemPropSetup(IDem* demfile, CDemDraw* dem)
     //
     connect(checkElevationLimit, &QCheckBox::toggled, demfile, &IDem::slotSetElevationLimit);
     connect(checkElevationLimit, &QCheckBox::clicked, dem, &CDemDraw::emitSigCanvasUpdate);
-    connect(spinBoxElevationLimit, QOverload<int>::of(&QSpinBox::valueChanged), this, &CDemPropSetup::slotElevationAfterEdit);
+    connect(spinBoxElevationLimit, QOverload<int>::of(&QSpinBox::valueChanged), this, &CDemPropSetup::slotElevationValueChanged);
+
+    connect(checkElevationShading, &QCheckBox::toggled, demfile, &IDem::slotSetElevationShading);
+    connect(checkElevationShading, &QCheckBox::clicked, dem, &CDemDraw::emitSigCanvasUpdate);
+    connect(spinBoxElevationShadeLimitLow, QOverload<int>::of(&QSpinBox::valueChanged), this, &CDemPropSetup::slotElevationShadeLowValueChanged);
+    connect(spinBoxElevationShadeLimitHi, QOverload<int>::of(&QSpinBox::valueChanged), this, &CDemPropSetup::slotElevationShadeHiValueChanged);
+    connect(showElevationShadeScale, &QPushButton::toggled, demfile, &IDem::slotShowElevationShadeScale);
+    connect(showElevationShadeScale, &QPushButton::toggled, dem, &CDemDraw::emitSigCanvasUpdate);
 
     for(size_t i = 0; i < SLOPE_LEVELS; i++)
     {
@@ -66,13 +73,13 @@ CDemPropSetup::CDemPropSetup(IDem* demfile, CDemDraw* dem)
         connect(slopeSpins[i], &CTinySpinBox::valueChangedByStep, this, &CDemPropSetup::slotSlopeValiddateAfterEdit);
     }
 
-
     for(size_t i = 0; i < IDem::slopePresetCount; i++)
     {
         comboGrades->addItem(IDem::slopePresets[i].name);
     }
     comboGrades->addItem("custom");
     connect(comboGrades, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &CDemPropSetup::slotGradeIndex);
+
 
 
     const QVector<QRgb>& colortable = demfile->getSlopeColorTable();
@@ -107,6 +114,7 @@ void CDemPropSetup::slotPropertiesChanged()
 
     checkHillshading->setChecked(demfile->doHillshading());
     sliderHillshading->setValue(demfile->getFactorHillshading());
+
     checkSlopeColor->setChecked(demfile->doSlopeColor());
 
     bool spinsReadonly = true;
@@ -130,6 +138,13 @@ void CDemPropSetup::slotPropertiesChanged()
     checkElevationLimit->setChecked(demfile->doElevationLimit());
     spinBoxElevationLimit->setValue(demfile->getElevationLimit());
     spinBoxElevationLimit->setSuffix(IUnit::self().elevationUnit);
+
+    checkElevationShading->setChecked(demfile->doElevationShading());
+    spinBoxElevationShadeLimitLow->setValue(demfile->getElevationShadeLimitLow());
+    spinBoxElevationShadeLimitLow->setSuffix(IUnit::self().elevationUnit);
+    spinBoxElevationShadeLimitHi->setValue(demfile->getElevationShadeLimitHi());
+    spinBoxElevationShadeLimitHi->setSuffix(IUnit::self().elevationUnit);
+    showElevationShadeScale->setChecked(demfile->doShowElevationShadeScale());
 
     dem->emitSigCanvasUpdate();
 
@@ -200,10 +215,21 @@ void CDemPropSetup::slotGradeIndex(int idx)
     slotPropertiesChanged();
 }
 
-void CDemPropSetup::slotElevationAfterEdit()
+void CDemPropSetup::slotElevationValueChanged()
 {
     demfile->setElevationLimit(spinBoxElevationLimit->value());
 
     dem->emitSigCanvasUpdate();
 }
 
+void CDemPropSetup::slotElevationShadeLowValueChanged()
+{
+    demfile->setElevationShadeLow(spinBoxElevationShadeLimitLow->value());
+    dem->emitSigCanvasUpdate();
+}
+
+void CDemPropSetup::slotElevationShadeHiValueChanged()
+{
+    demfile->setElevationShadeHi(spinBoxElevationShadeLimitHi->value());
+    dem->emitSigCanvasUpdate();
+}

--- a/src/qmapshack/dem/CDemPropSetup.h
+++ b/src/qmapshack/dem/CDemPropSetup.h
@@ -43,7 +43,9 @@ private slots:
     void slotGradeIndex(int idx);
     void slotSlopeValiddateAfterEdit();
     void slotSlopeChanged(int val);
-    void slotElevationAfterEdit();
+    void slotElevationValueChanged();
+    void slotElevationShadeLowValueChanged();
+    void slotElevationShadeHiValueChanged();
 
 private:
     CTinySpinBox* slopeSpins[SLOPE_LEVELS];

--- a/src/qmapshack/dem/CDemVRT.h
+++ b/src/qmapshack/dem/CDemVRT.h
@@ -39,6 +39,8 @@ public:
     qreal getSlopeAt(const QPointF& pos, bool checkScale) override;
 
 private:
+    void drawElevationShadeScale(QPainter &p) const;
+
     QMutex mutex;
 
     QString filename;

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -54,7 +54,7 @@ public:
     virtual qreal getElevationAt(const QPointF& pos, bool checkScale) = 0;
     virtual qreal getSlopeAt(const QPointF& pos, bool checkScale) = 0;
 
-    bool activated()
+    bool activated() const
     {
         return isActivated;
     }
@@ -69,39 +69,59 @@ public:
      */
     virtual IDemProp* getSetup();
 
-    bool doHillshading()
+    bool doHillshading() const
     {
         return bHillshading;
     }
 
-    int getFactorHillshading();
+    int getFactorHillshading() const;
 
-    bool doSlopeColor()
+    bool doSlopeColor() const
     {
         return bSlopeColor;
     }
 
-    bool doElevationLimit()
+    bool doElevationLimit() const
     {
         return bElevationLimit;
     }
 
-    int getElevationLimit()
+    int getElevationLimit() const
     {
         return elevationValue;
     }
 
-    const QVector<QRgb> getSlopeColorTable()
+    bool doElevationShading() const
+    {
+        return bElevationShading;
+    }
+
+    int getElevationShadeLimitLow() const
+    {
+        return elevationShadeLimitLow;
+    }
+
+    int getElevationShadeLimitHi() const
+    {
+        return elevationShadeLimitHi;
+    }
+
+    const QVector<QRgb> getSlopeColorTable() const
     {
         return slopetable;
+    }
+
+    bool doShowElevationShadeScale() const
+    {
+        return bShowElevationShadeScale;
     }
 
     static const struct SlopePresets slopePresets[7];
     static const size_t slopePresetCount = sizeof(IDem::slopePresets) / sizeof(IDem::slopePresets[0]);
 
-    const qreal* getCurrentSlopeStepTable();
+    const qreal* getCurrentSlopeStepTable() const;
 
-    int getSlopeStepTableIndex()
+    int getSlopeStepTableIndex() const
     {
         return gradeSlopeColor;
     }
@@ -109,6 +129,10 @@ public:
     void setSlopeStepTable(int idx);
     void setSlopeStepTableCustomValue(int idx, int val);
     void setElevationLimit(int val);
+
+    void initElevationShadeTable();
+    void setElevationShadeLow(int val);
+    void setElevationShadeHi(int val);
 
     enum winsize_e {eWinsize3x3 = 9, eWinsize4x4 = 16};
 
@@ -130,13 +154,22 @@ public slots:
         bElevationLimit = yes;
     }
 
+    void slotSetElevationShading(bool yes)
+    {
+        bElevationShading = yes;
+    }
+
+    void slotShowElevationShadeScale(bool yes);
+
 protected:
 
-    void hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img);
+    void hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
 
-    void slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage& img);
+    void slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
 
-    void elevationLimit(QVector<qint16>& data, qreal w, qreal h, QImage& img);
+    void elevationLimit(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
+
+    void elevationShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
 
     /**
        @brief Slope in degrees based on a window. Origin is at point (1,1), counting from zero.
@@ -146,7 +179,7 @@ protected:
        @param y     Fractional value (0..1) for interpolation in y (4x4 window only)
        @return      Slope in degrees
      */
-    qreal slopeOfWindowInterp(qint16* win2, winsize_e size, qreal x, qreal y);
+    qreal slopeOfWindowInterp(qint16* win2, winsize_e size, qreal x, qreal y) const;
 
     /**
        @brief Reproject (translate, rotate, scale) tile before drawing it.
@@ -185,6 +218,8 @@ protected:
 
     QVector<QRgb> graytable;
 
+    QVector<QRgb> elevationShadeTable;
+
     QVector<QRgb> slopetable;
 
     QVector<QRgb> elevationtable;
@@ -196,12 +231,15 @@ protected:
 private:
     bool bHillshading = false;
     qreal factorHillshading = 0.1666666716337204;
-
     bool bSlopeColor = false;
     bool bElevationLimit = false;
     int gradeSlopeColor = 0;
     qreal slopeCustomStepTable[5];
     int elevationValue;
+    bool bElevationShading = false;
+    int elevationShadeLimitLow;
+    int elevationShadeLimitHi;
+    bool bShowElevationShadeScale = false;
 };
 
 #endif //IDEM_H

--- a/src/qmapshack/dem/IDemList.ui
+++ b/src/qmapshack/dem/IDemList.ui
@@ -44,6 +44,9 @@
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
      </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
      <property name="dragDropMode">
       <enum>QAbstractItemView::InternalMove</enum>
      </property>
@@ -52,6 +55,9 @@
        <width>32</width>
        <height>32</height>
       </size>
+     </property>
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
      </property>
      <attribute name="headerVisible">
       <bool>false</bool>

--- a/src/qmapshack/dem/IDemPropSetup.ui
+++ b/src/qmapshack/dem/IDemPropSetup.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>269</width>
-    <height>182</height>
+    <width>256</width>
+    <height>357</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -113,18 +113,18 @@ zoom-out for use of the DEM data.</string>
     </layout>
    </item>
    <item>
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_2">
      <property name="spacing">
       <number>3</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="checkHillshading">
-       <property name="text">
-        <string>Hillshading</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
+     <item row="1" column="1">
       <widget class="QSlider" name="sliderHillshading">
        <property name="minimum">
         <number>-8</number>
@@ -144,19 +144,37 @@ zoom-out for use of the DEM data.</string>
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QCheckBox" name="checkSlopeColor">
+      <widget class="QCheckBox" name="checkHillshading">
        <property name="text">
-        <string>Slope </string>
+        <string>Hillshading</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line_4">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_5">
+     <item row="0" column="1">
       <widget class="QComboBox" name="comboGrades">
        <property name="insertPolicy">
         <enum>QComboBox::NoInsert</enum>
        </property>
        <property name="sizeAdjustPolicy">
         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkSlopeColor">
+       <property name="text">
+        <string>Slope </string>
        </property>
       </widget>
      </item>
@@ -596,6 +614,13 @@ zoom-out for use of the DEM data.</string>
     </layout>
    </item>
    <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_3">
      <item row="0" column="1">
       <widget class="QSpinBox" name="spinBoxElevationLimit">
@@ -638,6 +663,101 @@ zoom-out for use of the DEM data.</string>
        </property>
        <property name="text">
         <string>Elevation Limit</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_4" rowstretch="0,0,0" columnstretch="0,0">
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="spinBoxElevationShadeLimitLow">
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <number>-12000</number>
+       </property>
+       <property name="maximum">
+        <number>9000</number>
+       </property>
+       <property name="value">
+        <number>200</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Elevation Low</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QSpinBox" name="spinBoxElevationShadeLimitHi">
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <number>-12000</number>
+       </property>
+       <property name="maximum">
+        <number>9000</number>
+       </property>
+       <property name="value">
+        <number>600</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkElevationShading">
+       <property name="text">
+        <string>Elevation Shading</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Elevation High</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QPushButton" name="showElevationShadeScale">
+       <property name="text">
+        <string>Legend</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Added functionality in the DEM to color the map by the elevation
values including a switchable coresponding color scale legend and
min/max elevation spinners in the DEM property dialog.
Modified the scroll setting in the DEM list to allow for proper
scrolling of the DEM property tree widget.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#476

### What you have done:
[comment]: (Describe roughly.)
I've implemented the code that enables to color the map by elevation. Everything was implemented within the DEM folder.
Changed the scroll policy in the DEM list / property setup widget for a proper scrolling to enable that all widgets can be 
accessed properly. 

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open DEM Properties
2. Enable Elevation Shading check box and change elevation limits / toggle legend.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
