### PR TITLE
Remove duplicate tile map server requests for the same tile, allow HTTP(S) redirection

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-699] Fix writing to default config when using command line parameter -c
 [QMS-706] Apply PNG file’s offset to user-defined waypoint icon from "External Icons" folder
 [QMS-709] Adjust square zoom levels to fit EPSG:3857 tiles and other minor fix in Proj Wizard
+[QMS-715] Remove duplicate tile map server requests for the same tile, allow HTTP(S) redirection
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/map/IMapOnline.cpp
+++ b/src/qmapshack/map/IMapOnline.cpp
@@ -53,15 +53,22 @@ void IMapOnline::slotQueueChanged() {
     // request up to 6 pending request
     for (int i = 0; i < (6 - urlPending.size()); i++) {
       QString url = urlQueue.dequeue();
+      // remove all remaining duplicates from queue
+      urlQueue.removeAll(url);
       lastRequest = urlQueue.isEmpty();
 
-      QNetworkRequest request;
-      request.setUrl(url);
-      for (const rawHeaderItem_t& item : qAsConst(rawHeaderItems)) {
-        request.setRawHeader(item.name.toLatin1(), item.value.toLatin1());
+      if (!urlPending.contains(url)) {
+        QNetworkRequest request;
+        request.setUrl(url);
+        for (const rawHeaderItem_t& item : qAsConst(rawHeaderItems)) {
+          request.setRawHeader(item.name.toLatin1(), item.value.toLatin1());
+        }
+	// allow http(s) redirects
+	request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,QNetworkRequest::NoLessSafeRedirectPolicy);
+
+        accessManager->get(request);
+        urlPending << url;
       }
-      accessManager->get(request);
-      urlPending << url;
 
       if (lastRequest) {
         break;
@@ -90,7 +97,8 @@ void IMapOnline::slotQueueChanged() {
 void IMapOnline::slotRequestFinished(QNetworkReply* reply) {
   QMutexLocker lock(&mutex);
 
-  QString url = reply->url().toString();
+  // use originally requested url due to possible redirects
+  QString url = reply->request().url().toString();
   if (urlPending.contains(url)) {
     QImage img;
     // only take good responses


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#715

### What you have done:
[comment]: # (Describe roughly.)

- To prevent unnecessary tile map server requests and reduce server load as well as network traffic:
 Add a tile request for a given URL to queue of pending requests only, if request for same tile is not already queued.
 Remove all further queued requests for same URL.
 Thus, server requests are reduced signifantly.  
- To follow HTTP(S) redirections:
  Add policy to allow "http"->"http", "http" -> "https" or "https" -> "https" redirections.
  In order to recognize reply belonging to request, use originally requested url due to possible redirects.
  
### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Test 1 - removing duplicate tile requests:
1. Open a tile map server map
2. Verify that despite of removing duplicates no tiles are missing.
3. Maybe you will even notice, that countdown of downloading is faster.

Test 2 - HTTP redirection
1. Create a tms file with `<ServerUrl>http://a.tile.opentopomap.org/%1/%2/%3.png</ServerUrl>`
2. Open corresponding map in QMS
3. Verify that tiles are successfully downloaded despite server's redirection from http://a.tile.opentopomap.org to https://a.tile.opentopomap.org.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
