### PR TITLE
[QMS-784] Solved two issues for GNOME/Wayland, Invalid Points Dialog …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ V1.XX.X
 [QMS-777] BRouter segments download "Cancel" dialog not translated
 [QMS-779] Avoid NaN when totalAscent or totalDescent = 0
 [QMS-782] Solved two issues for track point viewer
+[QMS-784] Solved two issues for GNOME/Wayland, Invalid Points Dialog vs Progress Dialog
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -778,9 +778,21 @@ void CGisListWks::slotLoadWorkspace() {
 
   QUERY_RUN("SELECT type, keyqms, name, changed, visible, data FROM workspace", return)
 
-  {  // open context for progress dialog
-    const int total = query.size();
+  { // open context for progress dialog
+    //Refer to https://stackoverflow.com/questions/26495049/qsqlquery-size-always-returns-1
+    qreal total = 0;
+    if (db.driver()->hasFeature(QSqlDriver::QuerySize)) {
+      total = query.size();
+    } else {
+      if(query.last())
+      {
+        total =  query.at() + 1;
+        query.first();
+        query.previous();
+      }
+    }
     PROGRESS_SETUP(tr("Loading workspace. Please wait."), 0, total, this);
+    progress.show();
     quint32 progCnt = 0;
 
     while (query.next()) {

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -577,6 +577,7 @@ IGisProject* CGisWorkspace::copyItemsByKey(const QList<IGisItem::key_t>& keys) {
   project->blockUpdateItems(true);
   int cnt = 1;
   PROGRESS_SETUP(tr("Copy items..."), 0, keys.count(), this);
+  progress.show();
   for (const IGisItem::key_t& key : keys) {
     PROGRESS(cnt++, break);
     IGisItem* gisItem = getItemByKey(key);


### PR DESCRIPTION
### What is the linked issue for this pull request:
[QMS-784](https://github.com/Maproom/qmapshack/issues)

### What you have done:
Solve two issues for:
1. Show Invalid Points Dialog on top of Progress Dialog when starting QMS and the current workspace contains tracks with invalid points
2. Bypass query.size() for SQLite

### Steps to perform a simple smoke test:
For GNOME/Wayland:
1. Start QMS with a workspace that contains tracks with invalid points 
2. Try to copy a projects/track with invalid points to a next project
=> The Invalid Points Dialog should always on top of all other windows

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):
- [x] yes

### Is every user facing string in a tr() macro?
- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.
- [x] yes, I didn't forget to change changelog.txt