### PR TITLE
[QMS-709] Adjust square zoom levels to fit EPSG:3857 tiles and other minor fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-692] Trackpoints erroneously flaged invalid for short tracks (<50m)
 [QMS-699] Fix writing to default config when using command line parameter -c
 [QMS-706] Apply PNG file’s offset to user-defined waypoint icon from "External Icons" folder
+[QMS-709] Adjust square zoom levels to fit EPSG:3857 tiles and other minor fix in Proj Wizard
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/canvas/IDrawContext.cpp
+++ b/src/qmapshack/canvas/IDrawContext.cpp
@@ -29,11 +29,15 @@ const qreal IDrawContext::scalesDefault[N_DEFAULT_ZOOM_LEVELS] = {
     //, 15000.0, 20000.0, 30000.0, 50000.0, 70000.0
 };
 
+// For TMS maps at zoom 0 there is only one tile of 256 px, and 6378137 is the radius of the sphere considered in Web Mercator,
+// so at zoom 0 one pixel equals 156543.033928041 m
+#define MPIXEL (156543.033928041 * 1.00025)
 #define N_SQUARE_ZOOM_LEVELS 17
 const qreal IDrawContext::scalesSquare[N_SQUARE_ZOOM_LEVELS] = {
-    0.1492910709,   0.2985821417,    0.5971642834,    1.1943285668,    2.3886571336,   4.7773142672,
-    9.5546285344,   19.1092570688,   38.2185141376,   76.4370282752,   152.8740565504, 305.7481131008,
-    611.4962262016, 1222.9924524032, 2445.9849048064, 4891.9698096128, 9783.9396192256};
+   MPIXEL/1048576., MPIXEL/524288., MPIXEL/262144., MPIXEL/131072., MPIXEL/65536.,
+   MPIXEL/32768., MPIXEL/16384., MPIXEL/8192., MPIXEL/4096.,
+   MPIXEL/2048., MPIXEL/1024., MPIXEL/512., MPIXEL/256.,
+   MPIXEL/128., MPIXEL/64., MPIXEL/32., MPIXEL/16.};
 
 QPointF operator*(const QPointF& p1, const QPointF& p2) { return QPointF(p1.x() * p2.x(), p1.y() * p2.y()); }
 

--- a/src/qmapshack/grid/CProjWizard.cpp
+++ b/src/qmapshack/grid/CProjWizard.cpp
@@ -74,9 +74,7 @@ CProjWizard::CProjWizard(QLineEdit& line) : QDialog(CMainWindow::getBestWidgetFo
           &CProjWizard::slotChange);
 
   QString projstr = line.text();
-  QRegExp re2(
-      "\\s*\\+proj=merc \\+a=6378137 \\+b=6378137 \\+lat_ts=0.001 \\+lon_0=0.0 \\+x_0=0.0 \\+y_0=0 \\+k=1.0 \\+units=m "
-      "\\+nadgrids=@null \\+no_defs");
+  QRegExp re2("\\s*EPSG:3857");
   QRegExp re3("\\s*\\+proj=merc\\s(.*)");
   QRegExp re4("\\s*\\+proj=utm \\+zone=([0-9]+)\\s(.*)");
 

--- a/src/qmaptool/overlay/refmap/CProjWizard.cpp
+++ b/src/qmaptool/overlay/refmap/CProjWizard.cpp
@@ -74,9 +74,7 @@ CProjWizard::CProjWizard(QLineEdit& line, QWidget* parent) : QDialog(parent), li
           &CProjWizard::slotChange);
 
   QString projstr = line.text();
-  QRegExp re2(
-      "\\s*\\+proj=merc \\+a=6378137 \\+b=6378137 \\+lat_ts=0.001 \\+lon_0=0.0 \\+x_0=0.0 \\+y_0=0 \\+k=1.0 \\+units=m "
-      "\\+nadgrids=@null \\+no_defs");
+  QRegExp re2("\\s*EPSG:3857");
   QRegExp re3("\\s*\\+proj=merc\\s(.*)");
   QRegExp re4("\\s*\\+proj=utm \\+zone=([0-9]+)\\s(.*)");
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#709

### What you have done:
[comment]: # (Describe roughly.)

A- Adjust square zoom levels to fit EPSG:3857 tiles according to proposed changes in #709
B- Minor fix in Proj Wizard UI to get World Mercator (OSM) button checked  if EPSG:3857 was previously selected.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

#### Test A
1. Open Setup Map View, choose Square for Scales
2. Hit upper right grid button in same window and choose `World Mercator (OSM)` as projection
3. Choose OSM Topo as map
4. Search location Frankfurt, Germany, de
5. Zoom map to scale 100 m
6. Map looks sharp, not blurry.

#### Test B
1. Open Setup Map View, type `EPSG:3857` for Projection&Datum 
2. Hit upper right grid button in same window to open Proj Wizard
3. `World Mercator (OSM)` option appears checked

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
