### PR TITLE
Add Qt version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,8 +164,15 @@ cxx_add_flag_if_supported(-Woverloaded-virtual)
 ###############################################################################################
 # Find all required packages and setup internal variables
 ###############################################################################################
-find_package(Qt6Widgets             REQUIRED)
 find_package(Qt6Core                REQUIRED)
+
+
+if (Qt6Core_VERSION VERSION_LESS 6.8.0)
+        message(FATAL_ERROR "Qt 6.8.0 or later is required.")
+endif()
+
+
+find_package(Qt6Widgets             REQUIRED)
 find_package(Qt6Xml                 REQUIRED)
 find_package(Qt6Sql                 REQUIRED)
 find_package(Qt6LinguistTools       REQUIRED)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-648] Porting to Qt6
 [QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps
 [QMS-668] MacOS build adapted to new gdal version and new brew packages
 [QMS-675] The label colors defined in the TYP are not used
@@ -8,6 +9,7 @@ V1.XX.X
 [QMS-699] Fix writing to default config when using command line parameter -c
 [QMS-706] Apply PNG file’s offset to user-defined waypoint icon from "External Icons" folder
 [QMS-709] Adjust square zoom levels to fit EPSG:3857 tiles and other minor fix in Proj Wizard
+
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#648

### What you have done:
[comment]: # (Describe roughly.)

Added a version check for Qt as some changes require recent version

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Try to cmake with a version less than 6.8.0 and with a version larger than 6.8.0

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
