### PR TITLE
[QMS-750] Fix QMS build error - Windows 10/MSVC

### DIFF
--- a/3rdparty/GarminFitSdk/CMakeLists.txt
+++ b/3rdparty/GarminFitSdk/CMakeLists.txt
@@ -305,7 +305,9 @@ set(FIT_HDR
 
 add_library(GarminFit STATIC ${FIT_SRC} ${FIT_HDR})
 # Geeee, this code is so sloppy written. Let's silence the warnings.
-target_compile_options(GarminFit PRIVATE -Wno-suggest-override -Wno-catch-value -Wno-unused-but-set-variable)
+if(UNIX)
+    target_compile_options(GarminFit PRIVATE -Wno-suggest-override -Wno-catch-value -Wno-unused-but-set-variable)
+endif()
 
 # add_executable(fit_decoder cpp/examples/decode/decode.cpp )
 # target_link_libraries(fit_decoder PRIVATE GarminFit)

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ V1.XX.X
 [QMS-740] Fix dbus compile issues for Windows
 [QMS-743] Fix crash when reseting a range in track profile graph
 [QMS-747] Remove support for MapQuest 
+[QMS-750] Fix QMS build error - Windows 10/MSVC
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -37,7 +37,6 @@ set( SRCS
     dem/IDemProp.cpp
     device/CDeviceGarmin.cpp
     device/CDeviceGarminArchive.cpp
-    device/CDeviceGarminArchiveMtp.cpp
     device/CDeviceTwoNav.cpp
     device/IDevice.cpp
     device/IDeviceWatcher.cpp
@@ -372,6 +371,7 @@ set( SRCS
     device/CDeviceAccessKMtp.cpp
     device/CDeviceAccessGvfsMtp.cpp
     device/CDeviceGarminMtp.cpp
+    device/CDeviceGarminArchiveMtp.cpp
     device/dbus/org.kde.kmtp.Daemon.cpp
     device/dbus/org.kde.kmtp.Device.cpp
     device/dbus/org.kde.kmtp.Storage.cpp
@@ -419,7 +419,6 @@ set( HDRS
     dem/IDemProp.h
     device/CDeviceGarmin.h
     device/CDeviceGarminArchive.h
-    device/CDeviceGarminArchiveMtp.h
     device/CDeviceTwoNav.h
     device/IDevice.h
     device/IDeviceWatcher.h
@@ -761,6 +760,7 @@ set( HDRS
     device/CDeviceAccessKMtp.h
     device/CDeviceAccessGvfsMtp.h
     device/CDeviceGarminMtp.h
+    device/CDeviceGarminArchiveMtp.h
     device/IDeviceAccess.h
     device/dbus/org.kde.kmtp.Daemon.h
     device/dbus/org.kde.kmtp.Device.h


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#750

### What you have done:
[comment]: # (Describe roughly.)

Make the compile switches UNIX dependent

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Should compile for Windows and Linux

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
