### PR TITLE
Added "Ok" button to DetailsWpt dialog

### DIFF
--- a/src/qmapshack/gis/wpt/CDetailsWpt.cpp
+++ b/src/qmapshack/gis/wpt/CDetailsWpt.cpp
@@ -57,6 +57,8 @@ CDetailsWpt::CDetailsWpt(CGisItemWpt& wpt, QWidget* parent)
     connect(toolAddImage, &QToolButton::clicked, photoAlbum, &CPhotoAlbum::slotAddImage);
     connect(toolDelImage, &QToolButton::clicked, photoAlbum, &CPhotoAlbum::slotDelImage);
     connect(photoAlbum, &CPhotoAlbum::sigChanged, this, &CDetailsWpt::slotChangedImages);
+
+    connect(toolOk, &QToolButton::clicked, this, &CDetailsWpt::done);
 }
 
 CDetailsWpt::~CDetailsWpt()

--- a/src/qmapshack/gis/wpt/IDetailsWpt.ui
+++ b/src/qmapshack/gis/wpt/IDetailsWpt.ui
@@ -432,6 +432,26 @@
              </property>
             </spacer>
            </item>
+           <item>
+            <widget class="QToolButton" name="toolOk">
+             <property name="toolTip">
+              <string>Add images.</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../../resources.qrc">
+               <normaloff>:/icons/32x32/Check.png</normaloff>:/icons/32x32/Check.png</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
          <item row="0" column="0">


### PR DESCRIPTION
Usually I use a tiling WM without any window decorations, so adding a waypoint requires to press hotkeys to close the dialog with waypoint description.
This commit just adds an "Ok" button. I do understand that location isn't usual bottom-right, but at least it's aligned with existing grid and doesn't affect layout.