### PR TITLE
[QMS-585] Fix gpx export for OSMAnd

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ V1.XX.X
 [QMS-560] Fix FilterSplitTrack to include all track points
 [QMS-571] MacOS build scripts and CMakeLists.txt changed (ARM/Intel, QMapTool.app fixed)
 [QMS-572] Added support for more decimals in GPS timestamps
+[QMS-585] GPX no more compatible with Osmand
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -40,6 +40,7 @@ const QString IGisProject::ql_ns = "http://www.qlandkarte.org/xmlschemas/v1.1";
 const QString IGisProject::gs_ns = "http://www.groundspeak.com/cache/1/0";
 const QString IGisProject::tp1_ns = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1";
 const QString IGisProject::gpxdata_ns = "http://www.cluetrust.com/XML/GPXDATA/1/0";
+const QString IGisProject::osmand_ns = "https://osmand.net";
 
 
 static void readXml(const QDomNode& xml, const QString& tag, qint32& value)
@@ -480,6 +481,7 @@ QDomNode IGisProject::writeMetadata(QDomDocument& doc, bool strictGpx11)
         gpx.setAttribute("xmlns:ql", ql_ns);
         gpx.setAttribute("xmlns:tp1", tp1_ns);
         gpx.setAttribute("xmlns:gpxdata", gpxdata_ns);
+        gpx.setAttribute("xmlns:osmand", osmand_ns);
 
 
 

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -601,6 +601,7 @@ protected:
     static const QString gpx_ns;
     static const QString xsi_ns;
     static const QString gpxdata_ns;
+    static const QString osmand_ns;
 
     static QString keyUserFocus;
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#585

### What you have done:
[comment]: # (Describe roughly.)

Simply add the OSMAnd xls namespace to the  list of known namespace

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Open gpx file from OSMAnd
* Save it with extensions 
*  Check if it can be read by OSMAnd

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
