### PR TITLE
[QMS-535] Loading a map view does not reset the layer checkboxes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V1.XX.X
 [QMS-517] GPX-tracks are not displayed if lon or lat are invariant over the entire track
 [QMS-522] Change URLs of built-in maps from http to https
 [QMS-526] Fix deprecation warnings
+[QMS-535] Loading a map view does not reset the layer checkboxes
 [QMS-537] Moving items to drop zone removes them from workspace
 
 V1.16.1

--- a/src/qmapshack/map/CMapPropSetup.cpp
+++ b/src/qmapshack/map/CMapPropSetup.cpp
@@ -101,6 +101,10 @@ void CMapPropSetup::slotPropertiesChanged() /* override */
     labelCachePath->setToolTip(lbl);
     spinCacheSize->setValue(mapfile->getCacheSize());
     spinCacheExpiration->setValue(mapfile->getCacheExpiration());
+    if(mapfile->hasFeatureLayers())
+    {
+        mapfile->getLayers(*listLayers);
+    }
 
     // type file
     QFileInfo fi(mapfile->getTypeFile());


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#535

### What you have done:
[comment]: # (Describe roughly.)

The check boxes where not updated in ` CMapPropSetup::slotPropertiesChanged()` 

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket for instructions

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
