### PR TITLE
[QMS-771] Adapt Fit2 Implementation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ V1.XX.X
 [QMS-766] Avoid: [warning] QMainWindow::addDockWidget: invalid 'area' argument
 [QMS-769] Fix: "Send to device" is not enabled/disabled properly
 [QMS-775] BRouter segments download: wrong accumulated size of segments, wrong outdated segments count
+[QMS-771] Adapt Fit2 Implementation
 [QMS-777] BRouter segments download "Cancel" dialog not translated
 
 V1.17.1

--- a/src/qmapshack/gis/fit2/CFit2Project.h
+++ b/src/qmapshack/gis/fit2/CFit2Project.h
@@ -84,8 +84,6 @@ class CFit2Project : public fit::FileIdMesgListener,
   }
   inline qreal semicircleToDegree(qint32 semicircles) { return semicircles * (degrees / twoPow31); }
 
-  void createTrack(const QString& name, const QString& comment);
-
   static const QSet<std::string> knownMessages;
 
   enum class eRecordType { Activity, Course };


### PR DESCRIPTION
### What is the linked issue for this pull request:

[QMS-771](https://github.com/Maproom/qmapshack/issues/771)

### What you have done:
[comment]: # (Describe roughly.)
- Restructured code based on different methods for chronological messages ordering
- Removed createTrack method
- Built trackname when a courses message is available otherwise built trackname from first trackpoint
- Adapted event handling for the different devices to create new segments
- Added timerTime value to show in trackpoint comment
- Removed extension distance
- Adapted handling of extension EnhanceSpeed for track comment
- Changed extension enhanceRespirationRate from float to int
- Beautified the code

### Steps to perform a simple smoke test:
- Read Fit files from different devices
- Check consistency of track in QMS

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):
- [x] yes

### Is every user facing string in a tr() macro?
- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.
- [x] yes, I didn't forget to change changelog.txt