### PR TITLE
cmake: allow variable customization

### DIFF
--- a/cmake/Modules/DefineInstallationPaths.cmake
+++ b/cmake/Modules/DefineInstallationPaths.cmake
@@ -10,101 +10,84 @@ if (UNIX)
   SET(EXEC_INSTALL_PREFIX
     "${CMAKE_INSTALL_PREFIX}"
     CACHE PATH  "Base directory for executables and libraries"
-    FORCE
   )
   SET(SHARE_INSTALL_PREFIX
     "${CMAKE_INSTALL_PREFIX}/share"
     CACHE PATH "Base directory for files which go to share/"
-    FORCE
   )
   SET(DATA_INSTALL_PREFIX
     "${SHARE_INSTALL_PREFIX}/"
-    CACHE PATH "The parent directory where applications can install their data" FORCE)
+    CACHE PATH "The parent directory where applications can install their data"
+  )
 
   # The following are directories where stuff will be installed to
   SET(BIN_INSTALL_DIR
     "${EXEC_INSTALL_PREFIX}/bin"
     CACHE PATH "The ${_PROJECT_NAME} binary install dir (default prefix/bin)"
-    FORCE
   )
   SET(SBIN_INSTALL_DIR
     "${EXEC_INSTALL_PREFIX}/sbin"
     CACHE PATH "The ${_PROJECT_NAME} sbin install dir (default prefix/sbin)"
-    FORCE
   )
   SET(LIB_INSTALL_DIR
     "${EXEC_INSTALL_PREFIX}/lib${LIB_SUFFIX}"
     CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is prefix/lib)"
-    FORCE
   )
   SET(LIBEXEC_INSTALL_DIR
     "${EXEC_INSTALL_PREFIX}/libexec"
     CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is prefix/libexec)"
-    FORCE
   )
   SET(PLUGIN_INSTALL_DIR
     "${LIB_INSTALL_DIR}/${_PROJECT_NAME}"
     CACHE PATH "The subdirectory relative to the install prefix where plugins will be installed (default is prefix/lib/${_PROJECT_NAME})"
-    FORCE
   )
   SET(INCLUDE_INSTALL_DIR
     "${CMAKE_INSTALL_PREFIX}/include"
     CACHE PATH "The subdirectory to the header prefix (default prefix/include)"
-    FORCE
   )
 
   SET(DATA_INSTALL_DIR
     "${DATA_INSTALL_PREFIX}"
     CACHE PATH "The parent directory where applications can install their data (default prefix/share/${_PROJECT_NAME})"
-    FORCE
   )
   SET(HTML_INSTALL_DIR
     "${DATA_INSTALL_PREFIX}/doc/HTML"
     CACHE PATH "The HTML install dir for documentation (default data/doc/html)"
-    FORCE
   )
   SET(ICON_INSTALL_DIR
     "${DATA_INSTALL_PREFIX}/icons"
     CACHE PATH "The icon install dir (default data/icons/)"
-    FORCE
   )
   SET(SOUND_INSTALL_DIR
     "${DATA_INSTALL_PREFIX}/sounds"
     CACHE PATH "The install dir for sound files (default data/sounds)"
-    FORCE
   )
 
   SET(LOCALE_INSTALL_DIR
     "${SHARE_INSTALL_PREFIX}/locale"
     CACHE PATH "The install dir for translations (default prefix/share/locale)"
-    FORCE
   )
 
   SET(XDG_APPS_DIR
     "${SHARE_INSTALL_PREFIX}/applications/"
     CACHE PATH "The XDG apps dir"
-    FORCE
   )
   SET(XDG_DIRECTORY_DIR
     "${SHARE_INSTALL_PREFIX}/desktop-directories"
     CACHE PATH "The XDG directory"
-    FORCE
   )
 
   SET(SYSCONF_INSTALL_DIR
     "${EXEC_INSTALL_PREFIX}/etc"
     CACHE PATH "The ${_PROJECT_NAME} sysconfig install dir (default prefix/etc)"
-    FORCE
   )
   SET(MAN_INSTALL_DIR
     "${SHARE_INSTALL_PREFIX}/man"
     CACHE PATH "The ${_PROJECT_NAME} man install dir (default prefix/man)"
-    FORCE
   )
   SET(INFO_INSTALL_DIR
     "${SHARE_INSTALL_PREFIX}/info"
     CACHE PATH "The ${_PROJECT_NAME} info install dir (default prefix/info)"
-    FORCE
   )
 endif (UNIX)
 


### PR DESCRIPTION
In order to allow distributors to change file locations, i.e. for documentation, remove the FORCE value so locations can changed as neeed.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#

### What you have done:
[comment]: # (Describe roughly.)



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open whatever
2. Click here

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [ ] yes

### Is every user facing string in a tr() macro?

- [ ] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ ] yes, I didn't forget to change changelog.txt
