### PR TITLE
[QMS-777] BRouter segments download "Cancel" dialog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ V1.XX.X
 [QMS-766] Avoid: [warning] QMainWindow::addDockWidget: invalid 'area' argument
 [QMS-769] Fix: "Send to device" is not enabled/disabled properly
 [QMS-775] BRouter segments download: wrong accumulated size of segments, wrong outdated segments count
+[QMS-777] BRouter segments download "Cancel" dialog not translated
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesPage.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesPage.cpp
@@ -56,13 +56,13 @@ bool CRouterBRouterTilesPage::raiseWarning() const {
   QMessageBox msgBox;
   msgBox.setIcon(QMessageBox::Warning);
   if (widgetLocalTilesSelect->isDownloading()) {
-    msgBox.setText("Download of routing data is in progress.");
+    msgBox.setText(tr("Download of routing data is in progress."));
   } else if (widgetLocalTilesSelect->isDownloadSelected()) {
-    msgBox.setText("You did not yet download the selected routing data.");
+    msgBox.setText(tr("You did not yet download the selected routing data."));
   } else {
     return false;
   }
-  msgBox.setInformativeText("Do you want to cancel or continue with setup");
+  msgBox.setInformativeText(tr("Do you want to cancel or continue with setup"));
   msgBox.setStandardButtons(QMessageBox::Cancel);
   QPushButton* continueButton = msgBox.addButton(tr("Continue with Setup"), QMessageBox::NoRole);
   msgBox.exec();


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#777

### What you have done:
[comment]: # (Describe roughly.)
Encapsulated 3 dialog texts by `tr()` macro
in order to be able to assign translations using `QT Linguist`.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Verify that text strings of source file `CRouterBRouterTilesPage.cpp` are encapsulated by `tr()` macro

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
