### PR TITLE
readd namespace processing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-730] TMS/WMTS fixed accidentally removed namespace processing
 [QMS-648] Porting to Qt6
 [QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps
 [QMS-668] MacOS build adapted to new gdal version and new brew packages
@@ -32,7 +33,7 @@ V1.17.0
 [QMS-490] Potentially incorrect slope shading opacity for slope value NOFLOAT
 [QMS-499] Disable close action for projects with autom. sync. to device
 [QMS-503] BRouter Version 1.6.3 local setup fails
-[QMS-507] QMapTool: Early projection validity check 
+[QMS-507] QMapTool: Early projection validity check
 [QMS-517] GPX-tracks are not displayed if lon or lat are invariant over the entire track
 [QMS-518] Enable edit for timestamps of waypoints
 [QMS-522] Change URLs of built-in maps from http to https
@@ -51,7 +52,7 @@ V1.17.0
 [QMS-591] MacOS build adapted for new Quazip version / preperation for brew package
 [QMS-594] Java version check fails in BRouter setup
 [QMS-606] Better hillshading with high resolution Lidar data
-[QMS-608] Update local copy of alglib 
+[QMS-608] Update local copy of alglib
 [QMS-610] Replace uncrustify by clang-format
 [QMS-612] Optimize DEM rendering by using a thread pool
 [QMS-615] Syntax error when compiling QMS for Windows

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -60,7 +60,7 @@ CMapTMS::CMapTMS(const QString& filename, CMapDraw* parent) : IMapOnline(parent)
   }
 
   QDomDocument dom;
-  const QDomDocument::ParseResult& result = dom.setContent(&file);
+  const QDomDocument::ParseResult& result = dom.setContent(&file, QDomDocument::ParseOption::UseNamespaceProcessing);
   if (!result) {
     file.close();
     QMessageBox::critical(CMainWindow::getBestWidgetForParent(), tr("Error..."),

--- a/src/qmapshack/map/CMapWMTS.cpp
+++ b/src/qmapshack/map/CMapWMTS.cpp
@@ -42,7 +42,7 @@ CMapWMTS::CMapWMTS(const QString& filename, CMapDraw* parent) : IMapOnline(paren
   }
 
   QDomDocument dom;
-  const QDomDocument::ParseResult& result = dom.setContent(&file);
+  const QDomDocument::ParseResult& result = dom.setContent(&file, QDomDocument::ParseOption::UseNamespaceProcessing);
   if (!result) {
     file.close();
     QMessageBox::critical(CMainWindow::getBestWidgetForParent(), tr("Error..."),


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#730

### What you have done:
[comment]: # (Describe roughly.)

Re-added namespace processing for xml files. The namespace processing was accidentally removed by fixing deprecation warnings.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Activate a WMTS or TMS map
2. An errorwindow is displayed

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes (i guess)

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
