### PR TITLE
[QMS-697]  Fix QByteArray to QString decoding

### DIFF
--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -341,7 +341,7 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QLi
     const QDomElement& xmlGpx = xml.documentElement();
 
     if (xmlGpx.isNull() || xmlGpx.tagName() != "gpx") {
-      throw QString(res);
+      throw QString(res.data());
     }
     setup->parseBRouterVersion(xmlGpx.attribute("creator"));
 
@@ -469,7 +469,7 @@ void CRouterBRouter::slotRequestFinished(QNetworkReply* reply) {
 
     const QDomElement& xmlGpx = xml.documentElement();
     if (xmlGpx.isNull() || xmlGpx.tagName() != "gpx") {
-      throw QString(res);
+      throw QString(res.data());
     }
 
     IGisItem::key_t key;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -670,7 +670,7 @@ void CRouterBRouterSetup::displayProfileAsync(const QString& profile) {
       file.open(QIODevice::ReadOnly);
       const QByteArray& content = file.readAll();
       file.close();
-      emit sigDisplayOnlineProfileFinished(profile, QString(content));
+      emit sigDisplayOnlineProfileFinished(profile, QString(content.data()));
     }
   } else {
     Q_ASSERT(installMode == eModeOnline);
@@ -711,7 +711,7 @@ void CRouterBRouterSetup::loadOnlineProfileFinished(QNetworkReply* reply) {
     readLocalProfiles();
   } else {
     Q_ASSERT(mode == eProfileDisplay);
-    emit sigDisplayOnlineProfileFinished(profile, QString(content));
+    emit sigDisplayOnlineProfileFinished(profile, QString(content.data()));
   }
 }
 

--- a/src/qmapshack/helpers/CTimeDialog.cpp
+++ b/src/qmapshack/helpers/CTimeDialog.cpp
@@ -33,10 +33,10 @@ CTimeDialog::CTimeDialog(QWidget* parent, const QDateTime& datetime)
 
   const QList<QByteArray>& ids = QTimeZone::availableTimeZoneIds();
   foreach (const QByteArray& id, ids) {
-    comboTimezone->addItem(id);
+    comboTimezone->addItem(id.data());
   }
 
-  comboTimezone->setCurrentText(zone);
+  comboTimezone->setCurrentText(zone.data());
 
   const QDateTime& newTime = timestamp_utc0.toTimeZone(QTimeZone(zone));
   dateTimeEdit->setDateTime(newTime);

--- a/src/qmapshack/map/CMapRMAP.cpp
+++ b/src/qmapshack/map/CMapRMAP.cpp
@@ -40,7 +40,7 @@ CMapRMAP::CMapRMAP(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibi
   QByteArray charbuf(20, 0);
   stream.readRawData(charbuf.data(), 19);
 
-  if ("CompeGPSRasterImage" != QString(charbuf)) {
+  if ("CompeGPSRasterImage" != QString(charbuf.data())) {
     QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."), tr("This is not a TwoNav RMAP file."),
                          QMessageBox::Abort, QMessageBox::Abort);
     return;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#697

### What you have done:
[comment]: # (Describe roughly.)

Search for QByteArray and use QByteArray::data() whenever a string conversion is done.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

There is no real bad case except in loading RMap.  But there is a list of functions that should be tested as good as possible:

* all time zone related stuff
* RMap support 
* BRouter setup and support
* Realtime data all modules.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ ] yes, I didn't forget to change changelog.txt
