### PR TITLE
[QMS-675] The label colors defined in the TYP are not used

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps
 [QMS-668] MacOS build adapted to new gdal version and new brew packages
+[QMS-675] The label colors defined in the TYP are not used
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -1565,9 +1565,8 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
   textpaths.clear();
   QFont font = CMainWindow::self().getMapFont();
 
-  font.setPixelSize(12);
+  font.setPointSize(9);
   font.setBold(false);
-  QFontMetricsF metrics(font);
 
   QVector<qreal> lengths;
   lengths.reserve(100);
@@ -1641,7 +1640,19 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
           }
 
           if (scale.x() < STREETNAME_THRESHOLD && property.labelType != CGarminTyp::eNone) {
-            collectText(item, poly, font, metrics, h);
+            QFont f(font);
+            switch (property.labelType) {
+              case CGarminTyp::eSmall:
+                f.setPointSize(font.pointSize() - 2);
+                break;
+              case CGarminTyp::eLarge:
+                f.setPointSize(font.pointSize() + 2);
+                break;
+              default:;
+            }
+
+            collectText(item, poly, f, h,
+                        CMainWindow::self().isNight() ? property.colorLabelNight : property.colorLabelDay);
           }
 
           path.addPolygon(poly);
@@ -1681,7 +1692,7 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
         QList<quint32>::const_iterator it = dict[type].constBegin();
         for (; it != dict[type].constEnd(); ++it) {
           // borderCount++;
-          drawLine(p, lines[*it], property, metrics, font, scale);
+          drawLine(p, lines[*it], property, font, scale);
         }
         // draw foreground line in a second run for nicer borders
       } else {
@@ -1690,7 +1701,7 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
         QList<quint32>::const_iterator it = dict[type].constBegin();
         for (; it != dict[type].constEnd(); ++it) {
           // normalCount++;
-          drawLine(p, lines[*it], property, metrics, font, scale);
+          drawLine(p, lines[*it], property, font, scale);
         }
       }
     }
@@ -1724,8 +1735,8 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
   //        << "deletedCount:" << deletedCount;
 }
 
-void CMapIMG::drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polyline_property& property,
-                       const QFontMetricsF& metrics, const QFont& font, const QPointF& scale) {
+void CMapIMG::drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polyline_property& property, const QFont& font,
+                       const QPointF& scale) {
   QPolygonF& poly = l.pixel;
   const int size = poly.size();
   const int lineWidth = p.pen().width();
@@ -1739,7 +1750,19 @@ void CMapIMG::drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polylin
   //    simplifyPolyline(line);
 
   if (scale.x() < STREETNAME_THRESHOLD && property.labelType != CGarminTyp::eNone) {
-    collectText(l, poly, font, metrics, lineWidth);
+    QFont f(font);
+    switch (property.labelType) {
+      case CGarminTyp::eSmall:
+        f.setPointSize(font.pointSize() - 2);
+        break;
+      case CGarminTyp::eLarge:
+        f.setPointSize(font.pointSize() + 2);
+        break;
+      default:;
+    }
+
+    collectText(l, poly, f, lineWidth,
+                CMainWindow::self().isNight() ? property.colorLabelNight : property.colorLabelDay);
   }
 
   p.drawPolyline(poly);
@@ -1758,8 +1781,8 @@ void CMapIMG::drawLine(QPainter& p, const CGarminPolygon& l) {
   p.drawPolyline(poly);
 }
 
-void CMapIMG::collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font,
-                          const QFontMetricsF& metrics, qint32 lineWidth) {
+void CMapIMG::collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font, qint32 lineWidth,
+                          const QColor& color) {
   QString str;
   if (item.hasLabel()) {
     str = item.getLabelText();
@@ -1774,6 +1797,7 @@ void CMapIMG::collectText(const CGarminPolygon& item, const QPolygonF& line, con
   tp.font = font;
   tp.text = str;
   tp.lineWidth = lineWidth;
+  tp.color = color;
 
   const int size = line.size();
   for (int i = 1; i < size; ++i) {
@@ -1914,17 +1938,17 @@ void CMapIMG::drawText(QPainter& p) {
 
     // adjust font size until string fits into polyline
     while (width > (length * 0.7)) {
-      font.setPixelSize(font.pixelSize() - 1);
+      font.setPointSize(font.pointSize() - 1);
       fm = QFontMetricsF(font);
       width = fm.width(textpath.text);
 
-      if ((font.pixelSize() < 8)) {
+      if ((font.pointSize() < 6)) {
         break;
       }
     }
 
     // no way to draw a readable string - skip
-    if ((font.pixelSize() < 8)) {
+    if ((font.pointSize() < 6)) {
       continue;
     }
 
@@ -2001,7 +2025,7 @@ void CMapIMG::drawText(QPainter& p) {
       p.drawText(0, +1, str);
       p.drawText(+1, +1, str);
 
-      p.setPen(Qt::black);
+      p.setPen(textpath.color);
       p.drawText(0, 0, str);
 
       p.restore();

--- a/src/qmapshack/map/CMapIMG.h
+++ b/src/qmapshack/map/CMapIMG.h
@@ -150,7 +150,8 @@ class CMapIMG : public IMap {
     QPoint pt;
     QRect rect;
     QString str;
-    CGarminTyp::label_type_e type = CGarminTyp::eStandard;
+    CGarminTyp::point_property property;
+    bool isNight = false;
   };
 
   quint8 scale2bits(const QPointF& scale);
@@ -165,7 +166,7 @@ class CMapIMG : public IMap {
                   bool fast, const QRectF& viewport, polytype_t& polylines, polytype_t& polygons, pointtype_t& points,
                   pointtype_t& pois);
   bool intersectsWithExistingLabel(const QRect& rect) const;
-  void addLabel(const CGarminPoint& pt, const QRect& rect, CGarminTyp::label_type_e type);
+  void addLabel(const CGarminPoint& pt, const QRect& rect, const CGarminTyp::point_property& property, bool isDay);
   void drawPolygons(QPainter& p, polytype_t& lines);
   void drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale);
   void drawPoints(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPois);

--- a/src/qmapshack/map/CMapIMG.h
+++ b/src/qmapshack/map/CMapIMG.h
@@ -174,12 +174,11 @@ class CMapIMG : public IMap {
   void drawLabels(QPainter& p, const QVector<strlbl_t>& lbls);
   void drawText(QPainter& p);
 
-  void drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polyline_property& property,
-                const QFontMetricsF& metrics, const QFont& font, const QPointF& scale);
+  void drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polyline_property& property, const QFont& font, const QPointF& scale);
   void drawLine(QPainter& p, const CGarminPolygon& l);
 
-  void collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font, const QFontMetricsF& metrics,
-                   qint32 lineWidth);
+  void collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font,
+                   qint32 lineWidth, const QColor& color);
 
   void getInfoPoints(const pointtype_t& points, const QPoint& pt, QMultiMap<QString, QString>& dict) const;
   void getInfoPolylines(const QPoint& pt, QMultiMap<QString, QString>& dict) const;
@@ -480,6 +479,7 @@ class CMapIMG : public IMap {
     QFont font;
     QVector<qreal> lengths;
     qint32 lineWidth;
+    QColor color;
   };
 
   QVector<textpath_t> textpaths;

--- a/src/qmapshack/map/garmin/CGarminTyp.cpp
+++ b/src/qmapshack/map/garmin/CGarminTyp.cpp
@@ -475,12 +475,12 @@ bool CGarminTyp::parsePolygon(QDataStream& in, QMap<quint32, polygon_property>& 
       property.labelType = (label_type_e)(t8 & 0x07);
 
       if (t8 & 0x08) {
-        in >> r >> g >> b;
+        in >> b >> g >> r;
         property.colorLabelDay = qRgb(r, g, b);
       }
 
       if (t8 & 0x10) {
-        in >> r >> g >> b;
+        in >> b >> g >> r;
         property.colorLabelNight = qRgb(r, g, b);
       }
 #ifdef DBG
@@ -826,12 +826,12 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
       property.labelType = (label_type_e)(t8_1 & 0x07);
 
       if (t8_1 & 0x08) {
-        in >> r >> g >> b;
+        in >> b >> g >> r;
         property.colorLabelDay = qRgb(r, g, b);
       }
 
       if (t8_1 & 0x10) {
-        in >> r >> g >> b;
+        in >> b >> g >> r;
         property.colorLabelNight = qRgb(r, g, b);
       }
 #ifdef DBG
@@ -1141,12 +1141,12 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
       property.labelType = (label_type_e)(t8_1 & 0x07);
 
       if (t8_1 & 0x08) {
-        in >> r >> g >> b;
+        in >> b >> g >> r;
         property.colorLabelDay = qRgb(r, g, b);
       }
 
       if (t8_1 & 0x10) {
-        in >> r >> g >> b;
+        in >> b >> g >> r;
         property.colorLabelNight = qRgb(r, g, b);
       }
 #ifdef DBG


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#675

### What you have done:
[comment]: # (Describe roughly.)

Simply use the information form the typ file to draw the lables

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use a Garmin map with typ file, that defines colored lables. e.g.Freizeitkarte

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
