### PR TITLE
[QMS-499] Disable Close action for projects with autom. sync. to device

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,11 @@
+V1.XX.X
 [QMS-470] Windows build scripts: adapt for release v1.16.1
 |QMS-476] Color the map by elevation
 [QMS-483] Add alpha transparency based hillshading
 [QMS-487] Add tooltips for DEM controls
 [QMS-489] Track selection 0-index bug
 [QMS-490] Potentially incorrect slope shading opacity for slope value NOFLOAT
+[QMS-499] Disable close action for projects with autom. sync. to device
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -1310,6 +1310,7 @@ void CGisListWks::slotContextMenu(const QPoint& point)
                     actionUserFocusPrj->setChecked(hasUserFocus);
                     const QIcon& icon = hasUserFocus ? QIcon("://icons/32x32/Focus.png") : QIcon("://icons/32x32/UnFocus.png");
                     actionUserFocusPrj->setIcon(icon);
+                    actionCloseProj->setEnabled(!autoSyncToDev);
                     showMenuProjectWks(p);
                 }
             }
@@ -2472,7 +2473,7 @@ void CGisListWks::slotToRoute()
 {
     CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-    CGisItemTrk *gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+    CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
     if(gisItem != nullptr)
     {
         CGisWorkspace::self().convertTrackToRoute(gisItem->getKey());


### PR DESCRIPTION
Those projects can't be closed.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#499

### What you have done:
[comment]: # (Describe roughly.)

Simply set the enable state according to the autom. sync to device state.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open several projects
2. Set one to "autom. sync. w. device"
3. Right click on project: "Close" disabled
4. Right click on other project: "Close" enabled
5. Group select projects: "Close" is enabled/disabled according to the first selected project

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
