### PR TITLE
[QMS-624] Suspicion: QMS crashes if BRouter RD5 file is missing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
+V1.XX.X
 [QMS-622] Update BRouter setup (install from github)
-[QMS-623] remove use of QTimer in brouter startup error detection
+[QMS-623] Remove use of QTimer in brouter startup error detection
+[QMS-624] Fix crashes while using BRouter
 [QMS-630] BRouter on-the-fly routing cannot be canceled
 
 V1.17.0

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -381,12 +381,12 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QLi
       }
     }
   } catch (const QString& msg) {
-    coords.clear();
+    reply->deleteLater();
+    mutex.unlock();
     if (!msg.isEmpty()) {
-      reply->deleteLater();
-      mutex.unlock();
       throw tr("Bad response from server: %1").arg(msg);
     }
+    return -1;
   }
 
   reply->deleteLater();

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -195,7 +195,8 @@ QString CRouterBRouter::getOptions() {
 void CRouterBRouter::routerSelected() { getBRouterVersion(); }
 
 bool CRouterBRouter::hasFastRouting() {
-  return setup->installMode == CRouterBRouterSetup::eModeLocal && setup->isLocalBRouterValid && checkFastRecalc->isChecked();
+  return setup->installMode == CRouterBRouterSetup::eModeLocal && setup->isLocalBRouterValid &&
+         checkFastRecalc->isChecked();
 }
 
 QNetworkRequest CRouterBRouter::getRequest(const QVector<QPointF>& routePoints, const QList<IGisItem*>& nogos) const {
@@ -282,7 +283,7 @@ QNetworkRequest CRouterBRouter::getRequest(const QVector<QPointF>& routePoints, 
   return QNetworkRequest(url);
 }
 
-int CRouterBRouter::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs) {
+int CRouterBRouter::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs) noexcept(false) {
   if (!hasFastRouting()) {
     return -1;
   }
@@ -296,7 +297,7 @@ int CRouterBRouter::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
 }
 
 int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QList<IGisItem*>& nogos, QPolygonF& coords,
-                                       qreal* costs = nullptr) {
+                                       qreal* costs = nullptr) noexcept(false) {
   if (!mutex.tryLock()) {
     // skip further on-the-fly-requests as long a previous request is still running
     return -1;

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.h
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.h
@@ -43,7 +43,8 @@ class CRouterBRouter : public IRouter, private Ui::IRouterBRouter {
   static CRouterBRouter& self() { return *pSelf; }
 
   void calcRoute(const IGisItem::key_t& key) override;
-  int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr) override;
+  int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords,
+                qreal* costs = nullptr) noexcept(false) override;
   bool hasFastRouting() override;
   QString getOptions() override;
   void routerSelected() override;
@@ -70,7 +71,7 @@ class CRouterBRouter : public IRouter, private Ui::IRouterBRouter {
   bool isMinimumVersion(int major, int minor, int patch) const;
   void updateBRouterStatus() const;
   int synchronousRequest(const QVector<QPointF>& points, const QList<IGisItem*>& nogos, QPolygonF& coords,
-                         qreal* costs);
+                         qreal* costs) noexcept(false);
   QNetworkRequest getRequest(const QVector<QPointF>& routePoints, const QList<IGisItem*>& nogos) const;
   QUrl getServiceUrl() const;
 

--- a/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
@@ -18,6 +18,8 @@
 
 #include "CRouterOptimization.h"
 
+#include <QDebug>
+
 #include "gis/GeoMath.h"
 #include "gis/rte/router/CRouterSetup.h"
 #include "helpers/CProgressDialog.h"
@@ -237,10 +239,16 @@ const CRouterOptimization::routing_cache_item_t* CRouterOptimization::getRoute(c
 
   if (!routingCache[start_key].contains(end_key)) {
     routing_cache_item_t cacheItem;
-    int response = CRouterSetup::self().calcRoute(start, end, cacheItem.route, &cacheItem.costs);
-    if (response < 0) {
+    try {
+      int response = CRouterSetup::self().calcRoute(start, end, cacheItem.route, &cacheItem.costs);
+      if (response < 0) {
+        return nullptr;
+      }
+    } catch (const QString& msg) {
+      qWarning() << msg;
       return nullptr;
     }
+
     routingCache[start_key][end_key] = cacheItem;
 
     qreal airToCostFactor = cacheItem.costs / GPS_Math_DistanceQuick(start.x(), start.y(), end.x(), end.y());

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -402,7 +402,8 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key) {
   CCanvas::triggerCompleteUpdate(CCanvas::eRedrawGis);
 }
 
-int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr) {
+int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords,
+                              qreal* costs = nullptr) noexcept(false) {
   if (!mutex.tryLock()) {
     return -1;
   }

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.h
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.h
@@ -35,7 +35,7 @@ class CRouterRoutino : public IRouter, private Ui::IRouterRoutino {
   static CRouterRoutino& self() { return *pSelf; }
 
   void calcRoute(const IGisItem::key_t& key) override;
-  int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs) override;
+  int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs) noexcept(false) override;
 
   bool hasFastRouting() override;
 

--- a/src/qmapshack/gis/rte/router/CRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterSetup.cpp
@@ -75,7 +75,7 @@ void CRouterSetup::calcRoute(const IGisItem::key_t& key) {
   }
 }
 
-int CRouterSetup::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs) {
+int CRouterSetup::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs) noexcept(false) {
   IRouter* router = dynamic_cast<IRouter*>(stackedWidget->currentWidget());
   if (router) {
     return router->calcRoute(p1, p2, coords, costs);

--- a/src/qmapshack/gis/rte/router/CRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/CRouterSetup.h
@@ -31,7 +31,7 @@ class CRouterSetup : public QWidget, private Ui::IRouterSetup {
   virtual ~CRouterSetup();
 
   void calcRoute(const IGisItem::key_t& key);
-  int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr);
+  int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr) noexcept(false);
   QString getOptions();
 
   bool hasFastRouting();

--- a/src/qmapshack/gis/rte/router/IRouter.h
+++ b/src/qmapshack/gis/rte/router/IRouter.h
@@ -30,7 +30,8 @@ class IRouter : public QWidget {
   virtual ~IRouter();
 
   virtual void calcRoute(const IGisItem::key_t& key) = 0;
-  virtual int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords, qreal* costs = nullptr) = 0;
+  virtual int calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& coords,
+                        qreal* costs = nullptr) noexcept(false) = 0;
   virtual bool hasFastRouting() { return fastRouting; }
 
   virtual QString getOptions() = 0;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#624

### What you have done:
[comment]: # (Describe roughly.)

Do not forward the exception in `CRouterBRouter::synchronousRequest()` Display the error on the canvas

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Follow the descriptions in the ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
