### PR TITLE
[QMS-791] Error determining BRouter-Web (online) version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ V1.XX.X
 [QMS-782] Solved two issues for track point viewer
 [QMS-784] Solved two issues for GNOME/Wayland, Invalid Points Dialog vs Progress Dialog
 [QMS-788] Fix: BRouter (offline) not shown in combobox
+[QMS-791] Error determining BRouter-Web (online) version
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetup.cpp
@@ -532,7 +532,7 @@ void CRouterBRouterSetup::loadOnlineVersionFinished(QNetworkReply* reply) {
     return;
   }
   const QString gpx(reply->readAll());
-  static const QRegularExpression reVersion("^<\\?xml.+<gpx.+creator=\"(.*)\"");
+  static const QRegularExpression reVersion("^<\\?xml.+<gpx.+creator=\"([^\"]*)\".*$",QRegularExpression::DotMatchesEverythingOption|QRegularExpression::MultilineOption);
   const QRegularExpressionMatch& match = reVersion.match(gpx);
   if (match.hasMatch()) {
     parseBRouterVersion(match.captured(1));


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#791

### What you have done:
[comment]: # (Describe roughly.)
Fixed QRegularExpression to extract BRouter version from BRouter reply.
### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Setup routing and select BRouter-Web (online) as router
2. No error message window is showing BRouter related errors

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
