### PR TITLE
[QMS-429] Bad OSM Tag formatting crashes QMS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-429] Bad OSM Tag formatting crashes QMS
 [QMS-470] Windows build scripts: adapt for release v1.16.1
 |QMS-476] Color the map by elevation
 [QMS-483] Add alpha transparency based hillshading

--- a/src/qmapshack/poi/CRawPoi.cpp
+++ b/src/qmapshack/poi/CRawPoi.cpp
@@ -25,22 +25,36 @@
 CRawPoi::CRawPoi(const QStringList& data, const QPointF& coordinates, const quint64& key, const QString& category, const QString& garminIcon)
     : category(category), coordinates(coordinates), rawData(data), garminIcon(garminIcon), key(key)
 {
+    QString lastValidKey = "";
     for(const QString& line : data)
     {
         const QStringList& keyValue = line.split("=");
-        if(keyValue[0].contains("wikipedia", Qt::CaseInsensitive))
+        if (keyValue.length() == 1)
         {
-            wikipediaRelatedKeys += keyValue[0];
+            this->data[lastValidKey] += line;
         }
-        if(keyValue[0].contains("wikidata", Qt::CaseInsensitive))
+        else if(keyValue.length() > 2)
         {
-            wikidataRelatedKeys += keyValue[0];
+            // facilitate debuging in case the line separateion changes in future and all lines are interpreted as one
+            qWarning() << "Encountered line with multiple key-value assignments: " + line;
         }
-        if(keyValue[0] == "name" || keyValue[0].contains("name:\\w\\w", Qt::CaseInsensitive) || keyValue[0].contains(QRegularExpression("[A-z]+_name")))
+        else
         {
-            nameRelatedKeys += keyValue[0];
+            if(keyValue[0].contains("wikipedia", Qt::CaseInsensitive))
+            {
+                wikipediaRelatedKeys += keyValue[0];
+            }
+            if(keyValue[0].contains("wikidata", Qt::CaseInsensitive))
+            {
+                wikidataRelatedKeys += keyValue[0];
+            }
+            if(keyValue[0] == "name" || keyValue[0].contains("name:\\w\\w", Qt::CaseInsensitive) || keyValue[0].contains(QRegularExpression("[A-z]+_name")))
+            {
+                nameRelatedKeys += keyValue[0];
+            }
+            this->data[keyValue[0]] = keyValue[1];
+            lastValidKey = keyValue[0];
         }
-        this->data[keyValue[0]] = keyValue[1];
     }
 
     //find name


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#429

### What you have done:
[comment]: # (Describe roughly.)

- fix the bug described in the issue
- implement warning for other unexpected cases

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Edit poi file so that a poi data column contains a line with no `=` sign. Make sure the line breaks are CR (hex: 0d)
2. Activate the poi file and the according category and center on the poi
3. see that QMS no longer crashes.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
