### PR TITLE
[QMS-630] on-the-fly routing cannot be canceled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 [QMS-622] Update BRouter setup (install from github)
+[QMS-630] BRouter on-the-fly routing cannot be canceled
 
 V1.17.0
 [QMS-429] Bad OSM Tag formatting crashes QMS

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -319,8 +319,7 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QLi
     QEventLoop eventLoop;
     connect(&progress, &CProgressDialog::rejected, reply, &QNetworkReply::abort);
     connect(reply, &QNetworkReply::finished, &eventLoop, &QEventLoop::quit);
-    // Processing userinputevents in local eventloop would cause a SEGV when clicking 'abort' of calling LineOp
-    eventLoop.exec(QEventLoop::ExcludeUserInputEvents);
+    eventLoop.exec(QEventLoop::AllEvents);
 
     const QNetworkReply::NetworkError& netErr = reply->error();
     if (netErr == QNetworkReply::RemoteHostClosedError && nogos.size() > 1 && !isMinimumVersion(1, 4, 10)) {


### PR DESCRIPTION
### What is the linked issue for this pull request:
[comment]: #

QMS-#630

### What you have done:
[comment]: # enabled processing of userInterfaceEvents in local brouter synchronous request processing to allow cancellation of progress-dialog.

### Steps to perform a simple smoke test:
[comment]: #

1. in router config dialog choose BRouter (offline)
2. if not yet done install BRouter locally klicking Setup and make sure to successfully complete the brouter installation wizzard downloading some tiles that cover a lager area.
3. zoom the map to a location that is covered by brouter routing data (see tiles download dialog in install wizzard).
4. right click on the map, choose a point that is located on some street or path that is likely to be inclused in brouter routing data.
5. zoom out and move to a location that of both some 100km away from the starting-point and also covered by brouter routing data.
6. zoom in and place the mouse over a location that is likely to be covered by routing data.
7. stop moving the mouse. On-the-fly routing should start.
8. wait until a dialog with the title 'Please wait...' appears.
9. click 'cancel' on this dialog.
=> the dialog closes, status area displays message in red: 'Routing: Bad response from server: Operation canceled'.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [X] yes

### Is every user facing string in a tr() macro?

- [X] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [X] yes, I didn't forget to change changelog.txt
