### PR TITLE
[QMS-756] Avoid: [warning] QIODevice::read (QProcess): device not open

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ V1.XX.X
 [QMS-747] Remove support for MapQuest 
 [QMS-750] Fix QMS build error - Windows 10/MSVC
 [QMS-753] Fix segfault for FIT sessions without track data
+[QMS-756] Avoid: [warning] QIODevice::read (QProcess): device not open
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -765,6 +765,10 @@ bool CRouterBRouterSetup::tryJavaVersion(const QStringList& arguments, const QSt
   QProcess cmd;
   QRegularExpression re(pattern);
 
+  if (localJavaExecutable == "") {
+    return false;
+  }
+
   cmd.setWorkingDirectory(localDir);
   cmd.start(localJavaExecutable, arguments);
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-756

### What you have done:
[comment]: # (Describe roughly.)

Check if value of variable `localJavaExecutable` is an empty string `""`.
If yes, prevent from starting executable set by variable `localJavaExecutable`
to avoid Qt warnings `[warning] QIODevice::read (QProcess): device not open`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run `<QMS installation folder>/QMapShack.exe -c <empty configuration file>` on Windows OS from command line
2. See **no** Qt warnings `[warning] QIODevice::read (QProcess): device not open` in output console

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
