### PR TITLE
broute java setup related fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ V1.XX.X
 [QMS-732] Migrate macOS build from Qt5 to Qt6
 [QMS-730] TMS/WMTS fixed accidentally removed namespace processing
 [QMS-740] Fix dbus compile issues for Windows
+[QMS-664] Fix BRouter java setup on Debian
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -751,10 +751,10 @@ bool CRouterBRouterSetup::isLocalBRouterDefaultDir() const { return localDir == 
 void CRouterBRouterSetup::setJava(const QString& path) {
   localJavaExecutable = path;
 
-  if (tryJavaVersion({"-version"}, "[\\S]+ version \"(\\d+)(\\.\\d+)*\" .*")) {
+  if (tryJavaVersion({"-version"}, "[\\S]+ version \"(\\d+)(\\.\\d+)*(-\\S+)?\" .*")) {
     return;
   }
-  if (tryJavaVersion({"--version"}, "[\\S]+ (\\d+)(\\.\\d+)* .*")) {
+  if (tryJavaVersion({"--version"}, "[\\S]+ (\\d+)(\\.\\d+)*(-\\S+)? .*")) {
     return;
   }
 

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -583,7 +583,7 @@ CRouterBRouterLocalSetupStatus CRouterBRouterSetup::checkLocalBRouterInstallatio
   bool isJavaOutdated =
       classMajorVersion != NOINT && (javaMajorVersion == NOINT || javaMajorVersion < classMajorVersion);
 
-  if (isBRouterJar && !isJavaOutdated) {
+  if (isBRouterJar && isJavaValid) {
     QProcess cmd;
 
     cmd.setWorkingDirectory(localDir);
@@ -602,7 +602,7 @@ CRouterBRouterLocalSetupStatus CRouterBRouterSetup::checkLocalBRouterInstallatio
 
   bool isValidBRouterVersion = versionMajor != NOINT && versionMinor != NOINT && versionPatch != NOINT;
 
-  isLocalBRouterValid = isBRouterJar && isValidBRouterVersion && isJavaExisting && !isJavaOutdated;
+  isLocalBRouterValid = isValidBRouterVersion;
 
   return CRouterBRouterLocalSetupStatus(isJavaExisting, isJavaValid, isJavaOutdated, isBRouterJar, isBRouterCandidate,
                                         isValidBRouterVersion);

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
@@ -419,8 +419,7 @@ void CRouterBRouterSetupWizard::updateLocalDirectory() const {
     labelLocalJavaResult->setText(tr("Java Executable not found"));
     labelLocalJavaResult->setVisible(true);
   }
-  pageLocalDirectory->setComplete(status.isLocalBRouterJar && status.isValidBRouterVersion && status.isJavaValid &&
-                                  !status.isJavaOutdated);
+  pageLocalDirectory->setComplete(status.isLocalBRouterJar && status.isValidBRouterVersion && status.isJavaValid);
 }
 
 void CRouterBRouterSetupWizard::slotCreateOrUpdateLocalInstallClicked() {

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
@@ -409,7 +409,7 @@ void CRouterBRouterSetupWizard::updateLocalDirectory() const {
             tr("Your Java version %1 seems to be older than the required version %2.\n"
                "BRouter will probably not work as expected.\n"
                "Please check the logs if Brouter fails to start.")
-                .arg(setup->javaMajorVersion == NOINT ? tr("unknown") : QString::number(setup->javaMajorVersion))
+                .arg(setup->javaMajorVersion == NOINT ? tr("<unknown>") : QString::number(setup->javaMajorVersion))
                 .arg(setup->classMajorVersion));
       }
     } else {


### PR DESCRIPTION
### What is the linked issue for this pull request:

QMS-#664

### What you have done:

- make error message about unknown java version less confusing
- make finding a too old java version a non-fatal error
- make java version check more accepting

### Steps to perform a simple smoke test:

1. Open BRouter setup wizard
2. Click through it

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt

the series is properly atomized - don't squash-merge.