### PR TITLE
Apply PNG file’s offset to user-defined waypoint icon from "External Icons" folder

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-683] Fix alglib error on interpolation
 [QMS-692] Trackpoints erroneously flaged invalid for short tracks (<50m)
 [QMS-699] Fix writing to default config when using command line parameter -c
+[QMS-706] Apply PNG file’s offset to user-defined waypoint icon from "External Icons" folder
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -198,8 +198,9 @@ void CWptIconManager::init() {
 }
 
 void CWptIconManager::setWptIconByName(const QString& name, const QString& filename) {
-  QPixmap icon(filename);
-  wptIcons[name] = icon_t(filename, icon.width() >> 1, icon.height() >> 1);
+  QImage icon(filename);
+  wptIcons[name] = (icon.offset() == QPoint(0, 0)) ? icon_t(filename, icon.width() >> 1, icon.height() >> 1)
+                                                   : icon_t(filename, icon.offset().x(), icon.offset().y());
 }
 
 void CWptIconManager::setWptIconByName(const QString& name, const QPixmap& icon) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-706

### What you have done:
[comment]: # (Describe roughly.)

Extract PNG offset by QImage::offset() function from user-defined waypoint icon file.
For offset value = (0,0) use icon center as offset (and preserve compatibility!),
for offset value ≠ (0,0) use this offset value.
Store offset value in "wptIcons".

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Add a PNG file with offset value ≠ (0,0) as user-defined waypoint icon to "External Icons" folder,
e.g. [png_with_offset](https://github.com/user-attachments/assets/5e9afe04-7952-4590-a632-886aa76ee738).
2. Create a waypoint on map using this waypoint icon
3. Verify that pin's tip is at waypoint position and does not obscur waypoint.
4. Add a PNG file without offset or with offset value = (0,0) as user-defined waypoint icon to "External Icons" folder,
e.g. [png_without_offset](https://github.com/user-attachments/assets/b8784e83-1d94-490e-b0a5-4cb34a7d0c3f).
5. Create a waypoint on map using this or any already existing waypoint icon from this folder.
6. Verify that icon is centered over the waypoint position and does obscur waypoint like before.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
