### PR TITLE
[QMS-769] Fix: "Send to device" is not enabled/disabled properly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ V1.XX.X
 [QMS-758] Avoid: [warning] QSqlError("19", "Unable to fetch row", "NOT NULL constraint failed: workspace.name")
 [QMS-759] Avoid: [warning] QWidget::setMinimumSize: (/QTextBrowser) Negative sizes (300,-140) are not possible
 [QMS-766] Avoid: [warning] QMainWindow::addDockWidget: invalid 'area' argument
+[QMS-769] Fix: "Send to device" is not enabled/disabled properly
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/device/CDeviceGarminArchive.cpp
+++ b/src/qmapshack/device/CDeviceGarminArchive.cpp
@@ -27,7 +27,7 @@
 #include "gis/gpx/CGpxProject.h"
 
 CDeviceGarminArchive::CDeviceGarminArchive(const QString& path, CDeviceGarmin* parent)
-    : IDevice(path, eTypeGarmin, parent->getKey(), parent) {
+    : IDevice(path, parent->getKey(), parent) {
   setText(CGisListWks::eColumnName, tr("Archive - expand to load"));
   setChildIndicatorPolicy(QTreeWidgetItem::ShowIndicator);
   connect(treeWidget(), &QTreeWidget::itemExpanded, this, &CDeviceGarminArchive::slotExpanded);

--- a/src/qmapshack/device/CDeviceGarminArchiveMtp.cpp
+++ b/src/qmapshack/device/CDeviceGarminArchiveMtp.cpp
@@ -26,7 +26,7 @@
 #include "gis/gpx/CGpxProject.h"
 
 CDeviceGarminArchiveMtp::CDeviceGarminArchiveMtp(const QString& path, IDeviceAccess* device, CDeviceGarminMtp* parent)
-    : IDevice(path, eTypeGarminMtp, parent->getKey(), parent), device(device) {
+    : IDevice(path, parent->getKey(), parent), device(device) {
   setText(CGisListWks::eColumnName, tr("Archive - expand to load"));
   setChildIndicatorPolicy(QTreeWidgetItem::ShowIndicator);
   connect(treeWidget(), &QTreeWidget::itemExpanded, this, &CDeviceGarminArchiveMtp::slotExpanded);

--- a/src/qmapshack/device/IDevice.cpp
+++ b/src/qmapshack/device/IDevice.cpp
@@ -20,7 +20,6 @@
 
 #include "CMainWindow.h"
 #include "canvas/CCanvas.h"
-#include "device/CDeviceGarmin.h"
 #include "gis/CGisListWks.h"
 #include "gis/prj/IGisProject.h"
 #include "helpers/CSelectCopyAction.h"
@@ -37,12 +36,16 @@ IDevice::IDevice(const QString& path, type_e type, const QString& key, QTreeWidg
   cnt++;
 }
 
-IDevice::IDevice(const QString& path, type_e type, const QString& key, IDevice* parent)
-    : QTreeWidgetItem(parent, type), dir(path), key(key) {
+IDevice::IDevice(const QString& path, const QString& key, IDevice* parent)
+    : QTreeWidgetItem(parent, eTypeVirtual), dir(path), key(key) {
   setIcon(CGisListWks::eColumnIcon, QIcon("://icons/32x32/PathGreen.png"));
 }
 
-IDevice::~IDevice() { cnt--; }
+IDevice::~IDevice() {
+  if (type() != eTypeVirtual) {
+    cnt--;
+  }
+}
 
 void IDevice::mount(const QString& path) {
 #ifdef HAVE_DBUS

--- a/src/qmapshack/device/IDevice.h
+++ b/src/qmapshack/device/IDevice.h
@@ -31,10 +31,10 @@ class CDeviceGarmin;
 class IDevice : public QTreeWidgetItem {
   Q_DECLARE_TR_FUNCTIONS(IDevice)
  public:
-  enum type_e { eTypeNone = 0, eTypeGarmin = 1, eTypeTwoNav = 2, eTypeGarminMtp = 3 };
+  enum type_e { eTypeNone = 0, eTypeGarmin = 1, eTypeTwoNav = 2, eTypeGarminMtp = 3, eTypeVirtual = 4 };
 
   IDevice(const QString& path, type_e type, const QString& key, QTreeWidget* parent);
-  IDevice(const QString& path, type_e type, const QString& key, IDevice* parent);
+  IDevice(const QString& path, const QString& key, IDevice* parent);
   virtual ~IDevice();
 
   static void mount(const QString& path);

--- a/src/qmapshack/gis/IGisItem.cpp
+++ b/src/qmapshack/gis/IGisItem.cpp
@@ -221,7 +221,7 @@ void IGisItem::loadFromDb(quint64 id, QSqlDatabase& db) {
   QSqlQuery query(db);
   query.prepare("SELECT data, keyqms, hash FROM items WHERE id=:id");
   query.bindValue(":id", id);
-  QUERY_EXEC(return );
+  QUERY_EXEC(return);
   if (query.next()) {
     QByteArray data(query.value(0).toByteArray());
     QDataStream in(&data, QIODevice::ReadOnly);
@@ -255,7 +255,7 @@ void IGisItem::updateFromDB(quint64 id, QSqlDatabase& db) {
 
   query.prepare("SELECT hash FROM items WHERE id=:id");
   query.bindValue(":id", id);
-  QUERY_EXEC(return );
+  QUERY_EXEC(return);
 
   /*
       Test on the hash stored in the database. If the hash is
@@ -681,7 +681,9 @@ QString IGisItem::html2Dev(const QString& str, bool strictGpx11) {
     return "";
   }
 
-  return (isOnDevice() == IDevice::eTypeGarmin) || strictGpx11 ? removeHtml(str) : str;
+  return (isOnDevice() == IDevice::eTypeGarmin) || (isOnDevice() == IDevice::eTypeGarminMtp) || strictGpx11
+             ? removeHtml(str)
+             : str;
 }
 
 QString IGisItem::toLink(bool isReadOnly, const QString& href, const QString& str, const QString& key) {

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -919,7 +919,7 @@ void IGisItem::writeWpt(QDomElement& xml, const wpt_t& wpt, bool strictGpx11) {
   writeXml(xml, "name", wpt.name);
   writeXml(xml, "cmt", html2Dev(wpt.cmt, strictGpx11));
   writeXml(xml, "desc", html2Dev(wpt.desc, strictGpx11));
-  if (isOnDevice() != IDevice::eTypeGarmin) {
+  if ((isOnDevice() != IDevice::eTypeGarmin) || (isOnDevice() != IDevice::eTypeGarminMtp)) {
     writeXml(xml, "src", wpt.src);
   }
   writeXml(xml, "link", wpt.links);

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -141,7 +141,8 @@ IGisProject* IGisProject::create(const QString filename, CGisListWks* parent) {
 }
 
 QString IGisProject::html2Dev(const QString& str) {
-  return isOnDevice() == IDevice::eTypeGarmin ? IGisItem::removeHtml(str) : str;
+  return (isOnDevice() == IDevice::eTypeGarmin) || (isOnDevice() == IDevice::eTypeGarminMtp) ? IGisItem::removeHtml(str)
+                                                                                             : str;
 }
 
 bool IGisProject::askBeforClose() {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#769

### What you have done:
[comment]: # (Describe roughly.)

The "Archive" folder found on Garmin devices is now a virtual device. Virtual device to not add to the device count.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
