### PR TITLE
[QMS-782] Solved two issues for track point viewer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ V1.XX.X
 [QMS-775] BRouter segments download: wrong accumulated size of segments, wrong outdated segments count
 [QMS-777] BRouter segments download "Cancel" dialog not translated
 [QMS-779] Avoid NaN when totalAscent or totalDescent = 0
+[QMS-782] Solved two issues for track point viewer
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/trk/CTableTrk.cpp
+++ b/src/qmapshack/gis/trk/CTableTrk.cpp
@@ -154,7 +154,7 @@ void CTableTrk::updateData() {
     item->setText(eColNum, QString::number(trkpt.idxTotal));
 
     item->setText(eColTime, trkpt.time.isValid()
-                                ? IUnit::self().datetime2string(trkpt.time, IUnit::eTimeFormatShort,
+                                ? IUnit::self().datetime2string(trkpt.time, IUnit::eTimeFormatShortPlusSecs,
                                                                 QPointF(trkpt.lon, trkpt.lat) * DEG_TO_RAD)
                                 : "-");
 
@@ -179,12 +179,14 @@ void CTableTrk::updateData() {
     }
 
     IUnit::self().slope2string(trkpt.slope1, val, unit);
-    item->setText(eColSlope, (trkpt.slope1 != NOFLOAT) ? QString("%1%2").arg(val, unit) : "-");
+
+    item->setText(eColSlope, (trkpt.slope1 != NOFLOAT && trkpt.ele != NOINT)
+                                 ? QString("%1%2").arg(val, unit) : "-");
 
     IUnit::self().meter2elevation(trkpt.ascent, val, unit);
-    item->setText(eColAscent, tr("%1%2").arg(val, unit));
+    item->setText(eColAscent, (trkpt.ele != NOINT) ? (tr("%1%2").arg(val, unit)) : "-");
     IUnit::self().meter2elevation(trkpt.descent, val, unit);
-    item->setText(eColDescent, tr("%1%2").arg(val, unit));
+    item->setText(eColDescent, (trkpt.ele != NOINT) ? (tr("%1%2").arg(val, unit)) : "-");
 
     // position
     QString str;

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -745,6 +745,8 @@ QString IUnit::datetime2string(const QDateTime& time, time_format_e format, cons
       return tmp.toString(QLocale().dateTimeFormat(useShortFormat ? QLocale::ShortFormat : QLocale::LongFormat));
     case eTimeFormatShort:
       return tmp.toString(QLocale().dateTimeFormat(QLocale::ShortFormat));
+    case eTimeFormatShortPlusSecs:
+      return QLocale().toString(tmp, "yyyy-MM-dd hh:mm:ss");
     case eTimeFormatIso:
       return tmp.toString(Qt::ISODate);
   }

--- a/src/qmapshack/units/IUnit.h
+++ b/src/qmapshack/units/IUnit.h
@@ -91,7 +91,7 @@ class IUnit : public QObject {
   /// parse a string for a timestamp
   static bool parseTimestamp(const QString& time, QDateTime& datetime);
 
-  enum time_format_e { eTimeFormatLong, eTimeFormatShort, eTimeFormatIso };
+  enum time_format_e { eTimeFormatLong, eTimeFormatShort, eTimeFormatShortPlusSecs, eTimeFormatIso };
   /**
      @brief Convert date time object to string using the current timezone configuration
 


### PR DESCRIPTION
### What is the linked issue for this pull request:
[QMS-782](https://github.com/Maproom/qmapshack/issues/782)

### What you have done:
- Show time with seconds
- Show value for slope, ascent, descent with "-" when trackpoint elevation is invalid

### Steps to perform a simple smoke test:
1. Load a track with invalid elevation at the beginning of the track
2. Do not delete the invalid tracks
3. Edit track, show track point editor

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):
- [x] yes

### Is every user facing string in a tr() macro?
- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.
- [x] yes, I didn't forget to change changelog.txt