### PR TITLE
[QMS-551] Set QDateTime short format back to Qt::ISODate

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ V1.XX.X
 [QMS-537] Moving items to drop zone removes them from workspace
 [QMS-540] MacOS: Updating bundle with GEOS and proper GDAS binaries
 [QMS-542] Changed drag`n drop in workspace
+[QMS-551] Set QDateTime short format back to Qt::ISODate
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/gis/fit/serialization.cpp
+++ b/src/qmapshack/gis/fit/serialization.cpp
@@ -51,7 +51,7 @@ static QDateTime toDateTime(quint32 timestamp)
 static QString dateTimeAsString(quint32 timestamp)
 {
     QDateTime dateTime = toDateTime(timestamp);
-    return IUnit::datetime2string(dateTime, true);
+    return IUnit::datetime2string(dateTime, IUnit::eTimeFormatIso, NOPOINTF);
 }
 
 template<typename T>

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -265,7 +265,7 @@ void CDetailsPrj::draw(QTextDocument& doc, bool printable)
 
     setWindowTitle(prj.getName());
 
-    labelTime->setText(IUnit::datetime2string(prj.getTime(), false));
+    labelTime->setText(IUnit::datetime2string(prj.getTime(), IUnit::eTimeFormatLong));
 
     QString keywords = prj.getKeywords();
     if(keywords.isEmpty())
@@ -673,7 +673,7 @@ QList<wpt_info_t> CDetailsPrj::getWptInfo(const CGisItemTrk& trk) const
 
             if(!hasValidTime && trkpt.time.isValid())
             {
-                info.info += "<br/>" + tr("Created: %1").arg(IUnit::datetime2string(trkpt.time, false, QPointF(trkpt.lon * DEG_TO_RAD, trkpt.lat * DEG_TO_RAD)));
+                info.info += "<br/>" + tr("Created: %1").arg(IUnit::datetime2string(trkpt.time, IUnit::eTimeFormatLong, QPointF(trkpt.lon * DEG_TO_RAD, trkpt.lat * DEG_TO_RAD)));
             }
 
             CWptIconManager& wptMgr = CWptIconManager::self();
@@ -716,7 +716,7 @@ QString CDetailsPrj::getNameAndTime(const wpt_info_t& info, const CGisItemTrk& t
     if (arrivalTime.isValid())
     {
         str += info.info + "<br/>\n" +
-               tr("Arrival: ") + QString("%1").arg(IUnit::datetime2string(arrivalTime.addSecs(info.elapsedSeconds1), false));
+               tr("Arrival: ") + QString("%1").arg(IUnit::datetime2string(arrivalTime.addSecs(info.elapsedSeconds1), IUnit::eTimeFormatLong));
     }
     else
     {

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -565,7 +565,7 @@ QString IGisProject::getInfo() const
     if(metadata.time.isValid())
     {
         str += "<br/>\n";
-        str += IUnit::datetime2string(metadata.time, false);
+        str += IUnit::datetime2string(metadata.time, IUnit::eTimeFormatLong);
     }
 
 

--- a/src/qmapshack/gis/rte/CGisItemRte.cpp
+++ b/src/qmapshack/gis/rte/CGisItemRte.cpp
@@ -430,7 +430,7 @@ QString CGisItemRte::getInfo(quint32 feature) const
     if(!rte.lastRoutedWith.isEmpty())
     {
         str += "<br/>\n";
-        str += tr("Last time routed:<br/>%1").arg(IUnit::datetime2string(rte.lastRoutedTime, false, boundingRect.center()));
+        str += tr("Last time routed:<br/>%1").arg(IUnit::datetime2string(rte.lastRoutedTime, IUnit::eTimeFormatLong, boundingRect.center()));
         str += "<br/>\n";
         str += tr("with %1").arg(rte.lastRoutedWith);
     }

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -548,7 +548,7 @@ QString CGisItemTrk::getInfo(quint32 feature) const
 
     if(timeIsValid && timeStart.isValid())
     {
-        str += tr("Start: %1").arg(IUnit::datetime2string(timeStart, false, boundingRect.center()));
+        str += tr("Start: %1").arg(IUnit::datetime2string(timeStart, IUnit::eTimeFormatLong, boundingRect.center()));
     }
     else
     {
@@ -558,7 +558,7 @@ QString CGisItemTrk::getInfo(quint32 feature) const
 
     if(timeIsValid && timeEnd.isValid())
     {
-        str += tr("End: %1").arg(IUnit::datetime2string(timeEnd, false, boundingRect.center()));
+        str += tr("End: %1").arg(IUnit::datetime2string(timeEnd, IUnit::eTimeFormatLong, boundingRect.center()));
     }
     else
     {
@@ -735,7 +735,7 @@ QString CGisItemTrk::getInfoTrkPt(const CTrackData::trkpt_t& pt) const
 
     if(totalElapsedSeconds != 0)
     {
-        str += IUnit::datetime2string(pt.time, false, QPointF(pt.lon, pt.lat) * DEG_TO_RAD);
+        str += IUnit::datetime2string(pt.time, IUnit::eTimeFormatLong, QPointF(pt.lon, pt.lat) * DEG_TO_RAD);
         str += "\n";
     }
 

--- a/src/qmapshack/gis/trk/CListTrkPts.cpp
+++ b/src/qmapshack/gis/trk/CListTrkPts.cpp
@@ -173,7 +173,7 @@ void CListTrkPts::addTableRow(bool focus, const CTrackData::trkpt_t& trkpt, bool
     stream << "<td style='background: " << bgInRange << ";'>" << QString::number(trkpt.idxTotal) << "</td>";
 
     stream << "<td>" << (trkpt.time.isValid()
-                         ? IUnit::self().datetime2string(trkpt.time, true, QPointF(trkpt.lon, trkpt.lat) * DEG_TO_RAD)
+                         ? IUnit::self().datetime2string(trkpt.time, IUnit::eTimeFormatShort, QPointF(trkpt.lon, trkpt.lat) * DEG_TO_RAD)
                          : "-") << "</td>";
 
     QString val, unit;

--- a/src/qmapshack/gis/trk/CTableTrk.cpp
+++ b/src/qmapshack/gis/trk/CTableTrk.cpp
@@ -180,7 +180,7 @@ void CTableTrk::updateData()
         item->setText(eColNum, QString::number(trkpt.idxTotal));
 
         item->setText(eColTime, trkpt.time.isValid()
-                      ? IUnit::self().datetime2string(trkpt.time, true, QPointF(trkpt.lon, trkpt.lat) * DEG_TO_RAD)
+                      ? IUnit::self().datetime2string(trkpt.time, IUnit::eTimeFormatShort, QPointF(trkpt.lon, trkpt.lat) * DEG_TO_RAD)
                       : "-"
                       );
 

--- a/src/qmapshack/gis/wpt/CDetailsWpt.cpp
+++ b/src/qmapshack/gis/wpt/CDetailsWpt.cpp
@@ -109,7 +109,7 @@ void CDetailsWpt::setupGui()
 
     if(wpt.getTimestamp().isValid())
     {
-        const QString& strTime = IUnit::datetime2string(wpt.getTimestamp(), false, QPointF(pos.x() * DEG_TO_RAD, pos.y() * DEG_TO_RAD));
+        const QString& strTime = IUnit::datetime2string(wpt.getTimestamp(), IUnit::eTimeFormatLong, QPointF(pos.x() * DEG_TO_RAD, pos.y() * DEG_TO_RAD));
         labelTime->setText(IGisItem::toLink(isReadOnly, "time", strTime, ""));
     }
     else

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -370,7 +370,7 @@ QString CGisItemWpt::getInfo(quint32 feature) const
         if(lastFound.isValid())
         {
             str += "<br/>" + tr("Last found: %1")
-                   .arg(IUnit::datetime2string(lastFound, false, wpt));
+                   .arg(IUnit::datetime2string(lastFound, IUnit::eTimeFormatLong, wpt));
         }
 
         const IGisProject* project = getParentProject();
@@ -380,7 +380,7 @@ QString CGisItemWpt::getInfo(quint32 feature) const
             if(projectDate.isValid())
             {
                 str += "<br/>" + tr("Project created: %1")
-                       .arg(IUnit::datetime2string(projectDate, false, wpt));
+                       .arg(IUnit::datetime2string(projectDate, IUnit::eTimeFormatLong, wpt));
             }
         }
     }
@@ -429,7 +429,7 @@ QString CGisItemWpt::getInfo(quint32 feature) const
             {
                 str += "<br/>\n";
             }
-            str += tr("Created: %1").arg(IUnit::datetime2string(wpt.time, false, QPointF(wpt.lon * DEG_TO_RAD, wpt.lat * DEG_TO_RAD)));
+            str += tr("Created: %1").arg(IUnit::datetime2string(wpt.time, IUnit::eTimeFormatLong, QPointF(wpt.lon * DEG_TO_RAD, wpt.lat * DEG_TO_RAD)));
         }
     }
 

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -777,7 +777,7 @@ QDateTime IUnit::parseTimestamp(const QString& timetext, int& tzoffset)
     return datetime;
 }
 
-QString IUnit::datetime2string(const QDateTime& time, bool shortDate, const QPointF& pos)
+QString IUnit::datetime2string(const QDateTime& time, time_format_e format, const QPointF& pos)
 {
     QTimeZone tz;
 
@@ -803,8 +803,18 @@ QString IUnit::datetime2string(const QDateTime& time, bool shortDate, const QPoi
     }
 
     QDateTime tmp = time.toTimeZone(tz);
-    const QString& format = QLocale().dateTimeFormat((shortDate | useShortFormat) ? QLocale::ShortFormat : QLocale::LongFormat);
-    return tmp.toString(format);
+
+    switch(format)
+    {
+    case eTimeFormatLong:
+        return tmp.toString(QLocale().dateTimeFormat(useShortFormat ? QLocale::ShortFormat: QLocale::LongFormat));
+    case eTimeFormatShort:
+        return tmp.toString(QLocale().dateTimeFormat(QLocale::ShortFormat));
+    case eTimeFormatIso:
+        return tmp.toString(Qt::ISODate);
+    }
+
+    return tmp.toString(QLocale().dateTimeFormat(QLocale::LongFormat));
 }
 
 QByteArray IUnit::pos2timezone(const QPointF& pos)

--- a/src/qmapshack/units/IUnit.h
+++ b/src/qmapshack/units/IUnit.h
@@ -105,16 +105,18 @@ public:
     /// parse a string for a timestamp
     static bool parseTimestamp(const QString& time, QDateTime& datetime);
 
+
+    enum time_format_e {eTimeFormatLong, eTimeFormatShort, eTimeFormatIso};
     /**
        @brief Convert date time object to string using the current timezone configuration
 
 
        @param time          the date/time object
-       @param shortDate     set true to get a short ISO time string
+       @param format        one of time_format_e
        @param pos           optional a position attached to the date/time object [rad]
        @return              A time string.
      */
-    static QString datetime2string(const QDateTime& time, bool shortDate, const QPointF& pos = NOPOINTF);
+    static QString datetime2string(const QDateTime& time, time_format_e format, const QPointF& pos = NOPOINTF);
 
     /// find the timezone setup by position
     static QByteArray pos2timezone(const QPointF& pos);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-551

### What you have done:
[comment]: # (Describe roughly.)
Set QDateTime short format back to Qt::ISODate in IUnit::datetime2string for qmapshack and qmaptool.
Note:
QDateTime is overloaded and can take two arguments:
enum Qt::DateFormat for Qt::ISODate
and
const QString for QLocale().dateTimeFormat(QLocale::LongFormat)

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Connect Garmin device with fit format ==> ISODate will be used as track (file) name.
2. Set in View / Setup Time zone long format, Exit QMS and restart
    Edit a track ==> in track info long format will be shown

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
