### PR TITLE
[QMS-623] remove use of QTimer in brouter startup error detection

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 [QMS-622] Update BRouter setup (install from github)
+[QMS-623] remove use of QTimer in brouter startup error detection
 [QMS-630] BRouter on-the-fly routing cannot be canceled
 
 V1.17.0

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterToolShell.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterToolShell.h
@@ -41,14 +41,12 @@ class CRouterBRouterToolShell : public IToolShell {
  private slots:
   void slotStateChanged(const QProcess::ProcessState newState);
   void slotError(const QProcess::ProcessError error);
-  void slotStartupTimer();
 
  private:
   void finished(int exitCode, QProcess::ExitStatus status) override;
 
   bool isBeingKilled{false};
-  bool isStarting{false};
-  QTimer* startupTimer{nullptr};
+  bool isBeingStopped{false};
 };
 
 #endif  // CROUTERBROUTERTOOLSHELL_H


### PR DESCRIPTION
### What is the linked issue for this pull request:

QMS-#623

### What you have done:

to distinguish normal shutdown from errors during startup a timer was used. Any transition to processState::NotRunning that would happen after expiry of this timer would not result in showing the error but would be ignored silently.
The timer has been replaced by a boolean flag 'isBeingStopped' that is set to false on process startup and to true when klicking the stop-button.

### Steps to perform a simple smoke test:

1. make sure BRouter is installed locally.
2. validate local BRouter starts fine by clicking the start/stop-button to the right of 'BRouter: stopped'
3. validate 'BRouter: stopped' has changed to 'BRouter: running' and that a second button did appear to the right of the start-button.
4. stop local BRouter by clicking the start/stop-button. Now 'BRouter: stopped' should be displayed again.
5. while QMapShack is still running locate the brouter-jar-file and rename it or move it to a different location.
6. now click the BRouter start/stop button again.
=> the label should switch to 'BRouter: starting' respectivly 'BRouter running' for a very short time and finally show 'BRouter stopped' again. Below the start/stop-button an error-message and a 'Dismiss'-button should be visible.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [X] yes

### Is every user facing string in a tr() macro?

- [X] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [X] yes, I didn't forget to change changelog.txt
