### PR TITLE
[QMS-594] adjust java version parsing regex to allow pure major version schemes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,4 @@
 V1.XX.X
-[QMS-594] Java version check fails in BRouter setup
 [QMS-429] Bad OSM Tag formatting crashes QMS
 [QMS-470] Windows build scripts: adapt for release v1.16.1
 |QMS-476] Color the map by elevation
@@ -27,6 +26,7 @@ V1.XX.X
 [QMS-572] Added support for more decimals in GPS timestamps
 [QMS-586] Added support for AIS realtime source
 [QMS-591] MacOS build adapted for new Quazip version / preperation for brew package
+[QMS-594] Java version check fails in BRouter setup
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-594] Java version check fails in BRouter setup
 [QMS-429] Bad OSM Tag formatting crashes QMS
 [QMS-470] Windows build scripts: adapt for release v1.16.1
 |QMS-476] Color the map by elevation

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -888,11 +888,11 @@ void CRouterBRouterSetup::setJava(const QString& path)
 {
     localJavaExecutable = path;
 
-    if (tryJavaVersion({ "-version" }, "[\\S]+ version \"(\\d+)\\.\\d+.*"))
+    if (tryJavaVersion({ "-version" }, "[\\S]+ version \"(\\d+)(\\.\\d+)*\" .*"))
     {
         return;
     }
-    if (tryJavaVersion({ "--version" }, "[\\S]+ (\\d+)\\.\\d+.*"))
+    if (tryJavaVersion({ "--version" }, "[\\S]+ (\\d+)(\\.\\d+)* .*"))
     {
         return;
     }


### PR DESCRIPTION
### What is the linked issue for this pull request:

QMS-#594

### What you have done:

changed the regular expression that parses the result of executing 'java -version' (resp. 'java --version') to detect version s that consist of a major version only (with no minor-version separated by '.' being defined).

### Steps to perform a simple smoke test:

1. Open brouter setup wizard, choose 'local installation', do not check 'expert-mode'
2. click next to the dialog that allows to choose the java executable
3. click 'search for installed java'
4. verify that no warning 'Your Java version unknown seems to be older than the required version xxx' is being displayed.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
