### PR TITLE
[QMS-522] Change URLs of built-in maps from http to https

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V1.XX.X
 [QMS-503] BRouter Version 1.6.3 local setup fails
 [QMS-507] QMapTool: Early projection validity check 
 [QMS-517] GPX-tracks are not displayed if lon or lat are invariant over the entire track
+[QMS-522] Change URLs of built-in maps from http to https
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/map/WorldSat.wmts
+++ b/src/qmapshack/map/WorldSat.wmts
@@ -8,7 +8,7 @@
 <ows:Operation name="GetCapabilities">
 <ows:DCP>
 <ows:HTTP>
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/1.0.0/WMTSCapabilities.xml">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/1.0.0/WMTSCapabilities.xml">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>RESTful</ows:Value>
@@ -16,7 +16,7 @@
 </ows:Constraint>
 </ows:Get>
 <!-- add KVP binding in 10.1 -->
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS?">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS?">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>KVP</ows:Value>
@@ -29,14 +29,14 @@
 <ows:Operation name="GetTile">
 <ows:DCP>
 <ows:HTTP>
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/tile/1.0.0/">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/tile/1.0.0/">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>RESTful</ows:Value>
 </ows:AllowedValues>
 </ows:Constraint>
 </ows:Get>
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS?">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS?">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>KVP</ows:Value>
@@ -68,7 +68,7 @@
 <!--Only show this TileMatrixSet if the tiling scheme is compliant to Google Maps (and that happens with tile width = 256 px)-->
 <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
 </TileMatrixSetLink>
-<ResourceURL format="image/jpg" resourceType="tile" template="http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/tile/1.0.0/World_Imagery/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+<ResourceURL format="image/jpg" resourceType="tile" template="https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/tile/1.0.0/World_Imagery/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
 </Layer> <!--TileMatrixSet-->
 <TileMatrixSet>
 <ows:Title>TileMatrix using 0.28mm</ows:Title>
@@ -374,4 +374,4 @@
 </TileMatrix>
 </TileMatrixSet>
 </Contents>
-<ServiceMetadataURL xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"/> </Capabilities>
+<ServiceMetadataURL xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"/> </Capabilities>

--- a/src/qmapshack/map/WorldTopo.wmts
+++ b/src/qmapshack/map/WorldTopo.wmts
@@ -8,7 +8,7 @@
 <ows:Operation name="GetCapabilities">
 <ows:DCP>
 <ows:HTTP>
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/1.0.0/WMTSCapabilities.xml">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/1.0.0/WMTSCapabilities.xml">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>RESTful</ows:Value>
@@ -16,7 +16,7 @@
 </ows:Constraint>
 </ows:Get>
 <!-- add KVP binding in 10.1 -->
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS?">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS?">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>KVP</ows:Value>
@@ -29,14 +29,14 @@
 <ows:Operation name="GetTile">
 <ows:DCP>
 <ows:HTTP>
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/tile/1.0.0/">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/tile/1.0.0/">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>RESTful</ows:Value>
 </ows:AllowedValues>
 </ows:Constraint>
 </ows:Get>
-<ows:Get xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS?">
+<ows:Get xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS?">
 <ows:Constraint name="GetEncoding">
 <ows:AllowedValues>
 <ows:Value>KVP</ows:Value>
@@ -68,7 +68,7 @@
 <!--Only show this TileMatrixSet if the tiling scheme is compliant to Google Maps (and that happens with tile width = 256 px)-->
 <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
 </TileMatrixSetLink>
-<ResourceURL format="image/jpg" resourceType="tile" template="http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/tile/1.0.0/World_Topo_Map/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+<ResourceURL format="image/jpg" resourceType="tile" template="https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/tile/1.0.0/World_Topo_Map/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
 </Layer> <!--TileMatrixSet-->
 <TileMatrixSet>
 <ows:Title>TileMatrix using 0.28mm</ows:Title>
@@ -374,4 +374,4 @@
 </TileMatrix>
 </TileMatrixSet>
 </Contents>
-<ServiceMetadataURL xlink:href="http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"/> </Capabilities>
+<ServiceMetadataURL xlink:href="https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"/> </Capabilities>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#522

### What you have done:
[comment]: # (Describe roughly.)

Fixed the built-in wmts files of WorldTopo and WorldSat

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Activate one of the maps
* Check if map is loading and displayed

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
