### PR TITLE
Make table borders visible again

### DIFF
--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -208,6 +208,7 @@ void CDetailsPrj::draw(QTextDocument& doc, bool printable) {
 
   fmtTableStandard.setBorder(1);
   fmtTableStandard.setBorderBrush(Qt::black);
+  fmtTableStandard.setBorderCollapse(false);
   fmtTableStandard.setCellPadding(4);
   fmtTableStandard.setCellSpacing(0);
   fmtTableStandard.setHeaderRowCount(1);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS- https://github.com/Maproom/qmapshack/issues/648#issuecomment-2634284430

### What you have done:
[comment]: # (Describe roughly.)
Added `setBorderCollapse(false);` which defaults to `true`.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. with 1.17.1 the table borders of the diary are shown
2. with porting-qt6 the table borders of the diary are missing

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ ] yes, I didn't forget to change changelog.txt
