### PR TITLE
[QMS-766] [warning] QMainWindow::addDockWidget

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ V1.XX.X
 [QMS-757] Avoid: [warning] Empty filename passed to function
 [QMS-758] Avoid: [warning] QSqlError("19", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")
 [QMS-759] Avoid: [warning] QWidget::setMinimumSize: (/QTextBrowser) Negative sizes (300,-140) are not possible
+[QMS-766] Avoid: [warning] QMainWindow::addDockWidget: invalid 'area' argument
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -1578,7 +1578,7 @@ void CMainWindow::slotSanityTest() {
 void CMainWindow::slotHelp() {
   if (help.isNull()) {
     help = new CHelp(IAppSetup::getPlatformInstance()->helpFile(), "qthelp://qms/doc/doc/html/DocMain.html", this);
-    addDockWidget(Qt::AllDockWidgetAreas, help);
+    addDockWidget(Qt::LeftDockWidgetArea, help);
   }
 
   help->setVisible(true);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#766

### What you have done:
[comment]: # (Describe roughly.)

Prevent Qt from throwing warning message
`[warning] QMainWindow::addDockWidget: invalid 'area' argument`
when calling local help by keyboard key F1.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS
2. Hit keyboard key F1
3. See no Qt warning `[warning] QMainWindow::addDockWidget: invalid 'area' argument` in ouput console

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
