### PR TITLE
[QMS-547] Fixed: QMS freezes on zoom when activating multi-layered on…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
+V1.XX.X
+[QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps
 [QMS-622] Update BRouter setup (install from github)
-[QMS-623] remove use of QTimer in brouter startup error detection
+[QMS-623] remove use of QTimer in BRouter startup error detection
 [QMS-630] BRouter on-the-fly routing cannot be canceled
 
 V1.17.0

--- a/src/qmapshack/map/IMapOnline.h
+++ b/src/qmapshack/map/IMapOnline.h
@@ -31,7 +31,14 @@ class QNetworkReply;
 
 class IMapOnline : public IMap {
   Q_OBJECT
+ public:
+  IMapOnline(CMapDraw* parent);
+  virtual ~IMapOnline() {}
 
+ signals:
+  void sigQueueChanged();
+
+ protected:
   struct rawHeaderItem_t {
     QString name;
     QString value;
@@ -39,10 +46,6 @@ class IMapOnline : public IMap {
 
   QList<rawHeaderItem_t> rawHeaderItems;
 
- signals:
-  void sigQueueChanged();
-
- protected:
   /// Mutex to control access to url queue
   QRecursiveMutex mutex;
   /// a queue with all tile urls to request
@@ -68,12 +71,8 @@ class IMapOnline : public IMap {
 
   void configureCache() override;
 
- public:
   void slotQueueChanged();
   void slotRequestFinished(QNetworkReply* reply);
-
-  IMapOnline(CMapDraw* parent);
-  virtual ~IMapOnline() {}
 };
 
 #endif  // IMAPONLINE_H


### PR DESCRIPTION
…line maps

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#547

### What you have done:
[comment]: # (Describe roughly.)

Instead of locking the mutex in the override methods of IDrawObject::getLayers(), try to lock the mutex and abort after 100ms.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Activate a TMS map with multiple layers, e.g. google.tms
2. Wildly move and zoom the map.
--> must not fail

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
