### PR TITLE
[QMS-794]Fix: Links to local files not opening in Waypoint on-screen dialog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@ V1.XX.X
 [QMS-740] Fix dbus compile issues for Windows
 [QMS-743] Fix crash when reseting a range in track profile graph
 [QMS-745] Remove old FIT implementation
-[QMS-747] Remove support for MapQuest 
+[QMS-747] Remove support for MapQuest
 [QMS-750] Fix QMS build error - Windows 10/MSVC
 [QMS-753] Fix segfault for FIT sessions without track data
 [QMS-756] Avoid: [warning] QIODevice::read (QProcess): device not open
@@ -35,6 +35,7 @@ V1.XX.X
 [QMS-784] Solved two issues for GNOME/Wayland, Invalid Points Dialog vs Progress Dialog
 [QMS-788] Fix: BRouter (offline) not shown in combobox
 [QMS-791] Error determining BRouter-Web (online) version
+[QMS-794] Fix: Links to local files in Waypoint on-screen dialog not opening
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/gis/ovl/IScrOptOvlArea.ui
+++ b/src/qmapshack/gis/ovl/IScrOptOvlArea.ui
@@ -151,6 +151,9 @@
      <property name="text">
       <string>TextLabel</string>
      </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
      <property name="textInteractionFlags">
       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
      </property>

--- a/src/qmapshack/gis/rte/IScrOptRte.ui
+++ b/src/qmapshack/gis/rte/IScrOptRte.ui
@@ -224,6 +224,9 @@
      <property name="textFormat">
       <enum>Qt::AutoText</enum>
      </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
      <property name="textInteractionFlags">
       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
      </property>

--- a/src/qmapshack/gis/trk/IScrOptTrk.ui
+++ b/src/qmapshack/gis/trk/IScrOptTrk.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>3</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>3</number>
+   </property>
+   <property name="topMargin">
+    <number>3</number>
+   </property>
+   <property name="rightMargin">
+    <number>3</number>
+   </property>
+   <property name="bottomMargin">
     <number>3</number>
    </property>
    <item>
@@ -316,6 +325,9 @@ recording. Use the range tool. </string>
     <widget class="QLabel" name="label">
      <property name="text">
       <string>TextLabel</string>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
      </property>
      <property name="textInteractionFlags">
       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/src/qmapshack/gis/wpt/IScrOptWpt.ui
+++ b/src/qmapshack/gis/wpt/IScrOptWpt.ui
@@ -296,6 +296,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
      <property name="textInteractionFlags">
       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
      </property>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#794

### What you have done:
[comment]: # (Describe roughly.)

- Edit ` IScrOptWpt.ui ` with Qt Designer, and set the property `openExternalLink` to true for `TextLabel`
- Do the same fix for`IScrOptTrk.ui`, `IScrOptRte.ui`and `IScrOptOvlArea.ui`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)
1. Edit a waypoint and create a link pointing to  a local file.(e.g.   file.jpg  file.pdf) 

2. Click this waypoint on the map - click on the link to the local file - file is opened
 ![Image](https://github.com/user-attachments/assets/201ade3b-acb4-4ace-b13f-1f5136baee59)
   
### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
