### PR TITLE
[QMS-507] QMapTool: Early projection validity check

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-489] Track selection 0-index bug
 [QMS-490] Potentially incorrect slope shading opacity for slope value NOFLOAT
 [QMS-499] Disable close action for projects with autom. sync. to device
+[QMS-507] QMapTool: Early projection validity check 
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmaptool/overlay/refmap/CProjWizard.cpp
+++ b/src/qmaptool/overlay/refmap/CProjWizard.cpp
@@ -211,6 +211,11 @@ void CProjWizard::accept()
 
 bool CProjWizard::validProjStr(const QString projStr)
 {
+    if(projStr.isEmpty())
+    {
+        return false;
+    }
+
     return CProj::validProjStr(projStr, true, [](const QString& msg){
         QMessageBox::warning(&CMainWindow::self(), tr("Error..."), msg, QMessageBox::Abort, QMessageBox::Abort);
     });


### PR DESCRIPTION
Check for empty string and stop bfore the the bla bla starts

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#507

### What you have done:
[comment]: # (Describe roughly.)

Check for empty projection  string and abort validity check  before the the bla bla starts


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use instructions from ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
