### PR TITLE
[QMS-699]  Fix writing to default config when using commandline parameter -c

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-680] Fix: Sending multiple selected projects to device
 [QMS-683] Fix alglib error on interpolation
 [QMS-692] Trackpoints erroneously flaged invalid for short tracks (<50m)
+[QMS-699] Fix writing to default config when using command line parameter -c
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -21,6 +21,7 @@
 #include "CMainWindow.h"
 #include "gis/GeoMath.h"
 #include "gis/proj_x.h"
+#include "helpers/CSettings.h"
 #include "units/CUnitAviation.h"
 #include "units/CUnitImperial.h"
 #include "units/CUnitMetric.h"
@@ -600,7 +601,7 @@ void IUnit::setUnitType(type_e t, QObject* parent) {
       break;
   }
 
-  QSettings cfg;
+  SETTINGS;
   cfg.setValue("Units/type", t);
 }
 


### PR DESCRIPTION
### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#699

### What you have done:
[comment]: # (Describe roughly.)
Replaced `QSetting cfg;` with `SETTINGS;` and included `CSettings.h` in `IUnit.cpp`


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Start QMS with command line parameter `-c ~/qms.conf`
2. The default config file will not be overwritten

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes (hopefully)

### Is every user facing string in a tr() macro?

- [x] yes (i guess)

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt

This change needs also to be included in the porting_qt6 branch