### PR TITLE
[QMS-743] Fix crash when reseting a range in track profile graph

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-558] Support for MTP devices
 [QMS-648] Porting to Qt6
 [QMS-656] TMS/WMTS: Fix loosing layer selection when reloading maps
+[QMS-664] Fix BRouter java setup on Debian
 [QMS-668] MacOS build adapted to new gdal version and new brew packages
 [QMS-675] The label colors defined in the TYP are not used
 [QMS-680] Fix: Sending multiple selected projects to device
@@ -14,7 +15,7 @@ V1.XX.X
 [QMS-732] Migrate macOS build from Qt5 to Qt6
 [QMS-730] TMS/WMTS fixed accidentally removed namespace processing
 [QMS-740] Fix dbus compile issues for Windows
-[QMS-664] Fix BRouter java setup on Debian
+[QMS-743] Fix crash when reseting a range in track profile graph
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/plot/IPlot.cpp
+++ b/src/qmapshack/plot/IPlot.cpp
@@ -281,7 +281,7 @@ void IPlot::mouseMoveEvent(QMouseEvent* e) {
 
   if (mouseDidMove) {
     if (!scrOptRange.isNull()) {
-      delete scrOptRange;
+      scrOptRange->deleteLater();
     }
     QPoint diff = pos - posLast;
 
@@ -422,7 +422,6 @@ bool IPlot::mouseReleaseEventNormal(QMouseEvent* e) {
           As the screen option is created on the fly it has to be connected to all slots,too.
           Later, when destroyed the slots will be disconnected automatically.
        */
-      delete scrOptRange;
       scrOptRange = new CScrOptRangeTrk(pos, trk, nullptr, this);
       connect(scrOptRange->toolHidePoints, &QToolButton::clicked, this, &IPlot::slotHidePoints);
       connect(scrOptRange->toolShowPoints, &QToolButton::clicked, this, &IPlot::slotShowPoints);
@@ -457,7 +456,9 @@ bool IPlot::mouseReleaseEventNormal(QMouseEvent* e) {
 
     case eMouseClick2nd: {
       // In second click state a mouse click will reset the range selection
-      delete scrOptRange;
+      if (!scrOptRange.isNull()) {
+        scrOptRange->deleteLater();
+      }
       trk->setMode(CGisItemTrk::eModeNormal, objectName());
       idxSel1 = idxSel2 = NOIDX;
       mouseClickState = eMouseClickIdle;
@@ -1306,7 +1307,9 @@ void IPlot::slotCopy() {
 }
 
 void IPlot::slotStopRange() {
-  scrOptRange->deleteLater();
+  if (!scrOptRange.isNull()) {
+    scrOptRange->deleteLater();
+  }
   trk->setMode(CGisItemTrk::eModeNormal, objectName());
   idxSel1 = idxSel2 = NOIDX;
   mouseClickState = eMouseClickIdle;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#743

### What you have done:
[comment]: # (Describe roughly.)

Make sure the smart pointer is not null

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
