### PR TITLE
[QMS-489] Track selection 0-index bug

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 |QMS-476] Color the map by elevation
 [QMS-483] Add alpha transparency based hillshading
 [QMS-487] Add tooltips for DEM controls
+[QMS-489] Track selection 0-index bug
 [QMS-490] Potentially incorrect slope shading opacity for slope value NOFLOAT
 
 V1.16.1

--- a/src/qmapshack/mouse/range/CScrOptRangeTool.cpp
+++ b/src/qmapshack/mouse/range/CScrOptRangeTool.cpp
@@ -68,10 +68,10 @@ CScrOptRangeTool::CScrOptRangeTool(CGisItemTrk& trk, CMouseRangeTrk* mouse, CCan
     slotCanvasResize(canvas->size());
     show();
 
-    connect(toolBegDn, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.incMouseRangeBegin(-1, owner);});
-    connect(toolBegUp, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.incMouseRangeBegin(+1, owner);});
-    connect(toolEndDn, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.incMouseRangeEnd(-1, owner);});
-    connect(toolEndUp, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.incMouseRangeEnd(+1, owner);});
+    connect(toolBegDn, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.decMouseRangeBegin(1, owner);});
+    connect(toolBegUp, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.incMouseRangeBegin(1, owner);});
+    connect(toolEndDn, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.decMouseRangeEnd(1, owner);});
+    connect(toolEndUp, &QToolButton::pressed, this, [this](){updateCanvas = true; this->trk.incMouseRangeEnd(1, owner);});
 
     connect(toolBegDn, &QToolButton::released, this, &CScrOptRangeTool::slotResetUpdateCanvas);
     connect(toolBegUp, &QToolButton::released, this, &CScrOptRangeTool::slotResetUpdateCanvas);
@@ -235,9 +235,9 @@ void CScrOptRangeTool::slotCopy()
 
 void CScrOptRangeTool::slotToRoute()
 {
-  QMutexLocker lock(&IGisItem::mutexItems);
-  trk.toRoute();
-  canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawGis);
+    QMutexLocker lock(&IGisItem::mutexItems);
+    trk.toRoute();
+    canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawGis);
 }
 
 void CScrOptRangeTool::slotDelete()


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#489

### What you have done:
[comment]: # (Describe roughly.)

Use the internal API to decrement the selection. 

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Perform steps from ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
