### PR TITLE
[QMS-606] Better hillshading with high resolution Lidar data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ V1.XX.X
 [QMS-586] Added support for AIS realtime source
 [QMS-591] MacOS build adapted for new Quazip version / preperation for brew package
 [QMS-594] Java version check fails in BRouter setup
+[QMS-606] Better hillshading with high resolution Lidar data
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -20,7 +20,6 @@
 #include "CMainWindow.h"
 #include "dem/CDemDraw.h"
 #include "dem/CDemVRT.h"
-#include "gis/GeoMath.h"
 #include "helpers/CDraw.h"
 #include "units/IUnit.h"
 
@@ -132,7 +131,7 @@ qreal CDemVRT::getElevationAt(const QPointF& pos, bool checkScale)
         return NOFLOAT;
     }
 
-    qint16 e[4];
+    float e[4];
     QPointF pt = pos;
 
     proj.transform(pt, PJ_INV);
@@ -148,7 +147,7 @@ qreal CDemVRT::getElevationAt(const QPointF& pos, bool checkScale)
     qreal y = pt.y() - qFloor(pt.y());
 
     mutex.lock();
-    CPLErr err = dataset->RasterIO(GF_Read, qFloor(pt.x()), qFloor(pt.y()), 2, 2, &e, 2, 2, GDT_Int16, 1, 0, 0, 0, 0);
+    CPLErr err = dataset->RasterIO(GF_Read, qFloor(pt.x()), qFloor(pt.y()), 2, 2, &e, 2, 2, GDT_Float32, 1, 0, 0, 0, 0);
     mutex.unlock();
     if(err == CE_Failure)
     {
@@ -191,9 +190,9 @@ qreal CDemVRT::getSlopeAt(const QPointF& pos, bool checkScale)
     qreal x = pt.x() - qFloor(pt.x());
     qreal y = pt.y() - qFloor(pt.y());
 
-    qint16 win[eWinsize4x4];
+    float win[eWinsize4x4];
     mutex.lock();
-    CPLErr err = dataset->RasterIO(GF_Read, qFloor(pt.x()) - 1, qFloor(pt.y()) - 1, 4, 4, &win, 4, 4, GDT_Int16, 1, 0, 0, 0, 0);
+    CPLErr err = dataset->RasterIO(GF_Read, qFloor(pt.x()) - 1, qFloor(pt.y()) - 1, 4, 4, &win, 4, 4, GDT_Float32, 1, 0, 0, 0, 0);
     mutex.unlock();
     if(err == CE_Failure)
     {
@@ -353,9 +352,9 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf)
                     }
                 }
 
-                QVector<qint16> data(wp2_used* hp2_used);
+                QVector<float> data(wp2_used* hp2_used);
                 mutex.lock();
-                err = dataset->RasterIO(GF_Read, x, y, wp2_used, hp2_used, data.data(), wp2_used, hp2_used, GDT_Int16, 1, 0, 0, 0, 0);
+                err = dataset->RasterIO(GF_Read, x, y, wp2_used, hp2_used, data.data(), wp2_used, hp2_used, GDT_Float32, 1, 0, 0, 0, 0);
                 mutex.unlock();
 
                 if(err)

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -17,7 +17,6 @@
 
 **********************************************************************************************/
 
-#include "CMainWindow.h"
 #include "dem/CDemDraw.h"
 #include "dem/CDemPropSetup.h"
 #include "dem/IDem.h"
@@ -25,12 +24,14 @@
 
 #include <QtWidgets>
 
-inline qint16 getValue(QVector<qint16>& data, int x, int y, int dx)
+template <typename T>
+inline T getValue(QVector<T>& data, int x, int y, int dx)
 {
     return data[x + y * dx];
 }
 
-inline void fillWindow(QVector<qint16>& data, int x, int y, int dx, qint16* w)
+template <typename T>
+inline void fillWindow(QVector<T>& data, int x, int y, int dx, T* w)
 {
     w[0] = getValue(data, x - 1, y - 1, dx);
     w[1] = getValue(data, x, y - 1, dx);
@@ -43,7 +44,8 @@ inline void fillWindow(QVector<qint16>& data, int x, int y, int dx, qint16* w)
     w[8] = getValue(data, x + 1, y + 1, dx);
 }
 
-inline void fillWindow4x4(QVector<qint16>& data, qreal x, qreal y, int dx, qint16* w)
+template <typename T>
+inline void fillWindow4x4(QVector<T>& data, qreal x, qreal y, int dx, T* w)
 {
     x = qFloor(x);
     y = qFloor(y);
@@ -259,7 +261,7 @@ int IDem::getFactorHillshading() const
     }
 }
 
-void IDem::hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const
+void IDem::hillshading(QVector<float>& data, qreal w, qreal h, QImage& img) const
 {
     int wp2 = w + 2;
 
@@ -273,7 +275,7 @@ void IDem::hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img) con
         unsigned char* scan = img.scanLine(m - 1);
         for(unsigned int n = 1; n <= w; n++)
         {
-            qint16 win[eWinsize3x3];
+            float win[eWinsize3x3];
             fillWindow(data, n, m, wp2, win);
 
             if(hasNoData && win[4] == noData)
@@ -307,7 +309,7 @@ int IDem::getFactorSlopeShading() const
     return factorSlopeShading * 100.;
 }
 
-void IDem::slopeShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const
+void IDem::slopeShading(QVector<float>& data, qreal w, qreal h, QImage& img) const
 {
     int wp2 = w + 2;
 
@@ -316,7 +318,7 @@ void IDem::slopeShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) co
         unsigned char* scan = img.scanLine(m - 1);
         for(unsigned int n = 1; n <= w; n++)
         {
-            qint16 win[eWinsize3x3];
+            float win[eWinsize3x3];
             fillWindow(data, n, m, wp2, win);
 
             if(hasNoData && win[4] == noData)
@@ -344,7 +346,7 @@ void IDem::slopeShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) co
     }
 }
 
-qreal IDem::slopeOfWindowInterp(qint16* win2, winsize_e size, qreal x, qreal y) const
+qreal IDem::slopeOfWindowInterp(float* win2, winsize_e size, qreal x, qreal y) const
 {
     for(int i = 0; i < size; i++)
     {
@@ -390,7 +392,7 @@ qreal IDem::slopeOfWindowInterp(qint16* win2, winsize_e size, qreal x, qreal y) 
     return slope;
 }
 
-void IDem::slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage& img) const
+void IDem::slopecolor(QVector<float>& data, qreal w, qreal h, QImage& img) const
 {
     int wp2 = w + 2;
 
@@ -399,7 +401,7 @@ void IDem::slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage& img) cons
         unsigned char* scan = img.scanLine(m - 1);
         for(unsigned int n = 1; n <= w; n++)
         {
-            qint16 win[eWinsize3x3];
+            float win[eWinsize3x3];
             fillWindow(data, n, m, wp2, win);
             qreal slope = slopeOfWindowInterp(win, eWinsize3x3, 0, 0);
 
@@ -433,7 +435,7 @@ void IDem::slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage& img) cons
     }
 }
 
-void IDem::elevationLimit(QVector<qint16>& data, qreal w, qreal h, QImage& img) const
+void IDem::elevationLimit(QVector<float>& data, qreal w, qreal h, QImage& img) const
 {
     int wp2 = w + 2;
 
@@ -442,7 +444,7 @@ void IDem::elevationLimit(QVector<qint16>& data, qreal w, qreal h, QImage& img) 
         unsigned char* scan = img.scanLine(m - 1);
         for(unsigned int n = 1; n <= w; n++)
         {
-            qint16 win[eWinsize3x3];
+            float win[eWinsize3x3];
             fillWindow(data, n, m, wp2, win);
 
             // get maximum of window (_not_ mean)
@@ -471,7 +473,7 @@ void IDem::elevationLimit(QVector<qint16>& data, qreal w, qreal h, QImage& img) 
     }
 }
 
-void IDem::elevationShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const
+void IDem::elevationShading(QVector<float>& data, qreal w, qreal h, QImage& img) const
 {
     int wp2 = w + 2;
 
@@ -480,7 +482,7 @@ void IDem::elevationShading(QVector<qint16>& data, qreal w, qreal h, QImage& img
         unsigned char* scan = img.scanLine(m - 1);
         for(unsigned int n = 1; n <= w; n++)
         {
-            qint16 win[eWinsize3x3];
+            float win[eWinsize3x3];
             fillWindow(data, n, m, wp2, win);
 
             // get maximum of window (_not_ mean)

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -178,15 +178,15 @@ public slots:
 
 protected:
 
-    void hillshading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
+    void hillshading(QVector<float>& data, qreal w, qreal h, QImage& img) const;
 
-    void slopeShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
+    void slopeShading(QVector<float> &data, qreal w, qreal h, QImage& img) const;
 
-    void slopecolor(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
+    void slopecolor(QVector<float> &data, qreal w, qreal h, QImage& img) const;
 
-    void elevationLimit(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
+    void elevationLimit(QVector<float> &data, qreal w, qreal h, QImage& img) const;
 
-    void elevationShading(QVector<qint16>& data, qreal w, qreal h, QImage& img) const;
+    void elevationShading(QVector<float> &data, qreal w, qreal h, QImage& img) const;
 
     /**
        @brief Slope in degrees based on a window. Origin is at point (1,1), counting from zero.
@@ -196,7 +196,7 @@ protected:
        @param y     Fractional value (0..1) for interpolation in y (4x4 window only)
        @return      Slope in degrees
      */
-    qreal slopeOfWindowInterp(qint16* win2, winsize_e size, qreal x, qreal y) const;
+    qreal slopeOfWindowInterp(float *win2, winsize_e size, qreal x, qreal y) const;
 
     /**
        @brief Reproject (translate, rotate, scale) tile before drawing it.


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#606

### What you have done:
[comment]: # (Describe roughly.)

Read data from files as float instead of uin16. Process data as float.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use Lidar data for DEM layer. Old version will show shading as stair cases. This patch will do a smooth shading.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
