### PR TITLE
Replace proj strings by EPSG code in CRS definitions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-622] Update BRouter setup (install from github)
 [QMS-623] remove use of QTimer in BRouter startup error detection
 [QMS-630] BRouter on-the-fly routing cannot be canceled
+[QMS-649] Replace proj strings by EPSG code in CRS definitions
 
 V1.17.0
 [QMS-429] Bad OSM Tag formatting crashes QMS

--- a/src/qmapshack/grid/CProjWizard.cpp
+++ b/src/qmapshack/grid/CProjWizard.cpp
@@ -139,9 +139,7 @@ void CProjWizard::slotChange() {
   if (radioMercator->isChecked()) {
     str += "+proj=merc ";
   } else if (radioWorldMercator->isChecked()) {
-    str +=
-        "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.001 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null "
-        "+no_defs";
+    str += "EPSG:3857";
     labelResult->setText(str);
     return;
   } else if (radioUPSNorth->isChecked()) {

--- a/src/qmapshack/map/CMapGEMF.cpp
+++ b/src/qmapshack/map/CMapGEMF.cpp
@@ -50,8 +50,7 @@ inline double tile2lat(int y, int z) {
 CMapGEMF::CMapGEMF(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibility, parent), filename(filename) {
   qDebug() << "CMapGEMF: try to open " << filename;
   proj.init(
-      "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext "
-      "+no_defs",
+      "EPSG:3857",
       "EPSG:4326");
   qDebug() << "CMapGEMF:" << proj.getProjSrc();
 

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -49,8 +49,7 @@ CMapTMS::CMapTMS(const QString& filename, CMapDraw* parent) : IMapOnline(parent)
   qDebug() << "TMS: try to open" << filename;
 
   proj.init(
-      "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext "
-      "+no_defs",
+      "EPSG:3857",
       "EPSG:4326");
 
   qDebug() << "tms:" << proj.getProjSrc();

--- a/src/qmaptool/overlay/refmap/CProjWizard.cpp
+++ b/src/qmaptool/overlay/refmap/CProjWizard.cpp
@@ -139,9 +139,7 @@ void CProjWizard::slotChange() {
   if (radioMercator->isChecked()) {
     str += "+proj=merc ";
   } else if (radioWorldMercator->isChecked()) {
-    str +=
-        "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.001 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null "
-        "+no_defs";
+    str += "EPSG:3857";
     labelResult->setText(str);
     return;
   } else if (radioUPSNorth->isChecked()) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#649

### What you have done:
[comment]: # (Describe roughly.)

Replace proj strings by EPSG code in these files:
`src/qmapshack/map/CMapTMS.cpp`
`src/qmapshack/map/CMapGEMF.cpp`
`src/qmapshack/grid/CProjWizard.cpp`
`src/qmaptool/overlay/refmap/CProjWizard.cpp`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Activate some TMS and GEMF maps and check that they are shown
2. Menu View - Setup map view - click on projection wizard icon and choose `World Mercator (OSM)`.  Check that EPSG:3857  is set.  

Appart and related to #647
1. Activate some  TMS maps in several views. 
3. On the map pannel: Do `reload maps`, and check that there is no delay scrolling up/down the map list, or trying to move the map.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt