### PR TITLE
[QMS-560] Fix FilterSplitTrack

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ V1.XX.X
 [QMS-542] Changed drag`n drop in workspace
 [QMS-551] Set QDateTime short format back to Qt::ISODate
 [QMS-557] Add FilterSplitTrack
+[QMS-560] Fix FilterSplitTrack to include all track points
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/gis/trk/filter/filter.cpp
+++ b/src/qmapshack/gis/trk/filter/filter.cpp
@@ -657,11 +657,13 @@ void CGisItemTrk::filterLoopsCut(qreal minLoopLength)
 
 void CGisItemTrk::filterSplitTrack(qint8 nTracks)
 {
-    IGisProject* project = CGisWorkspace::self().selectProject(false);
     if(cntTotalPoints <= nTracks)// Can't split into tracks with length 1 or smaller
     {
+        QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("The filter can not be applied"), tr("The number of points in the track must be higher"
+        " than the number of tracks to split into."), QMessageBox::Abort, QMessageBox::Abort);
         return;
     }
+    IGisProject* project = CGisWorkspace::self().selectProject(false);
     if(nullptr == project)
     {
         return;

--- a/src/qmapshack/gis/trk/filter/filter.cpp
+++ b/src/qmapshack/gis/trk/filter/filter.cpp
@@ -658,28 +658,29 @@ void CGisItemTrk::filterLoopsCut(qreal minLoopLength)
 void CGisItemTrk::filterSplitTrack(qint8 nTracks)
 {
     IGisProject* project = CGisWorkspace::self().selectProject(false);
+    if(cntTotalPoints <= nTracks)// Can't split into tracks with length 1 or smaller
+    {
+        return;
+    }
     if(nullptr == project)
     {
         return;
     }
-    const qint32 segNodes = cntTotalPoints/nTracks + (cntTotalPoints % nTracks != 0); //take ceil
+    const qint32 cntTotalPointsNew = cntTotalPoints + nTracks - 1;
+    const qint32 segNodes = cntTotalPointsNew/nTracks;
+    qint32 nOver = cntTotalPointsNew % nTracks; // Reaminder of nodes to distribute over splitted tracks
 
     qint32 segStartIdx = 0;
-    qint32 segEndIdx = segNodes-1;
-    qint32 remaining = cntTotalPoints;
+    qint32 segEndIdx = segNodes - 1 + (nOver > 0);
 
-    qint8 part=0;
-    while(part<nTracks)
+    qint8 part = 0;
+    while(part < nTracks)
     {
         new CGisItemTrk(tr("%1 (Part %2)").arg(trk.name).arg(part), segStartIdx, segEndIdx, trk, project);
-
-        // update remaining
-        remaining -= segNodes;
-        remaining += 1; //The last node is used as starting node
-
         // for next segment. If this was last, never used again
+        nOver--;
         segStartIdx = segEndIdx;
-        segEndIdx = segStartIdx + qMin(remaining, segNodes)-1;
+        segEndIdx = segStartIdx + segNodes - 1 + (nOver > 0);
 
         ++part;        
     }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#560

### What you have done:
[comment]: # (Describe roughly.)
I fixed the filter function filterSplitTrack to include all points of the original track and not generate empty tracks or tracks with just one point. In addition tracks points are distributed more equally over the track "segments".


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open a track
2. Right-click on the track, Edit, Filter, Miscellaneous
3. Split track into multiple shorter tracks: Select number of tracks to split into and press apply button.
4. Confirm dialog and check if new tracks are generated and contain the correct track points


### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
