### PR TITLE
[QMS-759] Avoid: [warning] QWidget::setMinimumSize: (/QTextBrowser) Negative sizes (300,-140) are not possible

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ V1.XX.X
 [QMS-747] Remove support for MapQuest 
 [QMS-750] Fix QMS build error - Windows 10/MSVC
 [QMS-753] Fix segfault for FIT sessions without track data
+[QMS-759] Avoid: [warning] QWidget::setMinimumSize: (/QTextBrowser) Negative sizes (300,-140) are not possible
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -487,11 +487,13 @@ void CCanvas::reportStatus(const QString& key, const QString& msg) {
     textStatusMessages->show();
     textStatusMessages->setText(report);
 
-    qreal h;
-    h = height() - Y_OFF_STATUS - getTrackProfileSize(height()).height() - 40;
-    h = qMin(h, textStatusMessages->document()->size().height() + 10);
-    textStatusMessages->setMinimumHeight(h);
-    textStatusMessages->setMaximumHeight(h);
+    if (isVisible()) {
+      qreal h;
+      h = height() - Y_OFF_STATUS - getTrackProfileSize(height()).height() - 40;
+      h = qMin(h, textStatusMessages->document()->size().height() + 10);
+      textStatusMessages->setMinimumHeight(h);
+      textStatusMessages->setMaximumHeight(h);
+    }
   }
   update();
 }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#759

### What you have done:
[comment]: # (Describe roughly.)

Prevent from calculating and setting height of QTextBrowser widget `textStatusMessage` within invisible view(s)
to avoid Qt warnings
`[warning] QWidget::setMinimumSize: (/QTextBrowser) Negative sizes (300,-140) are not possible`
and
`[warning] QWidget::setMaximumSize: (/QTextBrowser) Negative sizes (16777215,-140) are not possible`.
Height of invisible view(s) may be wrong and different from height of map drawing area.
Therefore calculation of `textStatusMessage` widget's height within invisible view may be wrong and even negative .

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run `<QMS installation folder>/QMapShack.exe` from command line
2. Define at least 2 views
3. Quit QMS
4. Run `<QMS installation folder>/QMapShack.exe` from command line
-> the last created view is visible. Do not make other view(s) visible !
5. Create a project
6. Create a waypoint within project
7. Open project and select waypoint by mouse click
8. See **no** Qt warnings
    `[warning] QWidget::setMinimumSize: (/QTextBrowser) Negative sizes (300,-140) are not possible`
    and
    `[warning] QWidget::setMaximumSize: (/QTextBrowser) Negative sizes (16777215,-140) are not possible`
    in output console

Notes on OS Windows:
Running executable from `cmd.exe` console prevents from seeing any stdout and stderr output.
Running executable however from Cygwin, MingGW, MSYS, ... console, or running from Windows powershell using
command line `& <QMS installation folder>/QMapShack.exe 2>&1 | write-host` shows stdout and stderr output on the fly.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
