### PR TITLE
Added support for more decimals in GPS timestamps

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ V1.XX.X
 [QMS-557] Add FilterSplitTrack
 [QMS-560] Fix FilterSplitTrack to include all track points
 [QMS-571] MacOS build scripts and CMakeLists.txt changed (ARM/Intel, QMapTool.app fixed)
+[QMS-572] Added support for more decimals in GPS timestamps
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/realtime/gpstether/CRtGpsTetherInfo.cpp
+++ b/src/qmapshack/realtime/gpstether/CRtGpsTetherInfo.cpp
@@ -344,7 +344,7 @@ void CRtGpsTetherInfo::nmeaRMC(const QStringList& tokens)
         return;
     }
     rmc.isValid = true;
-    rmc.datetime = QDateTime::fromString(tokens[1] + tokens[9], "hhmmss.00ddMMyy").addYears(100);
+    rmc.datetime = QDateTime::fromString(tokens[9] + tokens[1], "ddMMyyhhmmss.z").addYears(100);
     rmc.datetime.setTimeSpec(Qt::UTC);
 
     {
@@ -383,7 +383,7 @@ void CRtGpsTetherInfo::nmeaGGA(const QStringList& tokens)
     }
 
     gga.isValid = true;
-    gga.datetime.setTime(QTime::fromString(tokens[1], "hhmmss.00"));
+    gga.datetime.setTime(QTime::fromString(tokens[1], "hhmmss.z"));
     gga.datetime.setDate(QDate::currentDate());
     gga.datetime.setTimeSpec(Qt::UTC);
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#570

### What you have done:
[comment]: # (Describe roughly.)



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open whatever
2. Click here

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
