### PR TITLE
[QMS-612] Optimize DEM rendering by using a thread pool

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ V1.XX.X
 [QMS-606] Better hillshading with high resolution Lidar data
 [QMS-608] Update local copy of alglib 
 [QMS-610] Replace uncrustify by clang-format
+[QMS-612] Optimize DEM rendering by using a thread pool
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/canvas/IDrawContext.cpp
+++ b/src/qmapshack/canvas/IDrawContext.cpp
@@ -164,7 +164,7 @@ void IDrawContext::zoom(int idx) {
     zoomFactor.rx() = scales[idx];
     zoomFactor.ry() = scales[idx];
     intNeedsRedraw = true;
-
+    emit sigNeedsRedraw();
     emit sigScaleChanged(scale * zoomFactor);
   }
   mutex.unlock();  // --------- stop serialize with thread
@@ -370,6 +370,7 @@ void IDrawContext::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QPoint
   // intNeedsRedraw is reset by the thread
   if (needsRedraw & maskRedraw) {
     intNeedsRedraw = true;
+    emit sigNeedsRedraw();
   }
   mutex.unlock();  // --------- stop serialize with thread
 

--- a/src/qmapshack/canvas/IDrawContext.h
+++ b/src/qmapshack/canvas/IDrawContext.h
@@ -135,6 +135,7 @@ class IDrawContext : public QThread {
   void sigStartThread();
   void sigStopThread();
   void sigScaleChanged(const QPointF& scale);
+  void sigNeedsRedraw();
 
  public slots:
   void emitSigCanvasUpdate();

--- a/src/qmapshack/canvas/IDrawObject.cpp
+++ b/src/qmapshack/canvas/IDrawObject.cpp
@@ -72,7 +72,8 @@ void IDrawObject::setMaxScale(qreal s) {
   maxScale = s;
 }
 
-void IDrawObject::drawTileLQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context, const CProj& proj) {
+void IDrawObject::drawTileLQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context,
+                             const CProj& proj) const {
   QPolygonF tmp = l;
   context.convertRad2Px(l);
 
@@ -104,7 +105,8 @@ void IDrawObject::drawTileLQ(const QImage& img, QPolygonF& l, QPainter& p, IDraw
   p.restore();
 }
 
-void IDrawObject::drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context, const CProj& proj) {
+void IDrawObject::drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context,
+                             const CProj& proj) const {
   // the sub-tiles need a sensible size
   // if they get too small there will be too much
   // rounding effects.

--- a/src/qmapshack/canvas/IDrawObject.h
+++ b/src/qmapshack/canvas/IDrawObject.h
@@ -115,9 +115,9 @@ class IDrawObject : public QObject {
   virtual void configureCache() {}
 
   // draw tiles with low quality re-projection but fast
-  void drawTileLQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context, const CProj& proj);
+  void drawTileLQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context, const CProj& proj) const;
   // draw tiles with high quality re-projection but slow
-  void drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context, const CProj& proj);
+  void drawTileHQ(const QImage& img, QPolygonF& l, QPainter& p, IDrawContext& context, const CProj& proj) const;
 
  private:
   /// the opacity level of a map

--- a/src/qmapshack/dem/CDemVRT.h
+++ b/src/qmapshack/dem/CDemVRT.h
@@ -20,6 +20,7 @@
 #define CDEMVRT_H
 
 #include <QMutex>
+#include <QThreadPool>
 
 #include "dem/IDem.h"
 
@@ -37,10 +38,16 @@ class CDemVRT : public IDem {
   qreal getElevationAt(const QPointF& pos, bool checkScale) override;
   qreal getSlopeAt(const QPointF& pos, bool checkScale) override;
 
- private:
-  void drawElevationShadeScale(QPainter& p) const;
+ private slots:
+  void slotNeedsRedraw();
 
-  QMutex mutex;
+ private:
+  using IDem::drawTile;
+  void drawElevationShadeScale(QPainter& p) const;
+  void drawTile(const qint32 x, const qint32 y, const qint32 w, const qint32 h,
+                const qreal o1, const qreal o2, QPainter& p) const;
+
+  mutable QMutex mutex;
 
   QString filename;
   /// instance of GDAL dataset
@@ -55,10 +62,11 @@ class CDemVRT : public IDem {
   QTransform trInv;
 
   bool hasOverviews = false;
+  bool outOfScale = false;
 
   QRectF boundingBox;
 
-  bool outOfScale = false;
+  QThreadPool threadPool;
 };
 
 #endif  // CDEMVRT_H

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -65,16 +65,17 @@ inline void fillWindow4x4(QVector<T>& data, qreal x, qreal y, int dx, T* w) {
   w[15] = getValue(data, x + 2, y + 2, dx);
 }
 
-const struct SlopePresets IDem::slopePresets[7]{/* http://www.alpenverein.de/bergsport/sicherheit/skitouren-schneeschuh-sicher-im-schnee/dav-snowcard_aid_10619.html
-                                                 */
-                                                {"Grade 1 (DAV Snowcard)", {27.0, 31.0, 34.0, 39.0, 50.0}},
-                                                {"Grade 2 (DAV Snowcard)", {27.0, 30.0, 32.0, 35.0, 39.0}},
-                                                {"Grade 3 (DAV Snowcard)", {27.0, 29.0, 30.0, 31.0, 34.0}},
-                                                {"Grade 4 (DAV Snowcard)", {23.0, 25.0, 27.0, 28.0, 30.0}},
+const struct SlopePresets IDem::slopePresets[7]{
+    /* http://www.alpenverein.de/bergsport/sicherheit/skitouren-schneeschuh-sicher-im-schnee/dav-snowcard_aid_10619.html
+     */
+    {"Grade 1 (DAV Snowcard)", {27.0, 31.0, 34.0, 39.0, 50.0}},
+    {"Grade 2 (DAV Snowcard)", {27.0, 30.0, 32.0, 35.0, 39.0}},
+    {"Grade 3 (DAV Snowcard)", {27.0, 29.0, 30.0, 31.0, 34.0}},
+    {"Grade 4 (DAV Snowcard)", {23.0, 25.0, 27.0, 28.0, 30.0}},
 
-                                                {"level country", {3.0, 6.0, 8.0, 12.0, 15.0}},
-                                                {"secondary mountain", {4.0, 7.0, 10.0, 15.0, 20.0}},
-                                                {"lofty mountain", {10.0, 15.0, 20.0, 30.0, 50.0}}};
+    {"level country", {3.0, 6.0, 8.0, 12.0, 15.0}},
+    {"secondary mountain", {4.0, 7.0, 10.0, 15.0, 20.0}},
+    {"lofty mountain", {10.0, 15.0, 20.0, 30.0, 50.0}}};
 
 IDem::IDem(CDemDraw* parent) : IDrawObject(parent), dem(parent) {
   slotSetOpacity(17);
@@ -431,4 +432,4 @@ void IDem::elevationShading(QVector<float>& data, qreal w, qreal h, QImage& img)
 
 void IDem::slotShowElevationShadeScale(bool yes) { bShowElevationShadeScale = yes; }
 
-void IDem::drawTile(QImage& img, QPolygonF& l, QPainter& p) { drawTileLQ(img, l, p, *dem, proj); }
+void IDem::drawTile(QImage& img, QPolygonF& l, QPainter& p) const { drawTileLQ(img, l, p, *dem, proj); }

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -150,7 +150,7 @@ class IDem : public IDrawObject {
      @param l     a 4 point polygon to fit the tile in
      @param p     the QPainter used to paint the tile
    */
-  void drawTile(QImage& img, QPolygonF& l, QPainter& p);
+  void drawTile(QImage& img, QPolygonF& l, QPainter& p) const;
 
   CDemDraw* dem;
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#612

### What you have done:
[comment]: # (Describe roughly.)

Move tile rendering into it's own method and call this method from a thread pool.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Load DEM Data
* Enable hillshading or any other overlay feature
* Test performance and stability

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
