### PR TITLE
[QMS-517] GPX-tracks are not displayed if lon or lat are invariant ov…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-499] Disable close action for projects with autom. sync. to device
 [QMS-503] BRouter Version 1.6.3 local setup fails
 [QMS-507] QMapTool: Early projection validity check 
+[QMS-517] GPX-tracks are not displayed if lon or lat are invariant over the entire track
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -23,6 +23,7 @@
 #include "gis/GeoMath.h"
 #include "gis/prj/IGisProject.h"
 #include "gis/proj_x.h"
+#include "gis/rte/CGisItemRte.h"
 #include "gis/trk/CCutTrk.h"
 #include "gis/trk/CDetailsTrk.h"
 #include "gis/trk/CGisItemTrk.h"
@@ -30,16 +31,15 @@
 #include "gis/trk/CKnownExtension.h"
 #include "gis/trk/CPropertyTrk.h"
 #include "gis/trk/CScrOptTrk.h"
-#include "gis/rte/CGisItemRte.h"
 #include "gis/wpt/CGisItemWpt.h"
 #include "helpers/CDraw.h"
 #include "helpers/CProgressDialog.h"
 #include "helpers/CSettings.h"
 #include "misc.h"
 
+#include "gis/trk/CTrkToRteDialog.h"
 #include <QtWidgets>
 #include <QtXml>
-#include "gis/trk/CTrkToRteDialog.h"
 
 #define DEFAULT_COLOR       4
 #define MIN_DIST_CLOSE_TO   10
@@ -1176,7 +1176,10 @@ void CGisItemTrk::deriveSecondaryData()
         lastTrkpt = &trkpt;
     }
 
-    boundingRect = QRectF(QPointF(west * DEG_TO_RAD, north * DEG_TO_RAD), QPointF(east * DEG_TO_RAD, south * DEG_TO_RAD));
+    constexpr qreal kMargin = 0.0001 * DEG_TO_RAD; // ~5m
+    boundingRect = QRectF(
+        QPointF(west * DEG_TO_RAD - kMargin, north * DEG_TO_RAD + kMargin),
+        QPointF(east * DEG_TO_RAD + kMargin, south * DEG_TO_RAD - kMargin));
 
     for(int p = 0; p < lintrk.size(); p++)
     {
@@ -3416,9 +3419,9 @@ void CGisItemTrk::toRoute()
     qint32 idx1, idx2;
     QString routeName;
     bool saveSubPts;
-    IGisProject *project = getParentProject();
+    IGisProject* project = getParentProject();
 
-    if (nullptr==project)
+    if (nullptr == project)
     {
         qCritical("CGisItemTrk::toRoute no project");
         return;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-#)

QMS-#517

### What you have done:
[comment]: # (Describe roughly.)

Fix the bounding box by adding a very small margin.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use test tracks form ticket.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
