### PR TITLE
[QMS-622] change installation-source of brouter to github

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+[QMS-622] Update BRouter setup (install from github)
+
 V1.17.0
 [QMS-429] Bad OSM Tag formatting crashes QMS
 [QMS-470] Windows build scripts: adapt for release v1.16.1

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -120,6 +120,7 @@ set( SRCS
     gis/rte/router/CRouterRoutino.cpp
     gis/rte/router/CRouterSetup.cpp
     gis/rte/router/IRouter.cpp
+    gis/rte/router/brouter/CRouterBRouterDownloadPage.cpp
     gis/rte/router/brouter/CRouterBRouterInfo.cpp
     gis/rte/router/brouter/CRouterBRouterLocal.cpp
     gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -490,6 +491,7 @@ set( HDRS
     gis/rte/router/CRouterRoutino.h
     gis/rte/router/CRouterSetup.h
     gis/rte/router/IRouter.h
+    gis/rte/router/brouter/CRouterBRouterDownloadPage.h
     gis/rte/router/brouter/CRouterBRouterInfo.h
     gis/rte/router/brouter/CRouterBRouterLocal.h
     gis/rte/router/brouter/CRouterBRouterSetup.h

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -195,7 +195,7 @@ QString CRouterBRouter::getOptions() {
 void CRouterBRouter::routerSelected() { getBRouterVersion(); }
 
 bool CRouterBRouter::hasFastRouting() {
-  return setup->installMode == CRouterBRouterSetup::eModeLocal && checkFastRecalc->isChecked();
+  return setup->installMode == CRouterBRouterSetup::eModeLocal && setup->isLocalBRouterValid && checkFastRecalc->isChecked();
 }
 
 QNetworkRequest CRouterBRouter::getRequest(const QVector<QPointF>& routePoints, const QList<IGisItem*>& nogos) const {

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterDownloadPage.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterDownloadPage.cpp
@@ -1,0 +1,266 @@
+/**********************************************************************************************
+    Copyright (C) 2023 Norbert Truchsess <norbert.truchsess@t-online.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#include "gis/rte/router/brouter/CRouterBRouterDownloadPage.h"
+
+#include <JlCompress.h>
+
+#include <QCheckBox>
+#include <QDir>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageBox>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QPushButton>
+
+#include "gis/rte/router/brouter/CRouterBRouterSetup.h"
+
+CRouterBRouterReleaseItem::CRouterBRouterReleaseItem(const QString& _name, const QString& _description,
+                                                     const QString& _url)
+    : name(_name), description(_description), url(_url) {}
+
+CRouterBRouterDownloadPage::CRouterBRouterDownloadPage() : QWizardPage() {
+  networkAccessManager = new QNetworkAccessManager(this);
+  networkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
+  connect(networkAccessManager, &QNetworkAccessManager::finished, this,
+          &CRouterBRouterDownloadPage::slotNetworkAccessManagerReplyReceived);
+  model = new QStringListModel(this);
+}
+
+CRouterBRouterDownloadPage::~CRouterBRouterDownloadPage() {}
+
+void CRouterBRouterDownloadPage::initialize(QListView* listVersions, QTextBrowser* textVersionDetails,
+                                            QLabel* labelInstallLink, QPushButton* pushInstall,
+                                            QTextBrowser* textLocalInstall, CRouterBRouterSetup* setup) {
+  this->listVersions = listVersions;
+  this->textVersionDetails = textVersionDetails;
+  this->labelInstallLink = labelInstallLink;
+  this->pushInstall = pushInstall;
+  this->textLocalInstall = textLocalInstall;
+  this->setup = setup;
+  this->listVersions->setModel(model);
+}
+
+void CRouterBRouterDownloadPage::begin() {
+  setComplete(setup->isLocalBRouterValid);
+  textVersionDetails->setVisible(false);
+  textVersionDetails->clear();
+  textLocalInstall->setVisible(false);
+  textLocalInstall->clear();
+  labelInstallLink->setText(tr("no brouter-version to install selected"));
+  pushInstall->setEnabled(false);
+  wizard()->setOption(QWizard::HaveCustomButton1, false);
+  downloadUrl = QUrl();
+
+  QNetworkRequest request(QUrl(setup->expertBinariesUrl));
+  request.setRawHeader(QByteArray("Accept"), QByteArray("application/vnd.github+json"));
+  request.setRawHeader(QByteArray("X-GitHub-Api-Version"), QByteArray("2022-11-28"));
+  QNetworkReply* reply = networkAccessManager->get(request);
+  reply->setProperty("requestType", eRequestVersions);
+}
+
+void CRouterBRouterDownloadPage::slotListVersionsClicked(const QModelIndex& index) {
+  const QString& version = index.data().toString();
+  for (const CRouterBRouterReleaseItem& item : qAsConst(releaseItems)) {
+    if (item.name == version) {
+      downloadUrl = QUrl(item.url);
+      textVersionDetails->setText(item.description);
+      textVersionDetails->setVisible(true);
+      textLocalInstall->setVisible(false);
+      labelInstallLink->setText(QString(tr("selected %1 for download and installation")).arg(downloadUrl.fileName()));
+      pushInstall->setEnabled(true);
+      break;
+    }
+  }
+}
+
+void CRouterBRouterDownloadPage::updateModel() const {
+  QStringList versions;
+  for (const CRouterBRouterReleaseItem& item : qAsConst(releaseItems)) {
+    versions.append(item.name);
+  }
+  model->setStringList(versions);
+}
+
+void CRouterBRouterDownloadPage::slotNetworkAccessManagerReplyReceived(QNetworkReply* reply) {
+  reply->deleteLater();
+  switch (reply->property("requestType").toInt()) {
+    case eRequestVersions: {
+      localBRouterVersionsLoadFinished(reply);
+      break;
+    }
+
+    case eRequestDownload: {
+      localBRouterDownloadFinished(reply);
+      break;
+    }
+  }
+}
+
+void CRouterBRouterDownloadPage::localBRouterVersionsLoadFinished(QNetworkReply* reply) {
+  try {
+    if (reply->error() != QNetworkReply::NoError) {
+      throw tr("Network Error: %1").arg(reply->errorString());
+    }
+    QJsonParseError error;
+    QByteArray content = reply->readAll();
+    const QJsonDocument& document = QJsonDocument::fromJson(content, &error);
+    if (error.error != QJsonParseError::NoError) {
+      throw tr("Error parsing json: %1").arg(error.errorString());
+    }
+    if (!document.isArray()) {
+      throw tr("Error parsing json: response is not an array: %1").arg(QString(content));
+    }
+    releaseItems.clear();
+    const QJsonArray& values = document.array();
+    for (const QJsonValue& value : values) {
+      const QJsonObject& releaseObj = value.toObject();
+      const QString& name = releaseObj["name"].toString();
+      const QString& description = releaseObj["body"].toString();
+      const QJsonArray& assets = releaseObj["assets"].toArray();
+      for (const QJsonValue& assetValue : assets) {
+        const QJsonObject& asset = assetValue.toObject();
+        if (asset["content_type"].toString() == "application/x-zip-compressed") {
+          const QString& url = asset["browser_download_url"].toString();
+          releaseItems.append(CRouterBRouterReleaseItem(name, description, url));
+          break;
+        }
+      }
+    }
+    if (releaseItems.size() == 0) {
+      throw tr("No releases found at %1").arg(setup->expertBinariesUrl);
+    }
+  } catch (const QString& msg) {
+    textLocalInstall->setTextColor(Qt::red);
+    textLocalInstall->append(tr("loading brouter version-data failed: %1").arg(msg));
+  }
+  updateModel();
+}
+
+void CRouterBRouterDownloadPage::slotLocalDownloadButtonClicked() const {
+  const QString& strUrl = downloadUrl.toString();
+
+  if (!strUrl.startsWith("https")) {
+    QMessageBox mbox;
+    mbox.setWindowTitle(tr("Warning..."));
+    mbox.setIcon(QMessageBox::Warning);
+    mbox.setStandardButtons(QMessageBox::Ok | QMessageBox::Abort);
+    mbox.setDefaultButton(QMessageBox::Abort);
+
+    QString msg = tr("Download: %1<br/>"
+                     "<br/>"
+                     "This will download and install a zip file from a download location that is not secured "
+                     "by any standard at all, using plain HTTP. Usually this should be HTTPS. The risk is "
+                     "someone redirecting the request and sending you a replacement zip with malware. There "
+                     "is no way for QMapShack to detect this. <br/>"
+                     "If you do not understand this or if you are in doubt, do not proceed and abort. "
+                     "Use the Web version of BRouter instead.")
+                      .arg(strUrl);
+
+    mbox.setText(msg);
+
+    QCheckBox* checkAgree = new QCheckBox(tr("I understand the risk and wish to proceed."), &mbox);
+    mbox.setCheckBox(checkAgree);
+    connect(checkAgree, &QCheckBox::clicked, mbox.button(QMessageBox::Ok), &QPushButton::setEnabled);
+    mbox.button(QMessageBox::Ok)->setDisabled(true);
+
+    if (mbox.exec() != QMessageBox::Ok) {
+      return;
+    }
+  }
+  pushInstall->setEnabled(false);
+  textVersionDetails->setVisible(false);
+  textLocalInstall->clear();
+  textLocalInstall->setVisible(true);
+  textLocalInstall->setTextColor(Qt::darkGreen);
+  textLocalInstall->append(tr("download %1 started").arg(downloadUrl.toString()));
+  QNetworkReply* reply = networkAccessManager->get(QNetworkRequest(downloadUrl));
+  reply->setProperty("requestType", eRequestDownload);
+  reply->setProperty("fileName", downloadUrl.fileName());
+}
+
+void CRouterBRouterDownloadPage::localBRouterDownloadFinished(QNetworkReply* reply) {
+  try {
+    if (reply->error() != QNetworkReply::NoError) {
+      throw tr("Network Error: %1").arg(reply->errorString());
+    }
+    const QString& fileName = reply->property("fileName").toString();
+    const QDir outDir(setup->localDir);
+    if (!outDir.exists()) {
+      throw tr("Error directory %1 does not exist").arg(outDir.absolutePath());
+    }
+    QDir downloadDir = setup->getDownloadDir();
+    QFile outfile(downloadDir.absoluteFilePath(fileName));
+    QStringList messageList;
+    try {
+      if (!outfile.open(QIODevice::WriteOnly)) {
+        throw tr("Error creating file %1").arg(outfile.fileName());
+      }
+      if (outfile.write(reply->readAll()) < 0) {
+        throw tr("Error writing to file %1").arg(outfile.fileName());
+      }
+      outfile.close();
+      textLocalInstall->setTextColor(Qt::darkGreen);
+      textLocalInstall->append(tr("download %1 finished").arg(outfile.fileName()));
+      const QStringList& unzippedNames = JlCompress::extractDir(outfile.fileName(), downloadDir.path());
+      textLocalInstall->append(tr("unzipping:"));
+      for (const QString& unzipped : unzippedNames) {
+        textLocalInstall->append(unzipped);
+      }
+      textLocalInstall->append(tr("installing into %1").arg(setup->localDir));
+      setup->installLocalBRouter(messageList);
+      for (const QString& message : qAsConst(messageList)) {
+        textLocalInstall->append(message);
+      }
+      messageList.clear();
+      downloadDir.removeRecursively();
+      textLocalInstall->append(tr("installation successful"));
+      setup->checkLocalBRouterInstallation();
+      setComplete(setup->isLocalBRouterValid);
+      setup->readLocalProfiles();
+    } catch (const QString& msg) {
+      for (const QString& message : qAsConst(messageList)) {
+        textLocalInstall->append(message);
+      }
+      if (outfile.isOpen()) {
+        outfile.close();
+      }
+      if (outfile.exists()) {
+        outfile.remove();
+      }
+      if (downloadDir.exists() && !downloadDir.isEmpty()) {
+        downloadDir.removeRecursively();
+      }
+      throw msg;
+    }
+  } catch (const QString& msg) {
+    textLocalInstall->setTextColor(Qt::red);
+    textLocalInstall->append(tr("installation of brouter failed: %1").arg(msg));
+  }
+}
+
+void CRouterBRouterDownloadPage::setComplete(bool newComplete) {
+  if (newComplete != complete) {
+    complete = newComplete;
+    emit completeChanged();
+  }
+}
+
+bool CRouterBRouterDownloadPage::isComplete() const { return complete; }

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterDownloadPage.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterDownloadPage.h
@@ -1,0 +1,86 @@
+/**********************************************************************************************
+    Copyright (C) 2023 Norbert Truchsess <norbert.truchsess@t-online.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CROUTERBROUTERDOWNLOADPAGE_H
+#define CROUTERBROUTERDOWNLOADPAGE_H
+
+#include <QLabel>
+#include <QListView>
+#include <QNetworkAccessManager>
+#include <QStringListModel>
+#include <QTextBrowser>
+#include <QWizardPage>
+
+class CRouterBRouterSetup;
+
+struct CRouterBRouterReleaseItem {
+ public:
+  CRouterBRouterReleaseItem(const QString& _name, const QString& _description, const QString& _url);
+
+ private:
+  QString name;
+  QString description;
+  QString url;
+
+  friend class CRouterBRouterDownloadPage;
+};
+
+class CRouterBRouterDownloadPage : public QWizardPage {
+  Q_OBJECT
+ public:
+  CRouterBRouterDownloadPage();
+  virtual ~CRouterBRouterDownloadPage();
+
+  bool isComplete() const override;
+
+  void initialize(QListView* listVersions, QTextBrowser* textVersionDetails, QLabel* labelInstallLink,
+                  QPushButton* pushInstall, QTextBrowser* textLocalInstall, CRouterBRouterSetup* setup);
+  void begin();
+
+ signals:
+  void sigBRouterJarChanged(const QString& fileName);
+
+ private slots:
+  void slotListVersionsClicked(const QModelIndex& index);
+  void slotNetworkAccessManagerReplyReceived(QNetworkReply* reply);
+  void slotLocalDownloadButtonClicked() const;
+
+ private:
+  enum { eRequestVersions, eRequestDownload };
+
+  void updateModel() const;
+  void localBRouterVersionsLoadFinished(QNetworkReply* reply);
+  void localBRouterDownloadFinished(QNetworkReply* reply);
+  void setComplete(bool newComplete);
+
+  QList<CRouterBRouterReleaseItem> releaseItems;
+  QStringListModel* model;
+  QNetworkAccessManager* networkAccessManager;
+  QListView* listVersions = nullptr;
+  QTextBrowser* textVersionDetails = nullptr;
+  QLabel* labelInstallLink = nullptr;
+  QPushButton* pushInstall = nullptr;
+  QTextBrowser* textLocalInstall = nullptr;
+  CRouterBRouterSetup* setup = nullptr;
+  QUrl downloadUrl;
+  bool complete;
+
+  friend class CRouterBRouterSetupWizard;
+};
+
+#endif  // CROUTERBROUTERDOWNLOADPAGE_H

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.h
@@ -23,10 +23,35 @@
 
 #include "units/IUnit.h"
 
+class CRouterBRouterSetupWizard;
 class QJSValue;
 class QNetworkAccessManager;
 class QNetworkReply;
 class QWebEnginePage;
+
+struct CRouterBRouterLocalSetupStatus {
+ public:
+  CRouterBRouterLocalSetupStatus(const bool& isJavaExisting, const bool& isJavaValid, const bool& isJavaOutdated,
+                                 const bool& isLocalBRouterJar, const bool& isLocalBRouterCandidate,
+                                 const bool& isValidBRouterVersion)
+      : isJavaExisting(isJavaExisting),
+        isJavaValid(isJavaValid),
+        isJavaOutdated(isJavaOutdated),
+        isLocalBRouterJar(isLocalBRouterJar),
+        isLocalBRouterCandidate(isLocalBRouterCandidate),
+        isValidBRouterVersion(isValidBRouterVersion) {}
+
+ private:
+  const bool isJavaExisting;
+  const bool isJavaValid;
+  const bool isJavaOutdated;
+  const bool isLocalBRouterJar;
+  const bool isLocalBRouterCandidate;
+  const bool isValidBRouterVersion;
+
+  friend class CRouterBRouterSetup;
+  friend class CRouterBRouterSetupWizard;
+};
 
 class CRouterBRouterSetup : public QObject {
   Q_OBJECT
@@ -82,8 +107,6 @@ class CRouterBRouterSetup : public QObject {
   void setJava(const QString& path);
   QString findJava() const;
   void setLocalBRouterJar(const QString& path);
-  bool isLocalBRouterInstalled() const;
-  bool isLocalBRouterCandidate() const;
   bool isLocalBRouterDefaultDir() const;
 
   QUrl getServiceUrl() const;
@@ -92,7 +115,7 @@ class CRouterBRouterSetup : public QObject {
   QString getConfigUrl() const;
 
   void parseBRouterVersion(const QString& text);
-  void parseJavaVersion(const QString& text);
+  CRouterBRouterLocalSetupStatus checkLocalBRouterInstallation();
 
   void onInvalidSetup();
 
@@ -164,6 +187,8 @@ class CRouterBRouterSetup : public QObject {
   int javaMajorVersion{NOINT};
   int classMajorVersion{NOINT};
 
+  bool isLocalBRouterValid;
+
   const bool defaultExpertMode = false;
   const mode_e defaultInstallMode = eModeOnline;
   static constexpr const char* defaultConfigUrl = "https://brouter.de/brouter-web/config.js";
@@ -180,7 +205,7 @@ class CRouterBRouterSetup : public QObject {
   static constexpr const char* defaultLocalNumberThreads = "1";
   static constexpr const char* defaultLocalMaxRunningTime = "300";
   static constexpr const char* defaultLocalJavaOpts = "-Xmx128M -Xms128M -Xmn8M";
-  static constexpr const char* defaultBinariesUrl = "https://brouter.de/brouter_bin/";
+  static constexpr const char* defaultBinariesUrl = "https://api.github.com/repos/abrensch/brouter/releases";
   static constexpr const char* defaultSegmentsUrl = "https://brouter.de/brouter/segments4/";
 
   static constexpr const char* onlineProfileCacheDir = "BRouterProfiles";
@@ -188,6 +213,7 @@ class CRouterBRouterSetup : public QObject {
 
   friend class CRouterBRouter;
   friend class CRouterBRouterLocal;
+  friend class CRouterBRouterDownloadPage;
   friend class CRouterBRouterSetupPage;
   friend class CRouterBRouterSetupWizard;
   friend class CRouterBRouterTilesSelect;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupPage.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupPage.cpp
@@ -28,12 +28,7 @@ CRouterBRouterSetupPage::~CRouterBRouterSetupPage() {}
 bool CRouterBRouterSetupPage::isComplete() const {
   switch (wizard()->currentId()) {
     case CRouterBRouterSetupWizard::ePageLocalDirectory: {
-      return setup != nullptr && setup->isLocalBRouterInstalled() && QFile(setup->localJavaExecutable).exists() &&
-             QFileInfo(setup->localJavaExecutable).baseName().startsWith("java");
-    }
-
-    case CRouterBRouterSetupWizard::ePageLocalInstallation: {
-      return setup != nullptr && setup->isLocalBRouterInstalled();
+      return setup->isLocalBRouterValid;
     }
 
     case CRouterBRouterSetupWizard::ePageProfiles: {

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupPage.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupPage.h
@@ -41,4 +41,4 @@ class CRouterBRouterSetupPage : public QWizardPage {
   bool complete{false};
 };
 
-#endif  // CROUTERBROUTERTILESPAGE_H
+#endif  // CROUTERBROUTERSETUPPAGE_H

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.h
@@ -70,10 +70,6 @@ class CRouterBRouterSetupWizard : public QWizard, private Ui::IRouterBRouterSetu
   void slotOnlineConfigButtonClicked() const;
   void slotBinariesUrlCursorEdited();
   void slotSegmentsUrlEdited();
-  void slotWebLocalBRouterVersionsLoadFinished(bool ok);
-  void slotLocalDownloadLinkClicked(const QUrl& url);
-  void slotLocalDownloadButtonClicked();
-  void slotLocalDownloadButtonFinished(QNetworkReply* reply);
   void slotProfileClicked(const QModelIndex& index) const;
   void slotAvailableProfileClicked(const QModelIndex& index) const;
   void slotDisplayProfile(const QString& profile, const QString content);
@@ -119,11 +115,6 @@ class CRouterBRouterSetupWizard : public QWizard, private Ui::IRouterBRouterSetu
   CRouterBRouterSetup* setup;
 
   bool doLocalInstall;
-  bool localInstallLoaded;
-  QUrl downloadUrl;
-
-  CWebPage* localVersionsPage;
-  QNetworkAccessManager* networkAccessManager;
 
   bool isError{false};
   QString error;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterToolShell.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterToolShell.cpp
@@ -18,7 +18,7 @@
 
 #include "CRouterBRouterToolShell.h"
 
-#include <QtWidgets>
+#include <QTimer>
 
 CRouterBRouterToolShell::CRouterBRouterToolShell(QTextBrowser* textBrowser, QWidget* parent) : IToolShell(parent) {
   setTextBrowser(textBrowser);

--- a/src/qmapshack/gis/rte/router/brouter/IRouterBRouterSetupWizard.ui
+++ b/src/qmapshack/gis/rte/router/brouter/IRouterBRouterSetupWizard.ui
@@ -109,7 +109,7 @@
          <string>...</string>
         </property>
         <property name="icon">
-         <iconset resource="../../../../resources.qrc">
+         <iconset>
           <normaloff>:/icons/32x32/PathBlue.png</normaloff>:/icons/32x32/PathBlue.png</iconset>
         </property>
        </widget>
@@ -134,7 +134,7 @@
          <string>...</string>
         </property>
         <property name="icon">
-         <iconset resource="../../../../resources.qrc">
+         <iconset>
           <normaloff>:/icons/32x32/PathBlue.png</normaloff>:/icons/32x32/PathBlue.png</iconset>
         </property>
        </widget>
@@ -190,7 +190,7 @@
          <string>...</string>
         </property>
         <property name="icon">
-         <iconset resource="../../../../resources.qrc">
+         <iconset>
           <normaloff>:/icons/32x32/PathBlue.png</normaloff>:/icons/32x32/PathBlue.png</iconset>
         </property>
        </widget>
@@ -246,7 +246,7 @@
     </item>
    </layout>
   </widget>
-  <widget class="CRouterBRouterSetupPage" name="pageLocalInstallation">
+  <widget class="CRouterBRouterDownloadPage" name="pageLocalInstallation">
    <property name="sizePolicy">
     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
      <horstretch>0</horstretch>
@@ -266,24 +266,15 @@
     <item>
      <widget class="QLabel" name="labelLocalInstallTitle">
       <property name="text">
-       <string>Download and install BRouter Version</string>
+       <string>select BRouter Version:</string>
       </property>
      </widget>
     </item>
     <item>
-     <widget class="QWebEngineView" name="webLocalBRouterVersions">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="url">
-       <url>
-        <string>about:blank</string>
-       </url>
-      </property>
-     </widget>
+     <widget class="QListView" name="listLocalInstallVersions"/>
+    </item>
+    <item>
+     <widget class="QTextBrowser" name="textLocalInstallVersionDetails"/>
     </item>
     <item>
      <widget class="QLabel" name="labelLocalInstallLink">
@@ -370,7 +361,7 @@
            <string>...</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../../resources.qrc">
+           <iconset>
             <normaloff>:/icons/32x32/Right.png</normaloff>:/icons/32x32/Right.png</iconset>
           </property>
          </widget>
@@ -384,7 +375,7 @@
            <string>...</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../../resources.qrc">
+           <iconset>
             <normaloff>:/icons/32x32/Left.png</normaloff>:/icons/32x32/Left.png</iconset>
           </property>
          </widget>
@@ -417,7 +408,7 @@
            <string>...</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../../resources.qrc">
+           <iconset>
             <normaloff>:/icons/32x32/Up.png</normaloff>:/icons/32x32/Up.png</iconset>
           </property>
          </widget>
@@ -428,7 +419,7 @@
            <string>...</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../../resources.qrc">
+           <iconset>
             <normaloff>:/icons/32x32/Down.png</normaloff>:/icons/32x32/Down.png</iconset>
           </property>
          </widget>
@@ -700,12 +691,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QWebEngineView</class>
-   <extends>QWidget</extends>
-   <header location="global">QtWebEngineWidgets/QWebEngineView</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>CRouterBRouterTilesPage</class>
    <extends>QWizardPage</extends>
    <header>gis/rte/router/brouter/CRouterBRouterTilesPage.h</header>
@@ -717,9 +702,13 @@
    <header>gis/rte/router/brouter/CRouterBRouterSetupPage.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>CRouterBRouterDownloadPage</class>
+   <extends>QWizardPage</extends>
+   <header>gis/rte/router/brouter/CRouterBRouterDownloadPage.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../../resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/qmapshack/tool/IToolShell.h
+++ b/src/qmapshack/tool/IToolShell.h
@@ -21,9 +21,8 @@
 
 #include <QPointer>
 #include <QProcess>
+#include <QTextBrowser>
 #include <QWidget>
-
-class QTextBrowser;
 
 class IToolShell : public QWidget {
   Q_OBJECT


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:

QMS-#622

### What you have done:
the url that is used to download brouter binaries from has been changed to brouter releases page on github

### Steps to perform a simple smoke test:

1. Open brouter setup-wizzard
2. choose 'local installation'
3. click 'update existing BRouter installation'
4. click 'v1.7.2'
5. click 'Download and Install'
6. the log-output should end with 'installation successful'

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [X] yes

### Is every user facing string in a tr() macro?

- [X] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [X] yes, I didn't forget to change changelog.txt
