### PR TITLE
[QMS-758] Avoid: [warning] QSqlError("19", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ V1.XX.X
 [QMS-747] Remove support for MapQuest 
 [QMS-750] Fix QMS build error - Windows 10/MSVC
 [QMS-753] Fix segfault for FIT sessions without track data
+[QMS-758] Avoid: [warning] QSqlError("19", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -744,6 +744,9 @@ void CGisListWks::slotSaveWorkspace() {
     stream.setByteOrder(QDataStream::LittleEndian);
 
     project->IGisProject::operator>>(stream);
+    if (project->getName() == "") {
+      continue;
+    }
 
     query.prepare(
         "INSERT INTO workspace (type, keyqms, name, changed, visible, data) VALUES (:type, :keyqms, :name, :changed, "


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#758

### What you have done:
[comment]: # (Describe roughly.)

To avoid Qt warnings `[warning] QSqlError("19", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")`
or `[warning] QSqlError("1299", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")`,
prevent from updating SQL table `workspace` if table item `name` with constraint `NOT NULL` is an empty string `""`
which is considered by SQL to be `NULL`.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run `<QMS installation folder>/QMapShack.exe` from command line
2. Wait for automatic save and/or quit QMS
3. See **no** Qt warnings
`[warning] Execution of SQL-Statement "INSERT INTO workspace (type, keyqms, name, changed, visible, data) VALUES (:type, :keyqms, :name, :changed, :visible, :data)" failed:`
`[warning] QSqlError("19", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")`
or
`[warning] QSqlError("1299", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")`
in output console

Notes on OS Windows:
Running executable from `cmd.exe` console prevents from seeing any stdout and stderr output.
Running executable however from Cygwin, MingGW, MSYS, ... console, or running from Windows powershell using
command line `& <QMS installation folder>/QMapShack.exe 2>&1 | write-host` shows stdout and stderr output on the fly.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
