### PR TITLE
[QMS-537] Moving items to drop zone removes them from workspace

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V1.XX.X
 [QMS-517] GPX-tracks are not displayed if lon or lat are invariant over the entire track
 [QMS-522] Change URLs of built-in maps from http to https
 [QMS-526] Fix deprecation warnings
+[QMS-537] Moving items to drop zone removes them from workspace
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/gis/IGisWorkspace.ui
+++ b/src/qmapshack/gis/IGisWorkspace.ui
@@ -74,7 +74,7 @@
       <bool>true</bool>
      </property>
      <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
+      <enum>QAbstractItemView::DragDrop</enum>
      </property>
      <property name="defaultDropAction">
       <enum>Qt::CopyAction</enum>

--- a/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
+++ b/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
@@ -55,9 +55,10 @@ void CGisSummaryDropZone::dragEnterEvent(QDragEnterEvent* e)
     {
         return QLabel::dragEnterEvent(e);
     }
-
+    
+    e->setDropAction(Qt::CopyAction);
     setHighlighted(true);   
-    if(e->proposedAction() == Qt::MoveAction)
+    if(e->proposedAction() == Qt::CopyAction)
     {
         e->acceptProposedAction();
     }
@@ -72,8 +73,7 @@ void CGisSummaryDropZone::dragMoveEvent(QDragMoveEvent* e)
     }
 
 
-    e->setDropAction(Qt::CopyAction);
-    if(e->proposedAction() == Qt::MoveAction)
+    if(e->proposedAction() == Qt::CopyAction)
     {
         e->acceptProposedAction();
     }
@@ -87,8 +87,7 @@ void CGisSummaryDropZone::dragLeaveEvent(QDragLeaveEvent* e)
 
 void CGisSummaryDropZone::dropEvent(QDropEvent* e)
 {
-    e->setDropAction(Qt::CopyAction);
-    if(e->proposedAction() == Qt::MoveAction)
+    if(e->proposedAction() == Qt::CopyAction)
     {
         setHighlighted(false);
         e->acceptProposedAction();


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#537

### What you have done:
[comment]: # (Describe roughly.)

Set the drag-n-drop mode of the workspace from internal move to real drag-n-drop. By that the copy action can be selected.
Copy won't remove the origin items

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket for instructions

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
