### PR TITLE
QMS-518 Editable Timestamps for waypoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 # Define project name and version tags
 ###############################################################################################
 # this is not only the QMS version it will be the package version, too.
-project(QMapShack VERSION 1.16.1)
+project(QMapShack VERSION 1.16.1 LANGUAGES CXX C)
 
 # FOR A RELEASE:
 # remove "development" for a release

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V1.XX.X
 [QMS-503] BRouter Version 1.6.3 local setup fails
 [QMS-507] QMapTool: Early projection validity check 
 [QMS-517] GPX-tracks are not displayed if lon or lat are invariant over the entire track
+[QMS-518] Enable edit for timestamps of waypoints
 [QMS-522] Change URLs of built-in maps from http to https
 [QMS-526] Fix deprecation warnings
 [QMS-537] Moving items to drop zone removes them from workspace

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -211,6 +211,7 @@ set( SRCS
     helpers/CProgressDialog.cpp
     helpers/CSelectCopyAction.cpp
     helpers/CSelectProjectDialog.cpp
+    helpers/CTimeDialog.cpp
     helpers/CToolBarConfig.cpp
     helpers/CToolBarSetupDialog.cpp
     helpers/CValue.cpp
@@ -578,6 +579,7 @@ set( HDRS
     helpers/CSelectProjectDialog.h
     helpers/CSettings.h
     helpers/CTryMutexLocker.h
+    helpers/CTimeDialog.h
     helpers/CToolBarConfig.h
     helpers/CToolBarSetupDialog.h
     helpers/CValue.h
@@ -839,6 +841,7 @@ set( UIS
     helpers/IProgressDialog.ui
     helpers/ISelectCopyAction.ui
     helpers/ISelectProjectDialog.ui
+    helpers/ITimeDialog.ui
     helpers/IToolBarSetupDialog.ui
     helpers/IWptIconDialog.ui
     map/IMapList.ui

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -340,6 +340,7 @@ set( SRCS
     units/CUnitsSetup.cpp
     units/IUnit.cpp
     widgets/CColorLegend.cpp
+    widgets/CDateTimeEditor.cpp
     widgets/CDoubleSpinBox.cpp
     widgets/CFadingIcon.cpp
     widgets/CHistoryListWidget.cpp
@@ -711,6 +712,7 @@ set( HDRS
     units/IUnit.h
     version.h
     widgets/CColorLegend.h
+    widgets/CDateTimeEditor.h
     widgets/CDoubleSpinBox.h
     widgets/CFadingIcon.h
     widgets/CHistoryListWidget.h

--- a/src/qmapshack/gis/wpt/CDetailsGeoCache.cpp
+++ b/src/qmapshack/gis/wpt/CDetailsGeoCache.cpp
@@ -65,7 +65,7 @@ CDetailsGeoCache::CDetailsGeoCache(CGisItemWpt& wpt, QWidget* parent)
     labelOwner->setText(geocache.owner);
     labelSize->setText(geocache.container);
     const QString &format = QLocale().dateTimeFormat(QLocale::ShortFormat);
-    labelHiddenDate->setText(wpt.getTime().date().toString(format));
+    labelHiddenDate->setText(wpt.getTimestamp().date().toString(format));
     //Last found is set below to only loop logs once
 
     qreal d = geocache.difficulty;

--- a/src/qmapshack/gis/wpt/CDetailsWpt.cpp
+++ b/src/qmapshack/gis/wpt/CDetailsWpt.cpp
@@ -23,6 +23,7 @@
 #include "helpers/CInputDialog.h"
 #include "helpers/CLinksDialog.h"
 #include "helpers/CPositionDialog.h"
+#include "helpers/CTimeDialog.h"
 #include "helpers/CWptIconManager.h"
 #include "units/IUnit.h"
 #include "widgets/CTextEditWidget.h"
@@ -43,6 +44,7 @@ CDetailsWpt::CDetailsWpt(CGisItemWpt& wpt, QWidget* parent)
     connect(labelPosition, &QLabel::linkActivated, this, static_cast<void (CDetailsWpt::*)(const QString&)>(&CDetailsWpt::slotLinkActivated));
     connect(labelElevation, &QLabel::linkActivated, this, static_cast<void (CDetailsWpt::*)(const QString&)>(&CDetailsWpt::slotLinkActivated));
     connect(labelProximity, &QLabel::linkActivated, this, static_cast<void (CDetailsWpt::*)(const QString&)>(&CDetailsWpt::slotLinkActivated));
+    connect(labelTime, &QLabel::linkActivated, this, static_cast<void (CDetailsWpt::*)(const QString&)>(&CDetailsWpt::slotLinkActivated));
     connect(textCmtDesc, &QTextBrowser::anchorClicked, this, static_cast<void (CDetailsWpt::*)(const QUrl&)   >(&CDetailsWpt::slotLinkActivated));
 
     connect(lineName, &CLineEdit::textEdited, this, &CDetailsWpt::slotNameChanged);
@@ -105,9 +107,14 @@ void CDetailsWpt::setupGui()
     labelProximity->setText(IGisItem::toLink(isReadOnly, "proximity", proxStr, ""));
 
 
-    if(wpt.getTime().isValid())
+    if(wpt.getTimestamp().isValid())
     {
-        labelTime->setText(IUnit::datetime2string(wpt.getTime(), false, QPointF(pos.x() * DEG_TO_RAD, pos.y() * DEG_TO_RAD)));
+        const QString& strTime = IUnit::datetime2string(wpt.getTimestamp(), false, QPointF(pos.x() * DEG_TO_RAD, pos.y() * DEG_TO_RAD));
+        labelTime->setText(IGisItem::toLink(isReadOnly, "time", strTime, ""));
+    }
+    else
+    {
+        labelTime->setText(IGisItem::toLink(isReadOnly, "time", "-", ""));
     }
 
     textCmtDesc->document()->clear();
@@ -179,7 +186,14 @@ void CDetailsWpt::slotLinkActivated(const QString& link)
             wpt.setPosition(pos);
         }
     }
-
+    else if(link == "time")
+    {
+        CTimeDialog dlg(this, wpt.getTimestamp());
+        if(dlg.exec() == QDialog::Accepted)
+        {
+            wpt.setTimestamp(dlg.getTimestamp());
+        }
+    }
     setupGui();
 }
 

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -598,6 +598,11 @@ void CGisItemWpt::addImage(const image_t& img)
     changed(tr("Add image"), "://icons/48x48/Image.png");
 }
 
+void CGisItemWpt::setTimestamp(const QDateTime& datetime)
+{
+    wpt.time = datetime;
+    changed(tr("Changed timestamp"), "://icons/48x48/Time.png");
+}
 
 bool CGisItemWpt::isCloseTo(const QPointF& pos)
 {

--- a/src/qmapshack/gis/wpt/CGisItemWpt.h
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.h
@@ -199,6 +199,7 @@ public:
     void setDescription(const QString& str)         override;
     void setLinks(const QList<link_t>& links) override;
     void setImages(const QList<image_t>& imgs);
+    void setTimestamp(const QDateTime& datetime);
 
     /**
        @brief Silently append list of links
@@ -254,10 +255,6 @@ public:
     {
         return proximity;
     }
-    const QDateTime& getTime() const
-    {
-        return wpt.time;
-    }
     const QString& getIconName() const
     {
         return wpt.sym;
@@ -287,7 +284,6 @@ public:
     {
         return wpt.time;
     }
-
 
     IScrOpt* getScreenOptions(const QPoint& origin, IMouse* mouse) override;
 

--- a/src/qmapshack/helpers/CTimeDialog.cpp
+++ b/src/qmapshack/helpers/CTimeDialog.cpp
@@ -1,0 +1,61 @@
+/**********************************************************************************************
+    Copyright (C) 2022 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#include "CTimeDialog.h"
+
+#include <QTimeZone>
+
+#include "CSettings.h"
+
+CTimeDialog::CTimeDialog(QWidget* parent, const QDateTime& datetime)
+    : QDialog(parent), timestamp(datetime), timestamp_utc0(datetime.toTimeZone(QTimeZone("UTC+00:00")))
+{
+    setupUi(this);
+
+    SETTINGS;
+    cfg.beginGroup("TimeDialog");
+    const QByteArray& zone = cfg.value("timezone", QTimeZone::systemTimeZone().id()).toByteArray();
+    cfg.endGroup();
+
+    const QList<QByteArray>& ids = QTimeZone::availableTimeZoneIds();
+    foreach (const QByteArray &id, ids)
+    {
+        comboTimezone->addItem(id);
+    }
+
+    comboTimezone->setCurrentText(zone);
+
+    const QDateTime& newTime = timestamp_utc0.toTimeZone(QTimeZone(zone));
+    dateTimeEdit->setDateTime(newTime);
+
+    connect(comboTimezone, &QComboBox::currentTextChanged, this, [this](const QString& id){
+        SETTINGS;
+        cfg.beginGroup("TimeDialog");
+        cfg.setValue("timezone", id);
+        cfg.endGroup();
+        const QDateTime& newTime = timestamp_utc0.toTimeZone(QTimeZone(id.toUtf8()));
+        dateTimeEdit->setDateTime(newTime);
+    });
+}
+
+void CTimeDialog::accept()
+{
+    const QDateTime& newTime = dateTimeEdit->getDateTime();
+    timestamp = newTime.toTimeZone(timestamp.timeZone());
+    QDialog::accept();
+}

--- a/src/qmapshack/helpers/CTimeDialog.h
+++ b/src/qmapshack/helpers/CTimeDialog.h
@@ -1,0 +1,43 @@
+/**********************************************************************************************
+    Copyright (C) 2022 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CTIMEDIALOG_H
+#define CTIMEDIALOG_H
+
+#include "ui_ITimeDialog.h"
+
+#include <QDateTime>
+
+class CTimeDialog : public QDialog, public Ui::ITimeDialog
+{
+    Q_OBJECT
+public:
+    CTimeDialog(QWidget* parent, const QDateTime& timestamp);
+    virtual ~CTimeDialog() = default;
+
+    const QDateTime& getTimestamp() const {return timestamp;}
+
+    void accept() override;
+
+private:
+    QDateTime timestamp;
+    QDateTime timestamp_utc0;
+};
+
+#endif //CTIMEDIALOG_H
+

--- a/src/qmapshack/helpers/ITimeDialog.ui
+++ b/src/qmapshack/helpers/ITimeDialog.ui
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ITimeDialog</class>
+ <widget class="QDialog" name="ITimeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>125</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Edit timestamp...</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="CDateTimeEditor" name="dateTimeEdit" native="true">
+       <property name="toolTip">
+        <string>You can use the up, down, left and right key of 
+your keyboard to change the time/date. Or you 
+simply type the new time/date.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboTimezone"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CDateTimeEditor</class>
+   <extends>QWidget</extends>
+   <header>widgets/CDateTimeEditor.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ITimeDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ITimeDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qmapshack/widgets/CDateTimeEditor.cpp
+++ b/src/qmapshack/widgets/CDateTimeEditor.cpp
@@ -41,15 +41,6 @@ CDateTimeEditor::CDateTimeEditor(QWidget* parent) : QWidget(parent)
     addGroup(MINUTE, 0, 59, 'M');
     addGroup(SECOND, 0, 59, 'S');
 
-    addCharacter(HOUR, "012");
-    addCharacter(HOUR, "0123456789");
-    addFixedCharacter(':');
-    addCharacter(MINUTE, "012345");
-    addCharacter(MINUTE, "0123456789");
-    addFixedCharacter(':');
-    addCharacter(SECOND, "012345");
-    addCharacter(SECOND, "0123456789");
-    addFixedCharacter(' ');
     addCharacter(YEAR, "0123456789");
     addCharacter(YEAR, "0123456789");
     addCharacter(YEAR, "0123456789");
@@ -60,6 +51,16 @@ CDateTimeEditor::CDateTimeEditor(QWidget* parent) : QWidget(parent)
     addFixedCharacter('-');
     addCharacter(DAY, "0123");
     addCharacter(DAY, "0123456789");
+    addFixedCharacter(' ');
+    addCharacter(HOUR, "012");
+    addCharacter(HOUR, "0123456789");
+    addFixedCharacter(':');
+    addCharacter(MINUTE, "012345");
+    addCharacter(MINUTE, "0123456789");
+    addFixedCharacter(':');
+    addCharacter(SECOND, "012345");
+    addCharacter(SECOND, "0123456789");
+
 
     m_selectedPosition = -1;
     m_selectedGroup = NONE;

--- a/src/qmapshack/widgets/CDateTimeEditor.cpp
+++ b/src/qmapshack/widgets/CDateTimeEditor.cpp
@@ -1,0 +1,712 @@
+/*******************************************************************************
+* Copyright (c) 2015 Florian Pigorsch <mail@florian-pigorsch.de>               *
+*                                                                              *
+* Permission is hereby granted, free of charge, to any person obtaining a copy *
+* of this software and associated documentation files (the "Software"), to deal*
+* in the Software without restriction, including without limitation the rights *
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+* copies of the Software, and to permit persons to whom the Software is        *
+* furnished to do so, subject to the following conditions:                     *
+*                                                                              *
+* The above copyright notice and this permission notice shall be included in   *
+* all copies or substantial portions of the Software.                          *
+*                                                                              *
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+* THE SOFTWARE.                                                                *
+*******************************************************************************/
+
+#include "widgets/CDateTimeEditor.h"
+#include <QApplication>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QStyleOption>
+#include <QTimeZone>
+
+
+CDateTimeEditor::CDateTimeEditor(QWidget* parent) : QWidget(parent)
+{
+    setFocusPolicy(Qt::StrongFocus);
+
+    addGroup(YEAR, 1, 9999, 'Y');
+    addGroup(MONTH, 1, 12, 'M');
+    addGroup(DAY, 1, 31, 'D');
+    addGroup(HOUR, 0, 23, 'H');
+    addGroup(MINUTE, 0, 59, 'M');
+    addGroup(SECOND, 0, 59, 'S');
+
+    addCharacter(HOUR, "012");
+    addCharacter(HOUR, "0123456789");
+    addFixedCharacter(':');
+    addCharacter(MINUTE, "012345");
+    addCharacter(MINUTE, "0123456789");
+    addFixedCharacter(':');
+    addCharacter(SECOND, "012345");
+    addCharacter(SECOND, "0123456789");
+    addFixedCharacter(' ');
+    addCharacter(YEAR, "0123456789");
+    addCharacter(YEAR, "0123456789");
+    addCharacter(YEAR, "0123456789");
+    addCharacter(YEAR, "0123456789");
+    addFixedCharacter('-');
+    addCharacter(MONTH, "01");
+    addCharacter(MONTH, "0123456789");
+    addFixedCharacter('-');
+    addCharacter(DAY, "0123");
+    addCharacter(DAY, "0123456789");
+
+    m_selectedPosition = -1;
+    m_selectedGroup = NONE;
+
+    validate();
+}
+
+void CDateTimeEditor::setDateTime(const QDateTime& dateTime)
+{
+    m_dateTime = dateTime;
+    if (m_dateTime.isValid())
+    {
+        setNumber(YEAR, m_dateTime.date().year());
+        setNumber(MONTH, m_dateTime.date().month());
+        setNumber(DAY, m_dateTime.date().day());
+        setNumber(HOUR, m_dateTime.time().hour());
+        setNumber(MINUTE, m_dateTime.time().minute());
+        setNumber(SECOND, m_dateTime.time().second());
+    }
+    else
+    {
+        for (CharacterInfo& c : m_characters)
+        {
+            if (c.isEditable())
+            {
+                c.m_character = m_groups[c.m_group].placeholder;
+            }
+        }
+    }
+
+    validate();
+    update();
+}
+
+
+QSize CDateTimeEditor::sizeHint() const
+{
+    const QSize charSize = getCharSize();
+    const int h = qMax(charSize.height(), 14) + 2 * 5;
+    const int w = m_characters.size() * charSize.width() + 2 * 5;
+    return QSize(w, h);
+}
+
+
+QSize CDateTimeEditor::minimumSizeHint() const
+{
+    return sizeHint();
+}
+
+
+void CDateTimeEditor::paintEvent(QPaintEvent* /*event*/)
+{
+    QPainter painter(this);
+
+    QStyleOptionFrame panel;
+    initStyleOption(&panel);
+    style()->drawPrimitive(QStyle::PE_PanelLineEdit, &panel, &painter, this);
+
+    QRect r = style()->subElementRect(QStyle::SE_LineEditContents, &panel, this);
+    const int margin = 2;
+    r.setX(r.x() + margin);
+    r.setY(r.y() + margin);
+    r.setRight(r.right() - margin);
+    r.setBottom(r.bottom() - margin);
+    painter.setClipRect(r);
+
+    QPalette pal = style()->standardPalette();
+
+    if (m_selectedPosition >= 0)
+    {
+        const GroupInfo& g = m_groups[m_selectedGroup];
+
+        for (auto p : g.positions)
+        {
+            const QRect r = getCharacterRect(p);
+            painter.fillRect(r, pal.alternateBase());
+        }
+
+        const QRect r = getCharacterRect(m_selectedPosition);
+        if (g.invalid)
+        {
+            painter.fillRect(r, Qt::red);
+        }
+        else
+        {
+            painter.fillRect(r, pal.highlight());
+        }
+    }
+
+    painter.setRenderHint(QPainter::Antialiasing);
+    for (const CharacterInfo& c : qAsConst(m_characters))
+    {
+        const QRect r = getCharacterRect(c.m_position);
+        if (c.m_position == m_selectedPosition)
+        {
+            painter.setPen(pal.highlightedText().color());
+        }
+        else
+        {
+            const GroupInfo& g = m_groups[c.m_group];
+            if (g.invalid)
+            {
+                painter.setPen(Qt::red);
+            }
+            else
+            {
+                painter.setPen(pal.text().color());
+            }
+        }
+
+        painter.drawText(r, Qt::AlignCenter, c.m_character);
+    }
+}
+
+
+void CDateTimeEditor::mousePressEvent(QMouseEvent* event)
+{
+    const int p = getNearestEditablePosition(event->pos());
+    if (p >= 0)
+    {
+        m_selectedPosition = p;
+        m_selectedGroup = m_characters[m_selectedPosition].m_group;
+    }
+    else
+    {
+        m_selectedPosition = -1;
+        m_selectedGroup = NONE;
+    }
+    update();
+}
+
+
+void CDateTimeEditor::wheelEvent(QWheelEvent* event)
+{
+    if (m_selectedPosition == -1)
+    {
+        return;
+    }
+
+    if (event->angleDelta().y() > 0)
+    {
+        editSelectedCharacterDelta(+1);
+    }
+    else if (event->angleDelta().y() < 0)
+    {
+        editSelectedCharacterDelta(-1);
+    }
+}
+
+
+void CDateTimeEditor::keyPressEvent(QKeyEvent* event)
+{
+    switch (event->key())
+    {
+    case Qt::Key_Left:
+        selectPrevPosition();
+        break;
+
+    case Qt::Key_Right:
+        selectNextPosition();
+        break;
+
+    case Qt::Key_Up:
+        editSelectedCharacterDelta(+1);
+        break;
+
+    case Qt::Key_Down:
+        editSelectedCharacterDelta(-1);
+        break;
+
+    case Qt::Key_0:
+    case Qt::Key_1:
+    case Qt::Key_2:
+    case Qt::Key_3:
+    case Qt::Key_4:
+    case Qt::Key_5:
+    case Qt::Key_6:
+    case Qt::Key_7:
+    case Qt::Key_8:
+    case Qt::Key_9:
+        if (editSelectedCharacter(event->text()))
+        {
+            selectNextPosition();
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+
+void CDateTimeEditor::focusInEvent(QFocusEvent*)
+{
+    selectFirstPosition();
+}
+
+
+void CDateTimeEditor::focusOutEvent(QFocusEvent*)
+{
+    m_selectedPosition = -1;
+    m_selectedGroup = NONE;
+    update();
+}
+
+
+bool CDateTimeEditor::focusNextPrevChild(bool next)
+{
+    bool found = next ? selectNextPosition() : selectPrevPosition();
+
+    if (!found)
+    {
+        found = QWidget::focusNextPrevChild(next);
+    }
+    return found;
+}
+
+
+const QSize& CDateTimeEditor::getCharSize() const
+{
+    if (m_font != font() || m_charSize.isEmpty())
+    {
+        m_font = font();
+        const QFontMetrics metrics = fontMetrics();
+
+        m_charSize.setWidth(0);
+        m_charSize.setHeight(0);
+
+        const QString& chars = "0123456789-: YMDHS";
+        for (const QChar& c : chars)
+        {
+            const QSize cSize = metrics.size(0, c);
+            m_charSize = m_charSize.expandedTo(cSize);
+        }
+    }
+
+    return m_charSize;
+}
+
+QRect CDateTimeEditor::getCharacterRect(int position) const
+{
+    const QSize& s = getCharSize();
+    return QRect(QPoint(position * s.width() + 4, 5), s);
+}
+
+
+void CDateTimeEditor::addCharacter(CDateTimeEditor::Group group, const QString& availableCharacters)
+{
+    CharacterInfo c;
+    c.m_position = m_characters.size();
+    c.m_group = group;
+    c.m_character = m_groups[group].placeholder;
+    c.m_availableCharacters = availableCharacters;
+    m_characters << c;
+    m_groups[c.m_group].positions << c.m_position;
+}
+
+
+void CDateTimeEditor::addFixedCharacter(const QChar& character)
+{
+    CharacterInfo c;
+    c.m_position = m_characters.size();
+    c.m_group = NONE;
+    c.m_character = character;
+    m_characters << c;
+    m_groups[c.m_group].positions << c.m_position;
+}
+
+
+void CDateTimeEditor::addGroup(CDateTimeEditor::Group group, int minValue, int maxValue, const QChar& placeholder)
+{
+    GroupInfo g;
+    g.group = group;
+    g.value = -1;
+    g.invalid = true;
+    g.minValue = minValue;
+    g.maxValue = maxValue;
+    g.placeholder = placeholder;
+    m_groups.insert(group, g);
+}
+
+
+int CDateTimeEditor::getNearestEditablePosition(const QPoint& pos) const
+{
+    int minDist = -1;
+    int bestPosition = -1;
+
+    for (const CharacterInfo& c : m_characters)
+    {
+        if (c.isEditable())
+        {
+            const QRect r = getCharacterRect(c.m_position);
+            int dist = -1;
+            if (r.contains(pos))
+            {
+                dist = 0;
+            }
+            else
+            {
+                if (pos.x() <= r.left())
+                {
+                    const int d = r.left() - pos.x();
+                    if (dist < 0 || d < dist)
+                    {
+                        dist = d;
+                    }
+                }
+                else if (pos.x() >= r.right())
+                {
+                    const int d = pos.x() - r.right();
+                    if (dist < 0 || d < dist)
+                    {
+                        dist = d;
+                    }
+                }
+                if (pos.y() <= r.top())
+                {
+                    const int d = r.top() - pos.y();
+                    if (dist < 0 || d < dist)
+                    {
+                        dist = d;
+                    }
+                }
+                else if (pos.y() >= r.bottom())
+                {
+                    const int d = pos.y() - r.bottom();
+                    if (dist < 0 || d < dist)
+                    {
+                        dist = d;
+                    }
+                }
+            }
+
+            if (minDist < 0 || dist < minDist)
+            {
+                minDist = dist;
+                bestPosition = c.m_position;
+            }
+        }
+    }
+
+    return bestPosition;
+}
+
+
+bool CDateTimeEditor::selectFirstPosition()
+{
+    bool found = false;
+
+    m_selectedPosition = -1;
+    m_selectedGroup = NONE;
+
+    for (const CharacterInfo& c : qAsConst(m_characters))
+    {
+        if (c.isEditable())
+        {
+            found = true;
+            m_selectedPosition = c.m_position;
+            m_selectedGroup = c.m_group;
+            break;
+        }
+    }
+
+    update();
+
+    return found;
+}
+
+
+bool CDateTimeEditor::selectPrevPosition()
+{
+    bool found = false;
+
+    if (m_selectedPosition >= 0)
+    {
+        for (int i = m_selectedPosition - 1; i >= 0; --i)
+        {
+            const CharacterInfo& c = m_characters[i];
+            if (c.isEditable())
+            {
+                found = true;
+                m_selectedPosition = i;
+                m_selectedGroup = c.m_group;
+                break;
+            }
+        }
+    }
+    else
+    {
+        found = selectFirstPosition();
+    }
+
+    update();
+
+    return found;
+}
+
+
+bool CDateTimeEditor::selectNextPosition()
+{
+    bool found = false;
+    if (m_selectedPosition >= 0)
+    {
+        for (int i = m_selectedPosition + 1; i < m_characters.size(); ++i)
+        {
+            const CharacterInfo& c = m_characters[i];
+            if (c.isEditable())
+            {
+                found = true;
+                m_selectedPosition = i;
+                m_selectedGroup = c.m_group;
+                break;
+            }
+        }
+    }
+    else
+    {
+        found = selectFirstPosition();
+    }
+
+    update();
+
+    return found;
+}
+
+
+void CDateTimeEditor::editSelectedCharacterDelta(int delta)
+{
+    if (m_selectedPosition < 0 || m_selectedGroup == NONE)
+    {
+        return;
+    }
+
+    GroupInfo& g = m_groups[(int)m_selectedGroup];
+    int value = getNumber(m_selectedGroup);
+
+    if (value < 0)
+    {
+        setNumber(m_selectedGroup, g.minValue);
+    }
+    else
+    {
+        const int valuation = g.valuation(m_selectedPosition);
+        value += delta * valuation;
+        value = qMax(value, g.minValue);
+        value = qMin(value, g.maxValue);
+        setNumber(m_selectedGroup, value);
+    }
+
+    validate();
+    update();
+}
+
+
+bool CDateTimeEditor::editSelectedCharacter(const QString& keyText)
+{
+    if (m_selectedPosition < 0 || keyText.size() != 1)
+    {
+        return false;
+    }
+
+    CharacterInfo& c = m_characters[m_selectedPosition];
+    const int index = c.m_availableCharacters.indexOf(keyText[0]);
+    if (index < 0)
+    {
+        return false;
+    }
+
+    c.m_character = keyText[0];
+
+    validate();
+    update();
+
+    return true;
+}
+
+
+void CDateTimeEditor::validate()
+{
+    for (GroupInfo& g : m_groups)
+    {
+        g.invalid = false;
+    }
+
+    int hours = getNumber(HOUR);
+    int minutes = getNumber(MINUTE);
+    int seconds = getNumber(SECOND);
+    if (hours < 0 || hours > 23)
+    {
+        hours = -1;
+        markInvalid(HOUR);
+    }
+    if (minutes < 0 || minutes > 59)
+    {
+        minutes = -1;
+        markInvalid(MINUTE);
+    }
+    if (seconds < 0 || seconds > 59)
+    {
+        seconds = -1;
+        markInvalid(SECOND);
+    }
+
+    int years = getNumber(YEAR);
+    int months = getNumber(MONTH);
+    int days = getNumber(DAY);
+
+    if (years < 0 || years == 0)
+    {
+        years = -1;
+        markInvalid(YEAR);
+    }
+    if (months <= 0 || months > 12)
+    {
+        months = -1;
+        markInvalid(MONTH);
+    }
+    if (days <= 0 || days > 31 )
+    {
+        days = -1;
+        markInvalid(DAY);
+    }
+    if (months != -1 && days != -1)
+    {
+        if ((months == 2) && days > 29)
+        {
+            days = -1;
+            months = -1;
+        }
+        else if ((months == 4 || months == 6 || months == 9 || months == 11) && days > 30)
+        {
+            days = -1;
+            months = -1;
+        }
+
+        if (days == -1)
+        {
+            markInvalid(DAY);
+            markInvalid(MONTH);
+        }
+    }
+
+    if (years != -1 && months != -1 && days != -1)
+    {
+        if (!QDate(years, months, days).isValid())
+        {
+            years = -1;
+            months = -1;
+            days = -1;
+            markInvalid(YEAR);
+            markInvalid(MONTH);
+            markInvalid(DAY);
+        }
+    }
+
+    m_groups[YEAR].setValue(years);
+    m_groups[MONTH].setValue(months);
+    m_groups[DAY].setValue(days);
+    m_groups[HOUR].setValue(hours);
+    m_groups[MINUTE].setValue(minutes);
+    m_groups[SECOND].setValue(seconds);
+
+    if (years != -1 && months != -1 && days != -1 && hours != -1 && minutes != -1 && seconds != -1)
+    {
+        m_dateTime = QDateTime(QDate(years, months, days), QTime(hours, minutes, seconds), m_dateTime.timeZone());
+    }
+    else
+    {
+        m_dateTime = QDateTime();
+    }
+    emit dateTimeChanged(m_dateTime);
+
+    update();
+}
+
+
+void CDateTimeEditor::setNumber(Group group, int value)
+{
+    const auto& g = m_groups[group];
+
+    auto positions = g.positions;
+    if (value < 0)
+    {
+        for (auto p : positions)
+        {
+            CharacterInfo& c = m_characters[p];
+            c.m_character = g.placeholder;
+        }
+    }
+    else
+    {
+        QString s = QString::number(value);
+        while (s.size() < positions.size())
+        {
+            s.push_front('0');
+        }
+        while (s.size() > positions.size())
+        {
+            s.remove(0, 1);
+        }
+
+        for (int i = 0; i != positions.size(); ++i)
+        {
+            m_characters[positions[i]].m_character = s[i];
+        }
+    }
+
+    m_groups[group].setValue(getNumber(group));
+}
+
+
+int CDateTimeEditor::getNumber(Group group) const
+{
+    const auto& g = m_groups[group];
+    int value = 0;
+    for (auto p : g.positions)
+    {
+        const CharacterInfo& c = m_characters[p];
+        if (c.m_character.isDigit())
+        {
+            value = 10 * value + c.m_character.digitValue();
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    return value;
+}
+
+
+void CDateTimeEditor::markInvalid(Group group)
+{
+    m_groups[group].invalid = true;
+}
+
+
+void CDateTimeEditor::initStyleOption(QStyleOptionFrame* option) const
+{
+    if (!option)
+    {
+        return;
+    }
+
+    option->initFrom(this);
+    option->rect = contentsRect();
+    option->lineWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth, option, this);
+    option->midLineWidth = 0;
+    option->state |= QStyle::State_Sunken;
+}

--- a/src/qmapshack/widgets/CDateTimeEditor.h
+++ b/src/qmapshack/widgets/CDateTimeEditor.h
@@ -1,0 +1,135 @@
+/*******************************************************************************
+* Copyright (c) 2015 Florian Pigorsch <mail@florian-pigorsch.de>               *
+*                                                                              *
+* Permission is hereby granted, free of charge, to any person obtaining a copy *
+* of this software and associated documentation files (the "Software"), to deal*
+* in the Software without restriction, including without limitation the rights *
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+* copies of the Software, and to permit persons to whom the Software is        *
+* furnished to do so, subject to the following conditions:                     *
+*                                                                              *
+* The above copyright notice and this permission notice shall be included in   *
+* all copies or substantial portions of the Software.                          *
+*                                                                              *
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+* THE SOFTWARE.                                                                *
+*******************************************************************************/
+
+#ifndef QTDATETIMEEDITOR_H
+#define QTDATETIMEEDITOR_H
+
+#include <QDateTime>
+#include <QList>
+#include <QMap>
+#include <QWidget>
+class QStyleOptionFrame;
+
+class CDateTimeEditor : public QWidget
+{
+    Q_OBJECT
+
+public:
+    CDateTimeEditor(QWidget* parent = nullptr);
+
+    const QDateTime& getDateTime() const { return m_dateTime; }
+    void setDateTime(const QDateTime& dateTime);
+
+    virtual QSize sizeHint() const override;
+    virtual QSize minimumSizeHint() const override;
+
+signals:
+    void dateTimeChanged(const QDateTime&);
+
+protected:
+    virtual void paintEvent(QPaintEvent* event) override;
+    virtual void mousePressEvent(QMouseEvent* event) override;
+    virtual void wheelEvent(QWheelEvent* event) override;
+    virtual void keyPressEvent(QKeyEvent* event) override;
+    virtual void focusInEvent(QFocusEvent* event) override;
+    virtual void focusOutEvent(QFocusEvent* event) override;
+    virtual bool focusNextPrevChild(bool next) override;
+
+private:
+    enum Group
+    {
+        NONE = 0, YEAR, MONTH, DAY, HOUR, MINUTE, SECOND
+    };
+
+    const QSize& getCharSize() const;
+    QRect getCharacterRect(int position) const;
+    void addCharacter(Group group, const QString& availableCharacters);
+    void addFixedCharacter(const QChar& character);
+    void addGroup(Group group, int minValue, int maxValue, const QChar& placeholder);
+
+    int getNearestEditablePosition(const QPoint& pos) const;
+    bool selectFirstPosition();
+    bool selectPrevPosition();
+    bool selectNextPosition();
+    void editSelectedCharacterDelta(int delta);
+    bool editSelectedCharacter(const QString& keyText);
+    void validate();
+
+    void setNumber(Group group, int value);
+    int getNumber(Group group) const;
+    void markInvalid(Group group);
+
+    void initStyleOption(QStyleOptionFrame* option) const;
+
+private:
+    QDateTime m_dateTime;
+    mutable QFont m_font;
+    mutable QSize m_charSize;
+
+    int m_selectedPosition = -1;
+    struct CharacterInfo
+    {
+        int m_position;
+        Group m_group;
+        QChar m_character;
+        QString m_availableCharacters;
+        bool isEditable() const { return !m_availableCharacters.isEmpty(); }
+    };
+
+    Group m_selectedGroup = NONE;
+    struct GroupInfo
+    {
+        Group group;
+        QList<int> positions;
+        bool invalid;
+        int value;
+        int minValue;
+        int maxValue;
+        QChar placeholder;
+
+        void setValue(int v)
+        {
+            value = v;
+            invalid = (value < minValue || value > maxValue);
+        }
+
+        int valuation(int pos)
+        {
+            int v = 1;
+            for (int i = positions.size() - 1; i >= 0; --i)
+            {
+                if (positions[i] == pos)
+                {
+                    return v;
+                }
+
+                v *= 10;
+            }
+            return 0;
+        }
+    };
+
+    QList<CharacterInfo> m_characters;
+    QMap<int, GroupInfo> m_groups;
+};
+
+#endif

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,0 +1,1 @@
+call_Uncrustify.cfg


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#518

### What you have done:
[comment]: # (Describe roughly.)

Added a new dialog to edit the timestamps of waypoints, 

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Create waypoint
* Click on the linked timestamp
* Edit timestamp

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
