### PR TITLE
[QMS-788] Fix: BRouter (offline) not shown in combobox

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ V1.XX.X
 [QMS-779] Avoid NaN when totalAscent or totalDescent = 0
 [QMS-782] Solved two issues for track point viewer
 [QMS-784] Solved two issues for GNOME/Wayland, Invalid Points Dialog vs Progress Dialog
+[QMS-788] Fix: BRouter (offline) not shown in combobox
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/rte/router/CRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/CRouterSetup.h
@@ -36,7 +36,7 @@ class CRouterSetup : public QWidget, private Ui::IRouterSetup {
 
   bool hasFastRouting();
 
-  enum router_e { RouterRoutino, RouterMapquest, RouterBRouter };
+  enum router_e { RouterRoutino, RouterBRouter };
 
   void setRouterTitle(router_e, QString title);
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#788

### What you have done:
[comment]: # (Describe roughly.)

Removed MapQuest router from enumeration. The enumeration is used to index the combobox items when changing the text.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
