### PR TITLE
[QMS-692] Trackpoints erroneously flaged invalid for short tracks (<50m)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V1.XX.X
 [QMS-675] The label colors defined in the TYP are not used
 [QMS-680] Fix: Sending multiple selected projects to device
 [QMS-683] Fix alglib error on interpolation
+[QMS-692] Trackpoints erroneously flaged invalid for short tracks (<50m)
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -991,10 +991,10 @@ void CGisItemTrk::deriveSecondaryData() {
         continue;
       }
 
+      d1 = trkpt2.distance;
+      e1 = trkpt2.ele;
+      t1 = trkpt2.time.toMSecsSinceEpoch() / 1000.0;
       if (trkpt.distance - trkpt2.distance >= 25) {
-        d1 = trkpt2.distance;
-        e1 = trkpt2.ele;
-        t1 = trkpt2.time.toMSecsSinceEpoch() / 1000.0;
         break;
       }
     }
@@ -1008,10 +1008,10 @@ void CGisItemTrk::deriveSecondaryData() {
         continue;
       }
 
+      d2 = trkpt2.distance;
+      e2 = trkpt2.ele;
+      t2 = trkpt2.time.toMSecsSinceEpoch() / 1000.0;
       if (trkpt2.distance - trkpt.distance >= 25) {
-        d2 = trkpt2.distance;
-        e2 = trkpt2.ele;
-        t2 = trkpt2.time.toMSecsSinceEpoch() / 1000.0;
         break;
       }
     }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#692

### What you have done:
[comment]: # (Describe roughly.)

To get a better mean of the values metadata for a point is calculated by selecting the points +- 25 m form that point. Only if a point far enough is found the variables to derive all secondary data are set. For some points in the middle no other point has a distance of 25m. Therefor both points are the same resulting in an invalid slope.

Solution: If no point is 25m away use the one that is most far.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use the track from the ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
