### PR TITLE
[QMS-542] Changed drag`n drop in workspace

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ V1.XX.X
 [QMS-526] Fix deprecation warnings
 [QMS-535] Loading a map view does not reset the layer checkboxes
 [QMS-537] Moving items to drop zone removes them from workspace
+[QMS-542] Changed drag`n drop in workspace
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -384,6 +384,8 @@ void CGisListWks::dragMoveEvent(QDragMoveEvent* e )
 {
     CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
+    setDragDropMode(QAbstractItemView::DragDrop);
+
     QTreeWidgetItem* item1 = currentItem();
     QTreeWidgetItem* item2 = itemAt(e->pos());
 
@@ -466,10 +468,11 @@ void CGisListWks::dragMoveEvent(QDragMoveEvent* e )
         IGisProject* proj1 = dynamic_cast<IGisProject*>(item1);
         if(proj1)
         {
+            setDragDropMode(QAbstractItemView::InternalMove);
             e->setDropAction(proj2->isOnDevice() ? Qt::IgnoreAction : Qt::MoveAction);
             QTreeWidget::dragMoveEvent(e);
             return;
-        }
+        }        
 
         IGisItem* gisItem1 = dynamic_cast<IGisItem*>(item1);
         if(gisItem1)


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#542

### What you have done:
[comment]: # (Describe roughly.)

Switch mode between DragDrop and internal move

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
