### PR TITLE
[QMS-490] Potentially incorrect slope shading opacity for slope value NOFLOAT

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 |QMS-476] Color the map by elevation
 [QMS-483] Add alpha transparency based hillshading
 [QMS-487] Add tooltips for DEM controls
+[QMS-490] Potentially incorrect slope shading opacity for slope value NOFLOAT
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -327,11 +327,17 @@ void IDem::slopeShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) co
             }
 
             qreal slope = slopeOfWindowInterp(win, eWinsize3x3, 0, 0);
-            int alphaValue = slope * 255./90. // map slope angle to alpha [0 .. 255]
-                           * factorSlopeShading; // apply slider value [0.25 .. 3.0]
-            if (alphaValue > 255) alphaValue = 255;
-
-            scan[n - 1] = alphaValue;
+            if(slope == NOFLOAT)
+            {
+                scan[n - 1] = 0;
+            }
+            else
+            {
+                int alphaValue = slope * 255./90. // map slope angle to alpha [0 .. 255]
+                               * factorSlopeShading; // apply slider value [0.25 .. 3.0]
+                if (alphaValue > 255) alphaValue = 255;
+                scan[n - 1] = alphaValue;
+            }
         }
     }
 }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#490

### What you have done:
[comment]: # (Describe roughly.)
Calculation of the slope value can result in value NOFLOAT depending on DEM data. Case was unhandled before.
Expanded slope shading opacity calculation by mapping slope value NOFLOAT to alpha value 0 i.e. fully transparent.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Enable slope shading
2. Move map window's position to boundary of available DEM data.
3. Slope shading layer without DEM data should be fully transparent.
4. Slope calculation exactly on boundary of DEM data may be impossible due to missing elevation data outside of boundary. Therefore slope shading layer on boundary of DEM data should be fully transparent

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
