### PR TITLE
[QMS-732]: build scripts for macOS don't support qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,11 +86,11 @@ if (APPLE)
     # set(ROUTINO_DEV_PATH ${ROUTINO_DEV_PATH} CACHE PATH "Path to directory containing routino include and lib")
     message("ROUTINO_DEV_PATH = ${ROUTINO_DEV_PATH}")
     
-    if(NOT DEFINED QuaZip-Qt5_DIR)
-        message(FATAL_ERROR "QuaZip-Qt5_DIR not set!!!")
-    endif(NOT DEFINED QuaZip-Qt5_DIR)
-    # set(QuaZip-Qt5_DIR ${QuaZip-Qt5_DIR} CACHE PATH "Path to directory containing quazip cmake config files")
-    message("QuaZip-Qt5_DIR = ${QuaZip-Qt5_DIR}")
+    if(NOT DEFINED QuaZip-Qt6_DIR)
+        message(FATAL_ERROR "QuaZip-Qt6_DIR not set!!!")
+    endif(NOT DEFINED QuaZip-Qt6_DIR)    
+    # set(QuaZip-Qt6_DIR ${QuaZip-Qt6_DIR} CACHE PATH "Path to directory containing quazip cmake config files")
+    message("QuaZip-Qt6_DIR = ${QuaZip-Qt6_DIR}")
 
     if(NOT DEFINED PROJ_DEV_PATH)
         message(FATAL_ERROR "PROJ_DEV_PATH not set!!!")
@@ -275,5 +275,3 @@ endif (UNIX AND NOT WIN32 AND NOT APPLE)
 # this is used by the uninstall target
 CONFIGURE_FILE( "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
 ADD_CUSTOM_TARGET(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
-
-

--- a/MacOSX/build-QMS.sh
+++ b/MacOSX/build-QMS.sh
@@ -19,17 +19,8 @@ fi
 mkdir $QMSDEVDIR/build_QMapShack
 cd $QMSDEVDIR/build_QMapShack
 
-if [ ! -z `brew --prefix qt` ]; then
-  echo "unlinking qt and linking qt@5"
-  brew unlink qt
-  brew link qt@5
-fi
-
 GDAL_CMAKE_PAR="-DGDAL_CONFIG=$GDAL/bin/gdal-config -DGDAL_INCLUDE_DIR=$GDAL/include -DGDAL_LIBRARY=$GDAL/lib/libgdal.dylib -DGDAL_DEV_PATH=$GDAL"
-CMAKE_PAR="-DLOCAL_DEV=$LOCAL_ENV  -DCMAKE_MACOSX_RPATH=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQT_DEV_PATH=$QT_DEV_PATH $GDAL_CMAKE_PAR -DROUTINO_DEV_PATH=$ROUTINO_DEV_PATH -DPROJ_DEV_PATH=$PROJ_DEV_PATH -DQuaZip-Qt5_DIR=$QuaZip_Qt5_DIR"
-# else
-#   CMAKE_PAR="-DLOCAL_DEV=$LOCAL_ENV  -DCMAKE_MACOSX_RPATH=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQT_DEV_PATH=$QT_DEV_PATH -DGDAL_DEV_PATH=$GDAL -DROUTINO_DEV_PATH=$ROUTINO_DEV_PATH -DPROJ_DEV_PATH=$PROJ_DEV_PATH -DQuaZip-Qt5_DIR=$QuaZip_Qt5_DIR"
-# fi
+CMAKE_PAR="-DLOCAL_DEV=$LOCAL_ENV  -DCMAKE_MACOSX_RPATH=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQT_DEV_PATH=$QT_DEV_PATH $GDAL_CMAKE_PAR -DROUTINO_DEV_PATH=$ROUTINO_DEV_PATH -DPROJ_DEV_PATH=$PROJ_DEV_PATH -DQuaZip-Qt6_DIR=$QUAZIP_CMAKE_DIR"
 
 echo "${INFO} cmake ../qmapshack ${CMAKE_PAR}${NC}"
 
@@ -37,10 +28,10 @@ if [[ "$XCODE_PROJECT" == "" ]]; then
     $PACKAGES_PATH/bin/cmake ../qmapshack $CMAKE_PAR -DCMAKE_BUILD_TYPE=Release 
     # building QMapShack
     echo "${INFO}Building QMapShack - can take very long ...${NC}"
-    make
+    make -j$(sysctl -n hw.ncpu)
     echo "${INFO}Building QMapShack - finished${NC}"
 else
-    # Creade Xcode project for debugging    
+    # BROKEN:  Creade Xcode project for debugging    
     # export Qt5Widgets_DIR=/$QT_DIR/lib/cmake/Qt5Widgets
     # export Qt5Xml_DIR=$QT_DIR/lib/cmake/Qt5Xml
     # export Qt5Sql_DIR=$QT_DIR/lib/cmake/Qt5Sql
@@ -55,12 +46,5 @@ else
     echo "${INFO}Xcode project written in $QMSDEVDIR/build_QMapShack${NC}"
     exit
 fi
-
-if [ ! -z `brew --prefix qt` ]; then
-  echo "unlinking qt@5 and linking qt"
-  brew unlink qt@5
-  brew link qt
-fi
-
 
 cd $QMSDEVDIR

--- a/MacOSX/build-all.sh
+++ b/MacOSX/build-all.sh
@@ -26,10 +26,9 @@ read -n 1 -s
 
 ######################################################################## 
 # clean up
-if [[ "$1" == "clean" ]]; then
-
+if [ "$1" = "clean" ]; then
+    unset INCLUDED
     source $SRC_OSX_DIR/clean.sh
-    exit
 fi
 
 ########################################################################
@@ -60,7 +59,7 @@ fi
 ######################################################################## 
 # build Proj
 if [ -z "$MACPORTS_BUILD" ]; then
-   if [[ "$BUILD_PROJ" == "x" ]]; then
+   if [ "$BUILD_PROJ" = "x" ]; then
         cd $QMSDEVDIR
         source $SRC_OSX_DIR/build-proj.sh
         cd $QMSDEVDIR
@@ -70,7 +69,7 @@ fi
 ######################################################################## 
 # build GDAL
 if [ -z "$MACPORTS_BUILD" ]; then
-   if [[ "$BUILD_GDAL" == "x" ]]; then
+   if [ "$BUILD_GDAL" = "x" ]; then
         cd $QMSDEVDIR
         source $SRC_OSX_DIR/build-gdal.sh
         cd $QMSDEVDIR
@@ -89,7 +88,6 @@ sh $SRC_OSX_DIR/build-QMS.sh
 cd $QMSDEVDIR
 
 # Bundling QMapShack and QMapTool
-# source $QMS_BUILD_FILES/bundle.sh
 source $SRC_OSX_DIR/bundle-all.sh
 cd $QMSDEVDIR
 
@@ -106,5 +104,3 @@ cd $QMSDEVDIR
 # echo "${INFO}QMapShack can ignore dark mode by adding the following key to the \"info.plist\" file.${NC}"
 # echo "${INFO}<key>NSRequiresAquaSystemAppearance</key> <string>true</string>${NC}"
 # echo "${INFO}The \"info.plist\" file can be found in the bundle of the app under the \"Contents\" folder,${NC}"
-
-

--- a/MacOSX/build-gdal.sh
+++ b/MacOSX/build-gdal.sh
@@ -13,22 +13,22 @@ echo "${ATTN}-----------------${NC}"
     cd $QMSDEVDIR/gdal
     mkdir build
     cd ./build
+    
+    # Ensure local PROJ is used
+    export PKG_CONFIG_PATH="$LOCAL_ENV/lib/pkgconfig"
+    export CMAKE_PREFIX_PATH="$LOCAL_ENV:$CMAKE_PREFIX_PATH"
+    export PROJ_INCLUDE="$LOCAL_ENV/include"
+
     # Boost headers need to be in the include path
     export CPATH="$LOCAL_ENV/include:$PACKAGES_PATH/include:${CPATH}"
-    echo "CPATH = $CPATH"
     export LIBRARY_PATH="$LOCAL_ENV/lib:$PACKAGES_PATH/lib"
     export LD_LIBRARY_PATH="$LOCAL_ENV/lib:$PACKAGES_PATH/lib"
-    export PATH="$PACKAGES_PATH/opt/expat/bin:$PATH"
-
-
-    # LDFLAGS="-L$PACKAGES_PATH/opt/expat/lib"
-    # CPPFLAGS="-I$PACKAGES_PATH/opt/expat/include"
 
     GDAL=$LOCAL_ENV
 
-    $PACKAGES_PATH/bin/cmake .. -DCMAKE_PREFIX_PATH=$GDAL \
+    $PACKAGES_PATH/bin/cmake .. -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
                                 -DCMAKE_BUILD_TYPE=Release \
-                                -DCMAKE_INSTALL_PREFIX=$GDAL \
+                                -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV \
                                 -DGDAL_SET_INSTALL_RELATIVE_RPATH=ON \
                                 -DGDAL_USE_INTERNAL_LIBS=ON \
                                 -DGDAL_USE_EXTERNAL_LIBS=OFF \
@@ -38,7 +38,7 @@ echo "${ATTN}-----------------${NC}"
                                 -DGDAL_ENABLE_DRIVER_WCS:BOOL=ON \
                                 -DGDAL_USE_TIFF=ON \
                                 -DGDAL_USE_GEOTIFF=ON \
-                                -DGDAL_USE_GEOS=ON=ON \
+                                -DGDAL_USE_GEOS=ON \
                                 -DGDAL_USE_PNG=ON \
                                 -DGDAL_USE_GIF=ON \
                                 -DGDAL_USE_ODBC=ON \
@@ -48,11 +48,12 @@ echo "${ATTN}-----------------${NC}"
                                 -DGDAL_USE_EXPAT=ON \
                                 -DGDAL_USE_HEIF=ON \
                                 -DGDAL_USE_WEBP=OFF \
-                                # -DGDAL_USE_HDF5=ON \ (Problem)
-                                # -DGDAL_USE_JPEG=ON \ (Problem)
+                                -DGDAL_ENABLE_PYTHON=OFF \
+                                -DGDAL_USE_SWIG=OFF \
+                                -DBUILD_PYTHON_BINDINGS=OFF
                             
                                                                 
                              
-    $PACKAGES_PATH/bin/cmake --build . -j4
+    $PACKAGES_PATH/bin/cmake --build . -j"$(sysctl -n hw.ncpu)"
     $PACKAGES_PATH/bin/cmake --build . --target install
     cd $QMSDEVDIR

--- a/MacOSX/build-proj.sh
+++ b/MacOSX/build-proj.sh
@@ -7,7 +7,7 @@ echo "${ATTN}-----------------${NC}"
 ######################################################################## 
 # build Proj
 
-PROJ_PKG=proj-9.3.0
+PROJ_PKG=proj-9.6.0
 
 cd $QMSDEVDIR
 echo "${ATTN}Building Proj ...${NC}"
@@ -18,10 +18,9 @@ cd $QMSDEVDIR/$PROJ_PKG
 mkdir build
 cd build
 $PACKAGES_PATH/bin/cmake .. -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV
-$PACKAGES_PATH/bin/cmake .. -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV
 $PACKAGES_PATH/bin/cmake --build . -j4
 $PACKAGES_PATH/bin/cmake --build . --target install
 
-$LOCAL_ENV/share/proj
-curl https://download.osgeo.org/proj/proj-data-1.15.tar.gz | tar xzf -
+cd $LOCAL_ENV/share/proj
+curl https://download.osgeo.org/proj/proj-data-1.21.tar.gz | tar xzf -
 cd $QMSDEVDIR

--- a/MacOSX/build-quazip.sh
+++ b/MacOSX/build-quazip.sh
@@ -14,20 +14,8 @@ cd $QMSDEVDIR/quazip
 mkdir build
 cd ./build
 
-if [ ! -z `brew --prefix qt` ]; then
-  echo "unlinking qt and linking qt@5"
-  brew unlink qt
-  brew link qt@5
-fi
-
-$PACKAGES_PATH/bin/cmake .. -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV -DQT_VERSION_MAJOR=5 -DQUAZIP_QT_MAJOR_VERSION=5
-$PACKAGES_PATH/bin/cmake --build . -j4
+$PACKAGES_PATH/bin/cmake .. -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV -DQT_VERSION_MAJOR=6 -DQUAZIP_QT_MAJOR_VERSION=6 -DCMAKE_PREFIX_PATH=$QT_DEV_PATH
+$PACKAGES_PATH/bin/cmake --build . -j"$(sysctl -n hw.ncpu)"
 $PACKAGES_PATH/bin/cmake --build . --target install
-
-if [ ! -z `brew --prefix qt` ]; then
-  echo "unlinking qt@5 and linking qt"
-  brew unlink qt@5
-  brew link qt
-fi
 
 cd $QMSDEVDIR

--- a/MacOSX/bundle-all.sh
+++ b/MacOSX/bundle-all.sh
@@ -4,7 +4,7 @@ source $QMSDEVDIR/qmapshack/MacOSX/config.sh   # check for important paramters
 
 # Bundling QMapShack and QMapTool
 echo "${INFO}Bundle QMapShack ...${NC}"
-mkdir $BUILD_RELEASE_DIR
+mkdir -p $BUILD_RELEASE_DIR
 cd $SRC_OSX_DIR
 source ./bundle-qmapshack.sh
 cd $SRC_OSX_DIR

--- a/MacOSX/bundle-qmapshack.sh
+++ b/MacOSX/bundle-qmapshack.sh
@@ -2,7 +2,7 @@
 
 source $QMSDEVDIR/qmapshack/MacOSX/config.sh   # check for important paramters
 
-echo "${ATTN}Building QMapShack.app ...${NC}"
+echo "${ATTN}Bundling QMapShack.app ...${NC}"
 echo "${ATTN}--------------------------${NC}"
 
 set -a
@@ -13,12 +13,12 @@ source $SRC_OSX_DIR/bundle-common-func.sh
 
 
 function extendAppStructure {
-    mkdir $BUILD_BUNDLE_RES_QM_DIR
-    mkdir $BUILD_BUNDLE_RES_GDAL_DIR
-    mkdir $BUILD_BUNDLE_RES_PROJ_DIR
-    mkdir $BUILD_BUNDLE_RES_ROUTINO_DIR
-    mkdir $BUILD_BUNDLE_RES_HELP_DIR
-    mkdir $BUILD_BUNDLE_RES_BIN_DIR
+    mkdir -p "$BUILD_BUNDLE_RES_QM_DIR"
+    mkdir -p "$BUILD_BUNDLE_RES_GDAL_DIR"
+    mkdir -p "$BUILD_BUNDLE_RES_PROJ_DIR"
+    mkdir -p "$BUILD_BUNDLE_RES_ROUTINO_DIR"
+    mkdir -p "$BUILD_BUNDLE_RES_HELP_DIR"
+    mkdir -p "$BUILD_BUNDLE_RES_BIN_DIR"
 }
 
 
@@ -27,43 +27,36 @@ function copyAdditionalLibraries {
 
         echo "---building with homebrew---"
         cp -v    $ROUTINO_DEV_PATH/lib/libroutino* $BUILD_BUNDLE_FRW_DIR
-        cp -v    $LOCAL_ENV/lib/libquazip*.dylib $BUILD_BUNDLE_FRW_DIR
+        install -m 644 $LOCAL_ENV/lib/libquazip*.dylib $BUILD_BUNDLE_FRW_DIR
 
         if [ -z "$BREW_PACKAGE_BUILD" ]; then
             # copy only if built as standalone package (QMS not as a brew pkg)
             echo "---build needs brew at runtime---"
 
-            if [[ "$BUILD_GDAL" == "x" ]]; then
-                cp -vP `brew --prefix openjpeg`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP `brew --prefix libkml`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP `brew --prefix minizip`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP `brew --prefix uriparser`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP `brew --prefix geos`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP $LOCAL_ENV/lib/libgdal*.dylib $BUILD_BUNDLE_FRW_DIR
+            if [ "$BUILD_GDAL" = "x" ]; then
+                install -m 644 `brew --prefix openjpeg`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix libkml`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix minizip`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix uriparser`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix geos`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 $LOCAL_ENV/lib/libgdal*.dylib $BUILD_BUNDLE_FRW_DIR
             else
-                cp -vP `brew --prefix gdal`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP `brew --prefix openexr`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP `brew --prefix geos`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
-                cp -vP `brew --prefix jpeg-xl`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix gdal`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix openexr`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix geos`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix jpeg-xl`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
             fi
             
             $LOCAL_ENV/bin/otoolrecursive -u $BUILD_BUNDLE_FRW_DIR/libgdal.dylib | xargs -I{} cp -v {} $BUILD_BUNDLE_FRW_DIR
 
-            if [[ "$BUILD_PROJ" == "x" ]]; then
-                cp -vP $LOCAL_ENV/lib/libproj*.dylib $BUILD_BUNDLE_FRW_DIR
+            if [ "$BUILD_PROJ" = "x" ]; then
+                install -m 644 $LOCAL_ENV/lib/libproj*.dylib $BUILD_BUNDLE_FRW_DIR
             else
-                cp -vP `brew --prefix proj`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+                install -m 644 `brew --prefix proj`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
             fi
-            cp -vP `brew --prefix dbus`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+            install -m 644 `brew --prefix dbus`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
 
-            cp -v -R $QT_DEV_PATH/lib/QtOpenGL.framework $BUILD_BUNDLE_FRW_DIR
-            cp -v -R $QT_DEV_PATH/lib/QtQuick.framework $BUILD_BUNDLE_FRW_DIR
-            cp -v -R $QT_DEV_PATH/lib/QtQml.framework $BUILD_BUNDLE_FRW_DIR
-        fi
-        if [[ "$BUILD_GDAL" == "x" ]]; then
-            cp -vL $GDAL/lib/libgdal*.dylib $BUILD_BUNDLE_FRW_DIR
-        else
-            cp -vP `brew --prefix gdal`/lib/lib*.dylib $BUILD_BUNDLE_FRW_DIR
+            cp -v -R $QT_DEV_PATH/lib/QtQuickWidgets.framework $BUILD_BUNDLE_FRW_DIR
         fi
         
     else
@@ -92,10 +85,14 @@ function copyAdditionalLibraries {
 
 function copyExternalFiles {
     if [ -z "$MACPORTS_BUILD" ]; then
-
         echo "---building with homebrew---"
-        cp -vP $LOCAL_ENV/share/gdal/* $BUILD_BUNDLE_RES_GDAL_DIR
-        if [[ "$BUILD_PROJ" == "x" ]]; then
+        
+        if [ "$BUILD_GDAL" = "x" ]; then
+            cp -vP $LOCAL_ENV/share/gdal/* $BUILD_BUNDLE_RES_GDAL_DIR
+        else
+            cp -vP $(brew --prefix gdal)/share/gdal/* $BUILD_BUNDLE_RES_GDAL_DIR
+        fi
+        if [ "$BUILD_PROJ" = "x" ]; then
             cp -vP $LOCAL_ENV/share/proj/* $BUILD_BUNDLE_RES_PROJ_DIR
         else
             cp -vP $PACKAGES_PATH/share/proj/* $BUILD_BUNDLE_RES_PROJ_DIR
@@ -132,13 +129,17 @@ function copyExtTools {
  
         if [ -z "$BREW_PACKAGE_BUILD" ]; then
             # copy only if built as standalone package (QMS not as a brew pkg)
-            if [[ "$BUILD_PROJ" == "x" ]]; then
+            if [ "$BUILD_PROJ" = "x" ]; then
                 cp -v $LOCAL_ENV/bin/proj             $BUILD_BUNDLE_RES_BIN_DIR
             else
                 cp -v $PACKAGES_PATH/bin/proj             $BUILD_BUNDLE_RES_BIN_DIR
             fi
         fi
         cp -v $GDAL/bin/gdalbuildvrt                $BUILD_BUNDLE_RES_BIN_DIR
+        cp -v $GDAL/bin/gdaladdo                $BUILD_BUNDLE_RES_BIN_DIR
+        cp -v $GDAL/bin/gdal_translate          $BUILD_BUNDLE_RES_BIN_DIR
+        cp -v $GDAL/bin/gdalwarp                $BUILD_BUNDLE_RES_BIN_DIR
+
         cp -v $ROUTINO_DEV_PATH/bin/planetsplitter  $BUILD_BUNDLE_RES_BIN_DIR
       else
         echo "---building with macports---"
@@ -147,9 +148,6 @@ function copyExtTools {
         cp -v $ROUTINO_DEV_PATH/bin/planetsplitter       $BUILD_BUNDLE_RES_BIN_DIR
     fi
    
-    # currently only used by QMapTool.
-    cp -v $BUILD_BIN_DIR/qmt_rgb2pct            $BUILD_BUNDLE_RES_BIN_DIR
-    cp -v $BUILD_BIN_DIR/qmt_map2jnx            $BUILD_BUNDLE_RES_BIN_DIR
 }
 
 
@@ -165,75 +163,80 @@ function archiveBundle {
 }
 
 
-if [[ "$1" == "" ]]; then
 
-    if [ ! -z `brew --prefix qt` ]; then
-        echo "unlinking qt and linking qt@5"
-        brew unlink qt
-        brew link qt@5
-    fi
 
-    echo "---extract version -----------------"
-    extractVersion
-    readRevisionHash
-    echo "---build bundle --------------------"
-    buildAppStructure
-    extendAppStructure
-    echo "---replace version string ----------"
-    updateInfoPlist
-    if [[ "$BREW_PACKAGE_BUILD" == "" ]] ; then
-        echo "---qt deploy tool ------------------"
-        qtDeploy
-    fi
-    echo "---copy libraries ------------------"
-    copyAdditionalLibraries
-    echo "---copy external files -------------"
-    copyQtTrqnslations
-    copyExternalFiles
-    copyExternalHelpFiles_QMS
-    if [ -z "$BREW_PACKAGE_BUILD"]; then
-        # copy only if built as standalone package (QMS not as a brew pkg)
-        echo "---adjust linking ------------------"
-        adjustLinking
-    fi
-    echo "---external tools ------------------"
-    copyExtTools
-    if [ -z "$BREW_PACKAGE_BUILD" ]; then
-        # copy only if built as standalone package (QMS not as a brew pkg)
-        adjustLinkingExtTools
-    fi
-    printLinkingExtTools
-    echo "------------------------------------"
+echo "---extract version -----------------"
+extractVersion
+readRevisionHash
+echo "---build bundle --------------------"
+buildAppStructure
+extendAppStructure
+echo "---replace version string ----------"
+updateInfoPlist
 
-    # Codesign the apps (on arm64 mandatory):
-    echo "${INFO}Signing app bundles${NC}"
+echo "---qt deploy tool ------------------"
+if [ "$BREW_PACKAGE_BUILD" = "" ] ; then
+    qtDeploy
+fi
 
-    # 1. remove all empty directories, otherwiese verification of signing will fail
-    find $BUILD_BUNDLE_CONTENTS_DIR -type d -empty -delete
+echo "---copy libraries ------------------"
+copyAdditionalLibraries
 
-    if [ -z "$BREW_PACKAGE_BUILD" ]; then
-        # copy only if built as standalone package (QMS not as a brew pkg)
-    # 2. sign gdalbuild (special hack), since it is an executable copied from outside into the bundle
-    # install_name_tool -add_rpath @executable_path/../Frameworks $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
-    # codesign -s <Apple Dev Account> --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
-    codesign -s manfred.kern@gmail.com --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
-    # codesign  --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
-    fi
+echo "---copy translations ------------------"
+copyQtTranslations    
 
-    # 3. sign the complete app bundle
-    # codesign -s <Apple Dev Account> --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app
-    codesign -s manfred.kern@gmail.com --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app
-    # codesign --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app
+echo "---external data files -------------"
+copyExternalFiles
 
-    if [ ! -z `brew --prefix qt` ]; then
-        echo "unlinking qt@5 and linking qt"
-        brew unlink qt@5
-        brew link qt
-    fi
+echo "---external help files -------------"
+copyExternalHelpFiles_QMS
+
+
+
+echo "---external tools ------------------"
+copyExtTools
+
+
+if [ -z "$BREW_PACKAGE_BUILD" ]; then
+    # copy only if built as standalone package (QMS not as a brew pkg)
+    echo "---adjust linking ------------------"
+    adjustLinking
+fi
+
+if [ -z "$BREW_PACKAGE_BUILD" ]; then
+    # copy only if built as standalone package (QMS not as a brew pkg)
+        echo "---adjustLinkingExtTools -------------"
+
+    adjustLinkingExtTools
 
 fi
 
-if [[ "$1" == "archive" ]]; then
+
+printLinkingExtTools
+echo "------------------------------------"
+
+# Codesign the apps (on arm64 mandatory):
+echo "${INFO}Signing app bundles${NC}"
+
+# 1. remove all empty directories, otherwiese verification of signing will fail
+find $BUILD_BUNDLE_CONTENTS_DIR -type d -empty -delete
+
+if [ -z "$BREW_PACKAGE_BUILD" ]; then
+    # copy only if built as standalone package (QMS not as a brew pkg)
+# 2. sign gdalbuild (special hack), since it is an executable copied from outside into the bundle
+# install_name_tool -add_rpath @executable_path/../Frameworks $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
+# codesign -s <Apple Dev Account> --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
+codesign -s manfred.kern@gmail.com --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
+# codesign  --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app/Contents/Tools/gdalbuildvrt
+fi
+
+# 3. sign the complete app bundle
+# codesign -s <Apple Dev Account> --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app
+codesign -s manfred.kern@gmail.com --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app
+# codesign --force --deep --sign - $BUILD_RELEASE_DIR/QMapShack.app
+
+
+if [ "$1" = "archive" ]; then
     extractVersion
     archiveBundle
 fi

--- a/MacOSX/config.sh
+++ b/MacOSX/config.sh
@@ -22,6 +22,10 @@ export ATTN=$(tput setaf 1)  # red
 export NC=$(tput sgr0)
 
 export QMSDEVDIR=${QMSDEVDIR%/} # remove trailing slash, if there is any
+export BUILD_QMAPSHACK_DIR="$QMSDEVDIR/build_QMapShack"
+
+# ARM64 or Intel(?)
+export CMAKE_OSX_ARCHITECTURES=$(uname -m)
 
 echo ${ATTN}
 echo "-------------------------------------------------"
@@ -36,7 +40,7 @@ echo ${NC}
 # Check if you build qmapshack outside of the source dir (cloned from GitHub)
 ########################################################################
 
-if [[ "$QMSDEVDIR" == "" ]]; then
+if [ "$QMSDEVDIR" = "" ]; then
     echo $ATTN
     echo "shell var QMSDEVDIR is not set"
     echo "Please export QMSDEVDIR to a folder outside of qmapshack"
@@ -49,7 +53,7 @@ fi
 # echo $DIR_SCRIPT
 echo ${DIR_SCRIPT%/*}
 # echo ${DIR_SCRIPT%/*}/*
-if [[ "$QMSDEVDIR" == "$DIR_SCRIPT" ]] || [[ "$QMSDEVDIR"  ==  ${DIR_SCRIPT%/*}  ]]; then
+if [ "$QMSDEVDIR" = "$DIR_SCRIPT" ] || [ "$QMSDEVDIR" = "${DIR_SCRIPT%/*}" ]; then
     echo $ATTN
     echo "Your shell var QMSDEVDIR points to a driectory inside qmapshack"
     echo "Please export QMSDEVDIR to a folder outside of qmapshack"
@@ -87,7 +91,7 @@ export XCODE_PROJECT=
 export BUILD_GDAL="x"
 # PROJ (still experimental): if set to "x", it will be built from source. 
 # If not set (i.e. blank), PROJ will be taken from the package manager
-export BUILD_PROJ=
+export BUILD_PROJ="x"
 
 
 # checking arguments: intested in -x (Xcode), -m (MacPorts), -b (Homebrew)
@@ -134,7 +138,7 @@ export LOCAL_ENV=$QMSDEVDIR/local  # folder for building pkgs from source
 # package manager
 eval "$(brew shellenv)"   # set HOMEBREW_PREFIX
 export PACKAGES_PATH=$HOMEBREW_PREFIX
-if [[ "$MACPORTS_BUILD" == "x" ]]; then
+if [ "$MACPORTS_BUILD" = "x" ]; then
     export MACPORTS=/opt/local          # Macports package manager
     export HOMEBREW_PREFIX=
     export BREW_PACKAGE_BUILD=
@@ -146,35 +150,35 @@ export BUILD_RELEASE_DIR=$QMSDEVDIR/release # app bundles will be put
 export QMS_SRC_DIR=$QMSDEVDIR/qmapshack # QMS source dir (clone from GitHub)
 export SRC_OSX_DIR=$QMSDEVDIR/qmapshack/MacOSX # Sources only for MacOS
 
-# QT5
-if [[ "$MACPORTS_BUILD" == "x" ]]; then
-    export QT_DEV_PATH=$PACKAGES_PATH/libexec/qt5
+# QT6
+if [ "$MACPORTS_BUILD" = "x" ]; then
+    export QT_DEV_PATH=$PACKAGES_PATH/libexec/qt6
 else
-    export QT_DEV_PATH=$PACKAGES_PATH/opt/qt5
+    export QT_DEV_PATH=$PACKAGES_PATH/opt/qt@6
 fi
-export Qt5_DIR=$QT_DEV_PATH/lib/cmake
+export Qt6_DIR=$QT_DEV_PATH/lib/cmake
 
 # Other packages needed
-if [[ "$MACPORTS_BUILD" == "x" ]]; then
+if [ "$MACPORTS_BUILD" = "x" ]; then
     export GDAL=$PACKAGES_PATH
     export ROUTINO_DEV_PATH=$PACKAGES_PATH
     export PROJ_DEV_PATH=$PACKAGES_PATH/lib/proj9
-    export QuaZip_Qt5_DIR=$PACKAGES_PATH/lib/cmake/QuaZip-Qt5-1.4
+    export QuaZip_Qt6_DIR=$PACKAGES_PATH/lib/cmake/QuaZip-Qt6-1.5
 else
     # GDAL, ROUTINO, QUAZIP, PROJ are compiled from source
-    if [[ "$BUILD_GDAL" == "x" ]]; then
-        export GDAL_RELEASE="3.8"
+    if [ "$BUILD_GDAL" = "x" ]; then
+        export GDAL_RELEASE="3.10"
         export GDAL=$LOCAL_ENV
     else
         export GDAL=$PACKAGES_PATH
     fi
     export ROUTINO_DEV_PATH=$LOCAL_ENV
-    if [[ "$BUILD_PROJ" == "x" ]]; then
+    if [ "$BUILD_PROJ" = "x" ]; then
         export PROJ_DEV_PATH=$LOCAL_ENV
     else
         export PROJ_DEV_PATH=$PACKAGES_PATH
     fi
-    export QuaZip_Qt5_DIR=$LOCAL_ENV/lib/cmake/QuaZip-Qt5-1.4
+export QuaZip_Qt6_DIR=$LOCAL_ENV/lib/cmake/QuaZip-Qt6-1.5
 fi
 
 # env vars for building QMS
@@ -198,14 +202,14 @@ echo "BUILD_RELEASE_DIR = $BUILD_RELEASE_DIR"
 echo "QMS_SRC_DIR = $QMS_SRC_DIR"
 echo "SRC_OSX_DIR = $SRC_OSX_DIR"
 echo "QT_DEV_PATH = $QT_DEV_PATH"
-echo "Qt5_DIR = $Qt5_DIR"
+echo "Qt6_DIR = $Qt6_DIR"
 echo "BUILD_GDAL = $BUILD_GDAL"
 echo "GDAL = $GDAL"
 echo "GDAL_RELEASE = $GDAL_RELEASE"
 echo "ROUTINO_DEV_PATH = $ROUTINO_DEV_PATH"
 echo "BUILD_PROJ = $BUILD_PROJ"
 echo "PROJ_DEV_PATH = $PROJ_DEV_PATH"
-echo "QuaZip_Qt5_DIR = $QuaZip_Qt5_DIR"
+echo "QuaZip_Qt6_DIR = $QuaZip_Qt6_DIR"
 echo "OSX_DEPLOYMENT_TARGET = $OSX_DEPLOYMENT_TARGET"
 echo "-------------------------------------"
 echo ${NC}

--- a/MacOSX/install-packages.sh
+++ b/MacOSX/install-packages.sh
@@ -31,7 +31,7 @@ if [ -z "$MACPORTS_BUILD" ]; then
     rm -f $QMSDEVDIR/brewlist*.txt
     brew list > $QMSDEVDIR/brewlist-`date +%s`.txt
     brew install cmake
-    brew install qt@5
+    brew install qt@6
 
     brew install dbus
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-732] Migrate macOS build from Qt5 to Qt6
 [QMS-730] TMS/WMTS fixed accidentally removed namespace processing
 [QMS-648] Porting to Qt6
 [QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#732

### What you have done:
[comment]: # (Describe roughly.)

- Update dependency versions:
    - Proj to 9.6.0 (from 9.3.0)
    - Routino to 3.4.2 (from 3.4.1)
    - GDAL to 3.10
    - Proj data to 1.21 (from 1.15)
- Adapt CMake configuration and build scripts (build-*.sh) for Qt6
- Update bundling scripts (bundle-*.sh) to handle Qt6
- Improve GDAL build configuration:
    - Explicitly disable Python bindings
    - Ensure local PROJ is used via PKG_CONFIG_PATH and CMAKE_PREFIX_PATH
    - Fix GEOS usage flag
- Patch Routino Makefile for macOS compatibility (dynamiclib, rpath)
- Build PROJ from source by default (BUILD_PROJ="x").
- Refactor and clean up build and bundling scripts
- Use make -j$(sysctl -n hw.ncpu) for parallel builds

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. follow instructions in MacOSX/README.md

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [ ] yes

### Is every user facing string in a tr() macro?

- [ ] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
