### PR TITLE
[QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps
+
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps
 [QMS-622] Update BRouter setup (install from github)

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -48,9 +48,7 @@ CMapTMS::CMapTMS(const QString& filename, CMapDraw* parent) : IMapOnline(parent)
   qDebug() << "------------------------------";
   qDebug() << "TMS: try to open" << filename;
 
-  proj.init(
-      "EPSG:3857",
-      "EPSG:4326");
+  proj.init("EPSG:3857", "EPSG:4326");
 
   qDebug() << "tms:" << proj.getProjSrc();
 
@@ -159,8 +157,9 @@ void CMapTMS::getLayers(QListWidget& list) /* override */
     int i = 0;
     for (const layer_t& layer : qAsConst(layers)) {
       QListWidgetItem* item = new QListWidgetItem(layer.title, &list);
-      item->setCheckState(layer.enabled ? Qt::Checked : Qt::Unchecked);
+      int enabled = layer.enabled;
       item->setData(Qt::UserRole, i++);
+      item->setCheckState(enabled ? Qt::Checked : Qt::Unchecked);
     }
 
     connect(&list, &QListWidget::itemChanged, this, &CMapTMS::slotLayersChanged);

--- a/src/qmapshack/map/CMapWMTS.cpp
+++ b/src/qmapshack/map/CMapWMTS.cpp
@@ -260,8 +260,9 @@ void CMapWMTS::getLayers(QListWidget& list) {
     int i = 0;
     for (const layer_t& layer : qAsConst(layers)) {
       QListWidgetItem* item = new QListWidgetItem(layer.title, &list);
-      item->setCheckState(layer.enabled ? Qt::Checked : Qt::Unchecked);
+      bool enabled = layer.enabled;
       item->setData(Qt::UserRole, i++);
+      item->setCheckState(enabled ? Qt::Checked : Qt::Unchecked);
     }
 
     connect(&list, &QListWidget::itemChanged, this, &CMapWMTS::slotLayersChanged);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#656

### What you have done:
[comment]: # (Describe roughly.)

More recent Qt5 versions send the QListWidget::itemChanged() signal also on QListWidgetItem::setData(). This will reset the layer's enable flag.  The trick is to cache the flag on the stack and apply the flag as the last step.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use the Google TMS file and enable the 1st layer only. Reload the map. Without the fix the layer is not displayed after reload. With the fix the layer is displayed properly.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
