### PR TITLE
[QMS-757] Avoid: [warning] Empty filename passed to function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ V1.XX.X
 [QMS-747] Remove support for MapQuest 
 [QMS-750] Fix QMS build error - Windows 10/MSVC
 [QMS-753] Fix segfault for FIT sessions without track data
+[QMS-757] Avoid: [warning] Empty filename passed to function
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -48,14 +48,14 @@ class CMainWindow : public QMainWindow, private Ui::IMainWindow {
 
   static QWidget* getBestWidgetForParent();
 
-  QString getHomePath() { return homeDir.exists() ? homeDir.absolutePath() : ""; }
+  QString getHomePath() { return (homeDir.path() != "" && homeDir.exists()) ? homeDir.absolutePath() : ""; }
 
-  QString getMapsPath() { return homeDir.exists(mapsPath) ? homeDir.absoluteFilePath(mapsPath) : ""; }
-  QString getDemPath() { return homeDir.exists(demPath) ? homeDir.absoluteFilePath(demPath) : ""; }
-  QString getRoutinoPath() { return homeDir.exists(routinoPath) ? homeDir.absoluteFilePath(routinoPath) : ""; }
-  QString getBRouterPath() { return homeDir.exists(brouterPath) ? homeDir.absoluteFilePath(brouterPath) : ""; }
-  QString getDatabasePath() { return homeDir.exists(databasePath) ? homeDir.absoluteFilePath(databasePath) : ""; }
-  QString getGpxPath() { return homeDir.exists(gpxPath) ? homeDir.absoluteFilePath(gpxPath) : ""; }
+  QString getMapsPath() { return (homeDir.path() != "" && homeDir.exists(mapsPath)) ? homeDir.absoluteFilePath(mapsPath) : ""; }
+  QString getDemPath() { return (homeDir.path() != "" && homeDir.exists(demPath)) ? homeDir.absoluteFilePath(demPath) : ""; }
+  QString getRoutinoPath() { return (homeDir.path() != "" && homeDir.exists(routinoPath)) ? homeDir.absoluteFilePath(routinoPath) : ""; }
+  QString getBRouterPath() { return (homeDir.path() != "" && homeDir.exists(brouterPath)) ? homeDir.absoluteFilePath(brouterPath) : ""; }
+  QString getDatabasePath() { return (homeDir.path() != "" && homeDir.exists(databasePath)) ? homeDir.absoluteFilePath(databasePath) : ""; }
+  QString getGpxPath() { return (homeDir.path() != "" && homeDir.exists(gpxPath)) ? homeDir.absoluteFilePath(gpxPath) : ""; }
 
   static QString getUser();
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#757

### What you have done:
[comment]: # (Describe roughly.)

If procedure `homeDir.path()` returns an empty string `""`
prevent from calling procedure `homeDir.exists(...)`
to avoid Qt warnings `[warning] Empty filename passed to function`.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run `<QMS installation folder>/QMapShack.exe -c <empty configuration file>` from command line
2. See **no** Qt warnings `[warning] Empty filename passed to function in output console`

Notes on OS Windows:
Running executable from `cmd.exe` console prevents from seeing any stdout and stderr output.
Running executable however from Cygwin, MingGW, MSYS, ... console, or running from Windows powershell using
command line `& <QMS installation folder>/QMapShack.exe -c <empty configuration file> 2>&1 | write-host` shows stdout and stderr output on the fly.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
