### PR TITLE
[QMS-483] Add alpha transparency based hillshading

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 [QMS-470] Windows build scripts: adapt for release v1.16.1
 |QMS-476] Color the map by elevation
+[QMS-483] Add alpha transparency based hillshading
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing
 [QMS-400] Set focus in text field

--- a/src/qmapshack/dem/CDemPropSetup.cpp
+++ b/src/qmapshack/dem/CDemPropSetup.cpp
@@ -50,6 +50,11 @@ CDemPropSetup::CDemPropSetup(IDem* demfile, CDemDraw* dem)
     connect(sliderHillshading, &QSlider::valueChanged, demfile, &IDem::slotSetFactorHillshade);
     connect(sliderHillshading, &QSlider::valueChanged, dem, &CDemDraw::emitSigCanvasUpdate);
 
+    connect(checkSlopeShading, &QCheckBox::toggled, demfile, &IDem::slotSetSlopeShading);
+    connect(checkSlopeShading, &QCheckBox::clicked, dem, &CDemDraw::emitSigCanvasUpdate);
+    connect(sliderSlopeShading, &QSlider::valueChanged, demfile, &IDem::slotSetFactorSlopeShade);
+    connect(sliderSlopeShading, &QSlider::valueChanged, dem, &CDemDraw::emitSigCanvasUpdate);
+
     connect(checkSlopeColor, &QCheckBox::toggled, demfile, &IDem::slotSetSlopeColor);
     connect(checkSlopeColor, &QCheckBox::clicked, dem, &CDemDraw::emitSigCanvasUpdate);
 
@@ -114,6 +119,8 @@ void CDemPropSetup::slotPropertiesChanged()
 
     checkHillshading->setChecked(demfile->doHillshading());
     sliderHillshading->setValue(demfile->getFactorHillshading());
+    checkSlopeShading->setChecked(demfile->doSlopeShading());
+    sliderSlopeShading->setValue(demfile->getFactorSlopeShading());
 
     checkSlopeColor->setChecked(demfile->doSlopeColor());
 

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -222,7 +222,7 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
     QPointF bufferScale = buf.scale * buf.zoomFactor;
     outOfScale = isOutOfScale(bufferScale);
 
-    if(outOfScale || (!doHillshading() && !doSlopeColor() && !doElevationLimit() && !doElevationShading()))
+    if(outOfScale || (!doHillshading() && !doSlopeShading() && !doSlopeColor() && !doElevationLimit() && !doElevationShading()))
     {
         QThread::msleep(100);
         return;
@@ -381,6 +381,17 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
                     img.setColorTable(graytable);
 
                     hillshading(data, w_used, h_used, img);
+
+                    drawTile(img, r, p);
+                }
+
+                if(doSlopeShading())
+                {
+                    QPolygonF r = l;
+
+                    QImage img(w_used, h_used, QImage::Format_Alpha8);
+
+                    slopeShading(data, w_used, h_used, img);
 
                     drawTile(img, r, p);
                 }

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -76,6 +76,13 @@ public:
 
     int getFactorHillshading() const;
 
+    bool doSlopeShading() const
+    {
+        return bSlopeShading;
+    }
+
+    int getFactorSlopeShading() const;
+
     bool doSlopeColor() const
     {
         return bSlopeColor;
@@ -144,6 +151,14 @@ public slots:
 
     void slotSetFactorHillshade(int f);
 
+
+    void slotSetSlopeShading(bool yes)
+    {
+        bSlopeShading = yes;
+    }
+
+    void slotSetFactorSlopeShade(int f);
+
     void slotSetSlopeColor(bool yes)
     {
         bSlopeColor = yes;
@@ -164,6 +179,8 @@ public slots:
 protected:
 
     void hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
+
+    void slopeShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
 
     void slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
 
@@ -231,6 +248,8 @@ protected:
 private:
     bool bHillshading = false;
     qreal factorHillshading = 0.1666666716337204;
+    bool bSlopeShading = false;
+    qreal factorSlopeShading = 1.0;
     bool bSlopeColor = false;
     bool bElevationLimit = false;
     int gradeSlopeColor = 0;

--- a/src/qmapshack/dem/IDemPropSetup.ui
+++ b/src/qmapshack/dem/IDemPropSetup.ui
@@ -124,6 +124,13 @@ zoom-out for use of the DEM data.</string>
      <property name="spacing">
       <number>3</number>
      </property>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="checkHillshading">
+       <property name="text">
+        <string>Hillshading</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="1">
       <widget class="QSlider" name="sliderHillshading">
        <property name="minimum">
@@ -143,10 +150,32 @@ zoom-out for use of the DEM data.</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="checkHillshading">
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="checkSlopeShading">
        <property name="text">
-        <string>Hillshading</string>
+        <string>Slope Shading</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QSlider" name="sliderSlopeShading">
+       <property name="minimum">
+        <number>25</number>
+       </property>
+       <property name="maximum">
+        <number>300</number>
+       </property>
+       <property name="singleStep">
+        <number>25</number>
+       </property>
+       <property name="pageStep">
+        <number>25</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -161,6 +190,13 @@ zoom-out for use of the DEM data.</string>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_5">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkSlopeColor">
+       <property name="text">
+        <string>Slope </string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="QComboBox" name="comboGrades">
        <property name="insertPolicy">
@@ -168,13 +204,6 @@ zoom-out for use of the DEM data.</string>
        </property>
        <property name="sizeAdjustPolicy">
         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="checkSlopeColor">
-       <property name="text">
-        <string>Slope </string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#483

### What you have done:
[comment]: # (Describe roughly.)
Added alpha transparency based slope shading layer where slope angle is mapped to transpareny.
Slope angle is evaluated using already implemented algorithm.
Layer at slope angle 0 degrees is fully transparent, layer at slope angle 90 degrees is fully opaque.
Slider may reduce slope angle down to 30 degrees where layer is fully opaque.



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open window Dig. Elev. Model (DEM)
2. Open VRT entry
3. Check _Slope Shading_ checkbutton
4. Position corresponding slider at the left side
Scaling factor is now 0.25 and slope relief 's opacity is at it's minimum.
5. Move corresponding slider to the right side
Slope relief becomes more and more stronger and slopes are becoming more opaque (darker).
6. Position corresponding slider at the right side
Scaling factor is now 3.0 and slope angles equal to or greater than 30 degrees are mapped to fully opaque.
7. Position corresponding slider 3 steps from left side
Scaling factor is now 1.0 and slope angle range from 0 to 90 degrees is mapped exactly from fully transparent to fully opaque.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
