### PR TITLE
[QMS-683] Fix alglib error on interpolation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps
 [QMS-668] MacOS build adapted to new gdal version and new brew packages
 [QMS-675] The label colors defined in the TYP are not used
+[QMS-683] Fix alglib error on interpolation
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -2658,21 +2658,14 @@ void CGisItemTrk::setupInterpolation(bool on, qint32 q) {
     y[trkpt.idxVisible] = trkpt.ele;
   }
 
-  /// @todo find a better way to scale the algorithm
-  interp.m = interp.Q * 50;
-  if (N < 400) {
-    interp.m = N / (16 / interp.Q);
-  }
-
-  interp.m &= 0xFFFFFFFE;
+  interp.m = interp.Q * N / 10;
 
   try {
-    alglib::spline1dfitcubic(x, y, interp.m, interp.info, interp.p, interp.rep);
+    alglib::spline1dfit(x, y, interp.m, 0.00001, interp.p, interp.rep);
+    interp.valid = true;
   } catch (const alglib::ap_error& e) {
     qWarning() << "Error from alglib: " << e.msg.c_str();
   }
-
-  interp.valid = interp.info > 0;
 
   updateVisuals(eVisualPlot, "setupInterpolation()");
 }

--- a/src/qmapshack/gis/trk/CGisItemTrk.h
+++ b/src/qmapshack/gis/trk/CGisItemTrk.h
@@ -911,7 +911,6 @@ class CGisItemTrk : public IGisItem, public IGisLine {
   struct interpolate_t {
     bool valid = false;
     quality_e Q = eQualityCoarse;
-    alglib::ae_int_t info = -1;
     alglib::ae_int_t m = 0;
     alglib::spline1dinterpolant p;
     alglib::spline1dfitreport rep;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#683

### What you have done:
[comment]: # (Describe roughly.)

Replace deprecated API by new API call

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
