### PR TITLE
[QMS-615] Syntax error when compiling QMS for Windows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ V1.XX.X
 [QMS-608] Update local copy of alglib 
 [QMS-610] Replace uncrustify by clang-format
 [QMS-612] Optimize DEM rendering by using a thread pool
+[QMS-615] Syntax error when compiling QMS for Windows
 
 V1.16.1
 [QMS-396] Save route sub-points as ordinary route points in case of track routing

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -22,6 +22,7 @@
 
 #include "CMainWindow.h"
 #include "CSingleInstanceProxy.h"
+#include "setup/CAppOpts.h"
 #include "setup/IAppSetup.h"
 #include "version.h"
 

--- a/src/qmapshack/setup/IAppSetup.cpp
+++ b/src/qmapshack/setup/IAppSetup.cpp
@@ -21,7 +21,14 @@
 #include <gdal.h>
 
 #include "CCommandProcessor.h"
+#if defined(Q_OS_MAC)
+#include "setup/CAppSetupMac.h"
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(__FreeBSD_kernel__) || defined(__GNU__)
 #include "setup/CAppSetupLinux.h"
+#elif defined(Q_OS_WIN32)
+#include "setup/CAppSetupWin.h"
+#endif
+
 #include "setup/CLogHandler.h"
 
 IAppSetup* IAppSetup::instance = nullptr;

--- a/src/qmapshack/setup/IAppSetup.h
+++ b/src/qmapshack/setup/IAppSetup.h
@@ -22,7 +22,6 @@
 #include <QApplication>
 #include <QtCore>
 
-#include "CAppOpts.h"
 
 class IAppSetup {
  public:


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#615

### What you have done:
[comment]: # (Describe roughly.)

Add includes for OS specific classes

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Compile for Windows

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
