### PR TITLE
[QMS-779] Avoid NaN for slope in Track Dialog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,9 +27,10 @@ V1.XX.X
 [QMS-759] Avoid: [warning] QWidget::setMinimumSize: (/QTextBrowser) Negative sizes (300,-140) are not possible
 [QMS-766] Avoid: [warning] QMainWindow::addDockWidget: invalid 'area' argument
 [QMS-769] Fix: "Send to device" is not enabled/disabled properly
-[QMS-775] BRouter segments download: wrong accumulated size of segments, wrong outdated segments count
 [QMS-771] Adapt Fit2 Implementation
+[QMS-775] BRouter segments download: wrong accumulated size of segments, wrong outdated segments count
 [QMS-777] BRouter segments download "Cancel" dialog not translated
+[QMS-779] Avoid NaN when totalAscent or totalDescent = 0
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -639,12 +639,14 @@ QString CGisItemTrk::getInfoProgress(const CTrackData::trkpt_t& pt) const {
 
   if (pt.ascent != NOFLOAT) {
     IUnit::self().meter2elevation(pt.ascent, val, unit);
-    asc = tr("Ascent: %1%2 (%3%)").arg(val, unit).arg(pt.ascent * 100 / totalAscent, 2, 'f', 0);
+    qreal slope = totalAscent ? (pt.ascent * 100 / totalAscent) : 0;
+    asc = tr("Ascent: %1%2 (%3%)").arg(val, unit).arg(slope, 2, 'f', 0);
   }
 
   if (pt.descent != NOFLOAT) {
     IUnit::self().meter2elevation(pt.descent, val, unit);
-    dsc = tr(", Descent: %1%2 (%3%)").arg(val, unit).arg(pt.descent * 100 / totalDescent, 2, 'f', 0);
+    qreal  slope = totalDescent ? (pt.descent * 100 / totalDescent) : 0;
+    dsc = tr("Descent: %1%2 (%3%)").arg(val, unit).arg(slope, 2, 'f', 0);
   }
 
   if (pt.distance != NOFLOAT) {


### PR DESCRIPTION
### What is the linked issue for this pull request:
QMS-779

### What you have done:
Avoid division by zero for slope in progressInfo textbox in Track Dialog when totalAscent or totalDescent = 0

### Steps to perform a simple smoke test:
1. Create a track with totalAscent or totalDescent = 0
2. Edit Track
3. Check values in progressInfo textbox

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):
- [x] yes

### Is every user facing string in a tr() macro?
- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.
- [x] yes, I didn't forget to change changelog.txt