### PR TITLE
[QMS-503] fix brouter local setup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-489] Track selection 0-index bug
 [QMS-490] Potentially incorrect slope shading opacity for slope value NOFLOAT
 [QMS-499] Disable close action for projects with autom. sync. to device
+[QMS-503] BRouter Version 1.6.3 local setup fails
 [QMS-507] QMapTool: Early projection validity check 
 
 V1.16.1

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
@@ -153,13 +153,11 @@ void CRouterBRouterLocal::getBRouterVersion() const
     {
         QProcess cmd;
 
-        QStringList args;
-        args << "-cp";
-        args << "brouter.jar";
-        args << "btools.server.RouteServer";
-
         cmd.setWorkingDirectory(brouter.setup->localDir);
-        cmd.start(brouter.setup->localJavaExecutable, args);
+        cmd.start(brouter.setup->localJavaExecutable,
+                  { "-cp",
+                    brouter.setup->localBRouterJar,
+                    "btools.server.RouteServer" } );
 
         cmd.waitForStarted();
         if (!cmd.waitForFinished(3000))

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
@@ -68,7 +68,7 @@ void CRouterBRouterLocal::startBRouter()
             args << brouter.setup->localJavaOpts.split(QRegExp("\\s+"));
             args << QString("-DmaxRunningTime=%1").arg(brouter.setup->localMaxRunningTime);
             args << "-cp";
-            args << "brouter.jar";
+            args << brouter.setup->localBRouterJar;
             args << "btools.server.RouteServer";
             args << brouter.setup->localSegmentsDir;
             args << brouter.setup->localProfileDir;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -346,16 +346,15 @@ QDir CRouterBRouterSetup::getDownloadDir() const
 
 void CRouterBRouterSetup::installLocalBRouter(QStringList& messageList)
 {
-    const QDir targetDir = QDir(localDir);
-    const QDir targetProfileDir = getProfileDir(eModeLocal);
-    const QString srcPath = getDownloadDir().absolutePath();
+    const QDir targetDir(localDir);
+    const QDir& targetProfileDir = getProfileDir(eModeLocal);
+    const QString& srcPath = getDownloadDir().absolutePath();
     QDirIterator srcIterator(srcPath, {"*.jar","*.brf","lookups.dat"}, QDir::Files, QDirIterator::Subdirectories);
     QStringList jarFiles;
     while(srcIterator.hasNext())
     {
-        QFile srcFile(srcIterator.next());
-        QFileInfo srcFileInfo(srcFile);
-        QString srcFileName = srcFileInfo.fileName();
+        QFileInfo srcFileInfo(srcIterator.next());
+        const QString& srcFileName = srcFileInfo.fileName();
         if (srcFileName.endsWith(".jar"))
         {
             jarFiles.append(srcFileName);
@@ -375,7 +374,7 @@ void CRouterBRouterSetup::installLocalBRouter(QStringList& messageList)
     else
     {
         bool isFirst = true;
-        for (QString jarFile : jarFiles)
+        for (const QString& jarFile : jarFiles)
         {
             if (isFirst)
             {
@@ -393,13 +392,13 @@ void CRouterBRouterSetup::installLocalBRouter(QStringList& messageList)
 
 void CRouterBRouterSetup::installLocalBRouterFile(const QFileInfo& srcFileInfo, const QDir& targetDir, QStringList& messageList) const
 {
-    QString srcAbsoluteFilePath = srcFileInfo.absoluteFilePath();
-    QString targetAbsoluteFilePath(targetDir.absoluteFilePath(srcFileInfo.fileName()));
+    const QString& srcAbsoluteFilePath = srcFileInfo.absoluteFilePath();
+    const QString& targetAbsoluteFilePath = targetDir.absoluteFilePath(srcFileInfo.fileName());
     if (QFile::exists(targetAbsoluteFilePath))
     {
         for (int i=1;;i++)
         {
-            QString newFilename = targetAbsoluteFilePath+"("+QString::number(i)+")";
+            const QString& newFilename = targetAbsoluteFilePath+"."+QString::number(i);
             if (QFile::exists(newFilename))
                 continue;
             if (QFile::rename(targetAbsoluteFilePath, newFilename))
@@ -804,8 +803,8 @@ void CRouterBRouterSetup::loadOnlineProfileFinished(QNetworkReply* reply)
     const QByteArray& content = reply->readAll();
     if (mode == eProfileInstall)
     {
-        const QDir dir = getProfileDir(eModeLocal);
-        const QString filename = dir.absoluteFilePath(profile + ".brf");
+        const QDir& dir = getProfileDir(eModeLocal);
+        const QString& filename = dir.absoluteFilePath(profile + ".brf");
         QFile file(filename);
         file.open(QIODevice::WriteOnly);
         file.write(content);
@@ -831,7 +830,7 @@ bool CRouterBRouterSetup::isLocalBRouterInstalled() const
 bool CRouterBRouterSetup::isLocalBRouterCandidate() const
 {
     const QDir dir(localDir);
-    const QStringList jarFiles = dir.entryList({"*.jar"}, QDir::Files, QDir::NoSort);
+    const QStringList& jarFiles = dir.entryList({"*.jar"}, QDir::Files, QDir::NoSort);
     const QDir profileDir(dir.absoluteFilePath(localProfileDir));
     const QFile lookupFile(profileDir.absoluteFilePath("lookups.dat"));
     return !jarFiles.isEmpty() && profileDir.exists() && lookupFile.exists();

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
@@ -45,6 +45,7 @@ public:
     void resetOnlineConfigUrl() { expertConfigUrl = defaultConfigUrl; }
     void resetOnlineServiceUrl() { onlineServiceUrl = defaultOnlineServiceUrl; }
     void resetOnlineProfilesUrl() { onlineProfilesUrl = defaultOnlineProfilesUrl; }
+    void resetLocalBRouterJar() { localBRouterJar = defaultLocalBRouterJar; }
     void resetLocalProfileDir() { localProfileDir = defaultLocalProfileDir; }
     void resetLocalCustomProfileDir() { localCustomProfileDir = defaultLocalCustomProfileDir; }
     void resetLocalSegmentsDir() { localSegmentsDir = defaultLocalSegmentsDir; }
@@ -76,6 +77,7 @@ public:
 
     QString findJava() const;
     bool isLocalBRouterInstalled() const;
+    bool isLocalBRouterCandidate() const;
     bool isLocalBRouterDefaultDir() const;
 
     QUrl getServiceUrl() const;
@@ -105,6 +107,9 @@ private:
     enum profileRequest_e { eProfileInstall, eProfileDisplay };
 
     QDir getProfileDir(const mode_e mode) const;
+    QDir getDownloadDir() const;
+    void installLocalBRouter(QStringList& messageList);
+    void installLocalBRouterFile(const QFileInfo& srcFileInfo, const QDir& targetDir, QStringList& messageList) const;
     void loadOnlineProfileAsync(const QString& profile, const profileRequest_e mode) const;
     void loadOnlineConfigFinished(QNetworkReply* reply);
     void loadOnlineVersionFinished(QNetworkReply* reply);
@@ -130,6 +135,7 @@ private:
     QStringList onlineProfilesAvailable;
     QString localDir;
     QString localJavaExecutable;
+    QString localBRouterJar;
     QString localProfileDir;
     QString localCustomProfileDir;
     QString localSegmentsDir;
@@ -152,6 +158,7 @@ private:
     const QString defaultOnlineServiceUrl = "https://brouter.de";
     const QString defaultOnlineProfilesUrl = "https://brouter.de/brouter/profiles2/";
     const QString defaultLocalDir = ".";
+    const QString defaultLocalBRouterJar = "brouter.jar";
     const QString defaultLocalProfileDir = "profiles2";
     const QString defaultLocalCustomProfileDir = "customprofiles";
     const QString defaultLocalSegmentsDir = "segments4";
@@ -164,7 +171,8 @@ private:
     const QString defaultBinariesUrl = "https://brouter.de/brouter_bin/";
     const QString defaultSegmentsUrl = "https://brouter.de/brouter/segments4/";
 
-    const QString onlineCacheDir = "BRouter";
+    const QString onlineProfileCacheDir = "BRouterProfiles";
+    const QString downloadCacheDir = "BRouterDownload";
 
     friend class CRouterBRouter;
     friend class CRouterBRouterLocal;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
@@ -113,6 +113,8 @@ private:
     QDir getDownloadDir() const;
     void installLocalBRouter(QStringList& messageList);
     void installLocalBRouterFile(const QFileInfo& srcFileInfo, const QDir& targetDir, QStringList& messageList) const;
+    bool tryJavaVersion(const QStringList& arguments,const QString& pattern);
+    bool parseJavaVersion(const QString& javaOutput, QRegularExpression& re);
     void loadOnlineProfileAsync(const QString& profile, const profileRequest_e mode) const;
     void loadOnlineConfigFinished(QNetworkReply* reply);
     void loadOnlineVersionFinished(QNetworkReply* reply);

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
@@ -154,25 +154,25 @@ private:
 
     const bool defaultExpertMode = false;
     const mode_e defaultInstallMode = eModeOnline;
-    const QString defaultConfigUrl = "https://brouter.de/brouter-web/config.js";
-    const QString defaultOnlineServiceUrl = "https://brouter.de";
-    const QString defaultOnlineProfilesUrl = "https://brouter.de/brouter/profiles2/";
-    const QString defaultLocalDir = ".";
-    const QString defaultLocalBRouterJar = "brouter.jar";
-    const QString defaultLocalProfileDir = "profiles2";
-    const QString defaultLocalCustomProfileDir = "customprofiles";
-    const QString defaultLocalSegmentsDir = "segments4";
-    const QString defaultLocalHost = "127.0.0.1";
-    const QString defaultLocalPort = "17777";
+    static constexpr const char * defaultConfigUrl = "https://brouter.de/brouter-web/config.js";
+    static constexpr const char * defaultOnlineServiceUrl = "https://brouter.de";
+    static constexpr const char * defaultOnlineProfilesUrl = "https://brouter.de/brouter/profiles2/";
+    static constexpr const char * defaultLocalDir = ".";
+    static constexpr const char * defaultLocalBRouterJar = "brouter.jar";
+    static constexpr const char * defaultLocalProfileDir = "profiles2";
+    static constexpr const char * defaultLocalCustomProfileDir = "customprofiles";
+    static constexpr const char * defaultLocalSegmentsDir = "segments4";
+    static constexpr const char * defaultLocalHost = "127.0.0.1";
+    static constexpr const char * defaultLocalPort = "17777";
     const bool defaultLocalBindLocalonly = true;
-    const QString defaultLocalNumberThreads = "1";
-    const QString defaultLocalMaxRunningTime = "300";
-    const QString defaultLocalJavaOpts = "-Xmx128M -Xms128M -Xmn8M";
-    const QString defaultBinariesUrl = "https://brouter.de/brouter_bin/";
-    const QString defaultSegmentsUrl = "https://brouter.de/brouter/segments4/";
+    static constexpr const char * defaultLocalNumberThreads = "1";
+    static constexpr const char * defaultLocalMaxRunningTime = "300";
+    static constexpr const char * defaultLocalJavaOpts = "-Xmx128M -Xms128M -Xmn8M";
+    static constexpr const char * defaultBinariesUrl = "https://brouter.de/brouter_bin/";
+    static constexpr const char * defaultSegmentsUrl = "https://brouter.de/brouter/segments4/";
 
-    const QString onlineProfileCacheDir = "BRouterProfiles";
-    const QString downloadCacheDir = "BRouterDownload";
+    static constexpr const char * onlineProfileCacheDir = "BRouterProfiles";
+    static constexpr const char * downloadCacheDir = "BRouterDownload";
 
     friend class CRouterBRouter;
     friend class CRouterBRouterLocal;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
@@ -45,7 +45,7 @@ public:
     void resetOnlineConfigUrl() { expertConfigUrl = defaultConfigUrl; }
     void resetOnlineServiceUrl() { onlineServiceUrl = defaultOnlineServiceUrl; }
     void resetOnlineProfilesUrl() { onlineProfilesUrl = defaultOnlineProfilesUrl; }
-    void resetLocalBRouterJar() { localBRouterJar = defaultLocalBRouterJar; }
+    void resetLocalBRouterJar() { setLocalBRouterJar(defaultLocalBRouterJar); }
     void resetLocalProfileDir() { localProfileDir = defaultLocalProfileDir; }
     void resetLocalCustomProfileDir() { localCustomProfileDir = defaultLocalCustomProfileDir; }
     void resetLocalSegmentsDir() { localSegmentsDir = defaultLocalSegmentsDir; }
@@ -75,7 +75,9 @@ public:
     void displayProfileAsync(const QString& profile);
     void displayOnlineProfileAsync(const QString& profile) const;
 
+    void setJava(const QString& path);
     QString findJava() const;
+    void setLocalBRouterJar(const QString& path);
     bool isLocalBRouterInstalled() const;
     bool isLocalBRouterCandidate() const;
     bool isLocalBRouterDefaultDir() const;
@@ -86,6 +88,7 @@ public:
     QString getConfigUrl() const;
 
     void parseBRouterVersion(const QString& text);
+    void parseJavaVersion(const QString& text);
 
     void onInvalidSetup();
 
@@ -151,6 +154,9 @@ private:
     int versionMajor { NOINT };
     int versionMinor { NOINT };
     int versionPatch { NOINT };
+
+    int javaMajorVersion  { NOINT };
+    int classMajorVersion { NOINT };
 
     const bool defaultExpertMode = false;
     const mode_e defaultInstallMode = eModeOnline;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
@@ -361,7 +361,7 @@ void CRouterBRouterSetupWizard::slotLocalToolSelectBRouterJar()
     if (dialog.exec())
     {
         const QStringList& files = dialog.selectedFiles();
-        setup->localBRouterJar = files.isEmpty() ? "" : QFileInfo(files.first()).fileName();
+        setup->setLocalBRouterJar(files.isEmpty() ? "" : QFileInfo(files.first()).fileName());
         updateLocalDirectory();
     }
 }
@@ -376,14 +376,14 @@ void CRouterBRouterSetupWizard::slotLocalToolSelectJava()
     if (dialog.exec())
     {
         const QStringList& files = dialog.selectedFiles();
-        setup->localJavaExecutable = files.isEmpty() ? "" : files.first();
+        setup->setJava(files.isEmpty() ? "" : files.first());
         updateLocalDirectory();
     }
 }
 
 void CRouterBRouterSetupWizard::slotLocalPushFindJava() const
 {
-    setup->localJavaExecutable = setup->findJava();
+    setup->setJava(setup->findJava());
     updateLocalDirectory();
 }
 
@@ -395,13 +395,13 @@ void CRouterBRouterSetupWizard::slotLocalDirectoryEdited() const
 
 void CRouterBRouterSetupWizard::slotLocalBRouterJarEdited() const
 {
-    setup->localBRouterJar = lineLocalBRouterJar->text();
+    setup->setLocalBRouterJar(lineLocalBRouterJar->text());
     updateLocalDirectory();
 }
 
 void CRouterBRouterSetupWizard::slotLocalJavaExecutableEdited() const
 {
-    setup->localJavaExecutable = lineJavaExecutable->text();
+    setup->setJava(lineJavaExecutable->text());
     updateLocalDirectory();
 }
 
@@ -420,11 +420,21 @@ void CRouterBRouterSetupWizard::updateLocalDirectory() const
         {
             lineLocalBRouterJar->setText(setup->localBRouterJar);
         }
+        if (setup->classMajorVersion == NOINT)
+        {
+            labelLocalBRouterResult->setVisible(true);
+            labelLocalBRouterResult->setText(tr("is not a valid BRouter jarfile"));
+        }
+        else
+        {
+            labelLocalBRouterResult->setVisible(false);
+        }
     }
     else
     {
         lineLocalBRouterJar->setVisible(false);
         toolLocalBRouterJar->setVisible(false);
+        labelLocalBRouterResult->setVisible(false);
     }
     if (lineJavaExecutable->text() != setup->localJavaExecutable)
     {
@@ -445,7 +455,9 @@ void CRouterBRouterSetupWizard::updateLocalDirectory() const
     {
         if (setup->isLocalBRouterInstalled())
         {
-            labelLocalDirResult->setText(tr("existing BRouter installation"));
+            labelLocalDirResult->setText(
+                        tr("existing BRouter installation (requires minimum Java version: %1)")
+                        .arg(QString::number(setup->classMajorVersion)));
             pushCreateOrUpdateLocalInstall->setText(tr("update existing BRouter installation"));
             pushCreateOrUpdateLocalInstall->setVisible(true);
         }
@@ -464,7 +476,10 @@ void CRouterBRouterSetupWizard::updateLocalDirectory() const
     {
         if (QFileInfo(setup->localJavaExecutable).baseName().startsWith("java"))
         {
-            labelLocalJavaResult->setText(tr("seems to be a valid Java-executable"));
+            labelLocalJavaResult->setText(
+                        tr("seems to be a valid Java-executable. (Java version: %1)")
+                        .arg(setup->javaMajorVersion == NOINT
+                             ? "unknown" : QString::number(setup->javaMajorVersion)));
         }
         else
         {

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
@@ -455,9 +455,7 @@ void CRouterBRouterSetupWizard::updateLocalDirectory() const
     {
         if (setup->isLocalBRouterInstalled())
         {
-            labelLocalDirResult->setText(
-                        tr("existing BRouter installation (requires minimum Java version: %1)")
-                        .arg(QString::number(setup->classMajorVersion)));
+            labelLocalDirResult->setText(tr("existing BRouter installation"));
             pushCreateOrUpdateLocalInstall->setText(tr("update existing BRouter installation"));
             pushCreateOrUpdateLocalInstall->setVisible(true);
         }
@@ -476,10 +474,18 @@ void CRouterBRouterSetupWizard::updateLocalDirectory() const
     {
         if (QFileInfo(setup->localJavaExecutable).baseName().startsWith("java"))
         {
-            labelLocalJavaResult->setText(
-                        tr("seems to be a valid Java-executable. (Java version: %1)")
-                        .arg(setup->javaMajorVersion == NOINT
-                             ? "unknown" : QString::number(setup->javaMajorVersion)));
+            labelLocalJavaResult->setText(tr("seems to be a valid Java-executable"));
+            if (setup->isLocalBRouterInstalled() && (setup->javaMajorVersion == NOINT || setup->javaMajorVersion < setup->classMajorVersion))
+            {
+                textLocalDirectory->setVisible(true);
+                textLocalDirectory->setTextColor(Qt::red);
+                textLocalDirectory->setText(
+                        tr( "Your Java version %1 seems to be older than the required version %2.\n"
+                            "BRouter will probably not work as expected.\n"
+                            "Please check the logs if Brouter fails to start." )
+                        .arg(setup->javaMajorVersion == NOINT ? tr("unknown") : QString::number(setup->javaMajorVersion))
+                        .arg(setup->classMajorVersion));
+            }
         }
         else
         {

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
@@ -594,7 +594,7 @@ void CRouterBRouterSetupWizard::slotLocalDownloadButtonFinished(QNetworkReply* r
             throw tr("Network Error: %1").arg(reply->errorString());
         }
         const QString& fileName = reply->property("fileName").toString();
-        QDir outDir(setup->localDir);
+        const QDir outDir(setup->localDir);
         if (!outDir.exists())
         {
             throw tr("Error directory %1 does not exist").arg(outDir.absolutePath());
@@ -753,7 +753,7 @@ void CRouterBRouterSetupWizard::updateProfiles() const
     }
 
     QList<int> selected = updateProfileView(listProfiles, profiles);
-    qSort(selected.begin(), selected.end());
+    std::sort(selected.begin(), selected.end());
     toolDeleteProfile->setEnabled(!selected.isEmpty());
     toolProfileUp->setEnabled(!selected.isEmpty() && selected.first() > 0);
     toolProfileDown->setEnabled(!selected.isEmpty() && selected.last() < profiles.size() - 1);

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.h
@@ -51,10 +51,12 @@ private slots:
     void slotRadioOnlineClicked() const;
     void slotCheckExpertClicked() const;
     void slotLocalToolSelectDirectory();
+    void slotLocalToolSelectBRouterJar();
     void slotLocalToolSelectJava();
     void slotLocalPushFindJava() const;
     void slotCreateOrUpdateLocalInstallClicked();
     void slotLocalDirectoryEdited() const;
+    void slotLocalBRouterJarEdited() const;
     void slotLocalJavaExecutableEdited() const;
     void slotProfilesUrlEdited();
     void slotOnlineServiceUrlEdited();

--- a/src/qmapshack/gis/rte/router/brouter/IRouterBRouterSetupWizard.ui
+++ b/src/qmapshack/gis/rte/router/brouter/IRouterBRouterSetupWizard.ui
@@ -142,6 +142,13 @@
      </layout>
     </item>
     <item>
+     <widget class="QLabel" name="labelLocalBRouterResult">
+      <property name="text">
+       <string>labelLocalBRouterResult</string>
+      </property>
+     </widget>
+    </item>
+    <item>
      <layout class="QHBoxLayout" name="horizontalLayout_4">
       <item>
        <widget class="QPushButton" name="pushCreateOrUpdateLocalInstall">

--- a/src/qmapshack/gis/rte/router/brouter/IRouterBRouterSetupWizard.ui
+++ b/src/qmapshack/gis/rte/router/brouter/IRouterBRouterSetupWizard.ui
@@ -124,6 +124,24 @@
      </widget>
     </item>
     <item>
+     <layout class="QHBoxLayout" name="layoutLocalBRouter">
+      <item>
+       <widget class="QLineEdit" name="lineLocalBRouterJar"/>
+      </item>
+      <item>
+       <widget class="QToolButton" name="toolLocalBRouterJar">
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../../resources.qrc">
+          <normaloff>:/icons/32x32/PathBlue.png</normaloff>:/icons/32x32/PathBlue.png</iconset>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
      <layout class="QHBoxLayout" name="horizontalLayout_4">
       <item>
        <widget class="QPushButton" name="pushCreateOrUpdateLocalInstall">


### PR DESCRIPTION
### What is the linked issue for this pull request:

QMS-#503

### What you have done:
adjusted the local brouter-setup wizard to work with the new zip-file format of brouter-version >=1.6.3


### Steps to perform a simple smoke test:
Open BRouter->Setup->local installation->update existing BRouter installation->brouter-1.6.3.zip->Download and install->(wait for installation to finish->next ...

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [X] yes

### Is every user facing string in a tr() macro?

- [X] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [X] yes, I didn't forget to change changelog.txt
