### PR TITLE
[QMS-740] Fix dbus compile issues for Windows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ V1.XX.X
 [QMS-715] Remove duplicate tile map server requests for the same tile, allow HTTP(S) redirection
 [QMS-732] Migrate macOS build from Qt5 to Qt6
 [QMS-730] TMS/WMTS fixed accidentally removed namespace processing
+[QMS-740] Fix dbus compile issues for Windows
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -35,22 +35,11 @@ set( SRCS
     dem/CDemWCS.cpp
     dem/IDem.cpp
     dem/IDemProp.cpp
-    device/CDeviceAccessKMtp.cpp
-    device/CDeviceAccessGvfsMtp.cpp
     device/CDeviceGarmin.cpp
     device/CDeviceGarminArchive.cpp
-    device/CDeviceGarminMtp.cpp
     device/CDeviceTwoNav.cpp
     device/IDevice.cpp
     device/IDeviceWatcher.cpp
-    device/IDeviceAccess.cpp
-    device/dbus/org.kde.kmtp.Daemon.cpp
-    device/dbus/org.kde.kmtp.Device.cpp
-    device/dbus/org.kde.kmtp.Storage.cpp
-    device/dbus/org.gtk.vfs.MTPVolumeMonitor.cpp
-    device/dbus/org.gtk.vfs.MountTracker.cpp
-    device/dbus/org.gtk.vfs.Mount.cpp
-    device/dbus/metatypes.cpp
     gis/CGisDatabase.cpp
     gis/CGisDraw.cpp
     gis/CGisItemRate.cpp
@@ -377,7 +366,18 @@ set( SRCS
 if(Qt6DBus_FOUND)
 set( SRCS
     ${SRCS}
+    device/IDeviceAccess.cpp
     device/CDeviceWatcherLinux.cpp
+    device/CDeviceAccessKMtp.cpp
+    device/CDeviceAccessGvfsMtp.cpp
+    device/CDeviceGarminMtp.cpp
+    device/dbus/org.kde.kmtp.Daemon.cpp
+    device/dbus/org.kde.kmtp.Device.cpp
+    device/dbus/org.kde.kmtp.Storage.cpp
+    device/dbus/org.gtk.vfs.MTPVolumeMonitor.cpp
+    device/dbus/org.gtk.vfs.MountTracker.cpp
+    device/dbus/org.gtk.vfs.Mount.cpp
+    device/dbus/metatypes.cpp
 )
 endif(Qt6DBus_FOUND)
 
@@ -416,22 +416,11 @@ set( HDRS
     dem/CDemWCS.h
     dem/IDem.h
     dem/IDemProp.h
-    device/CDeviceAccessKMtp.h
-    device/CDeviceAccessGvfsMtp.h
     device/CDeviceGarmin.h
     device/CDeviceGarminArchive.h
-    device/CDeviceGarminMtp.h
     device/CDeviceTwoNav.h
     device/IDevice.h
     device/IDeviceWatcher.h
-    device/IDeviceAccess.h
-    device/dbus/org.kde.kmtp.Daemon.h
-    device/dbus/org.kde.kmtp.Device.h
-    device/dbus/org.kde.kmtp.Storage.h
-    device/dbus/org.gtk.vfs.MTPVolumeMonitor.h
-    device/dbus/org.gtk.vfs.MountTracker.h
-    device/dbus/org.gtk.vfs.Mount.h
-    device/dbus/metatypes.h
     gis/CGisDatabase.h
     gis/CGisDraw.h
     gis/CGisItemRate.h
@@ -767,6 +756,17 @@ if(Qt6DBus_FOUND)
 set( HDRS
     ${HDRS}
     device/CDeviceWatcherLinux.h
+    device/CDeviceAccessKMtp.h
+    device/CDeviceAccessGvfsMtp.h
+    device/CDeviceGarminMtp.h
+    device/IDeviceAccess.h
+    device/dbus/org.kde.kmtp.Daemon.h
+    device/dbus/org.kde.kmtp.Device.h
+    device/dbus/org.kde.kmtp.Storage.h
+    device/dbus/org.gtk.vfs.MTPVolumeMonitor.h
+    device/dbus/org.gtk.vfs.MountTracker.h
+    device/dbus/org.gtk.vfs.Mount.h
+    device/dbus/metatypes.h
 )
 endif(Qt6DBus_FOUND)
 

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -784,10 +784,12 @@ void IGisProject::umount() {
 }
 
 bool IGisProject::remove() {
+#ifdef Q_OS_LINUX
   CDeviceGarminMtp* mtp = dynamic_cast<CDeviceGarminMtp*>(parent());
   if (mtp != nullptr) {
     return mtp->removeFromDevice(filename);
   }
+#endif
 
   CProjectMountLock mountLock(*this);
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#740

### What you have done:
[comment]: # (Describe roughly.)

Move all DBus dependent code for MTP devices into the USE_QT6DBus sections of the CMakeLists files

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Try to compile in Windows.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
