### PR TITLE
[QMS-793] Auto-routing with BRouter & minor fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@ V1.XX.X
 [QMS-784] Solved two issues for GNOME/Wayland, Invalid Points Dialog vs Progress Dialog
 [QMS-788] Fix: BRouter (offline) not shown in combobox
 [QMS-791] Error determining BRouter-Web (online) version
+[QMS-793] Auto-routing with BRouter & minor fixes
 [QMS-794] Fix: Links to local files in Waypoint on-screen dialog not opening
 
 V1.17.1

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -82,8 +82,6 @@ CRouterBRouter::CRouterBRouter(QWidget* parent) : IRouter(false, parent) {
 
   cfg.beginGroup("Route/brouter");
   comboProfile->setCurrentIndex(cfg.value("profile", 0).toInt());
-  checkFastRecalc->setChecked(cfg.value("fastRecalc", false).toBool() &&
-                              (setup->installMode == CRouterBRouterSetup::eModeLocal));
   comboAlternative->setCurrentIndex(cfg.value("alternative", 0).toInt());
   cfg.endGroup();
 }
@@ -97,7 +95,6 @@ CRouterBRouter::~CRouterBRouter() {
   cfg.beginGroup("Route/brouter");
   cfg.setValue("profile", comboProfile->currentIndex());
   cfg.setValue("alternative", comboAlternative->currentIndex());
-  cfg.setValue("fastRecalc", checkFastRecalc->isChecked());
   cfg.endGroup();
 }
 
@@ -188,15 +185,14 @@ void CRouterBRouter::slotCloseStatusMsg() const {
 
 QString CRouterBRouter::getOptions() {
   return QString(tr("profile: %1, alternative: %2")
-                     .arg(comboProfile->currentData().toString())
-                     .arg(comboAlternative->currentData().toInt() + 1));
+                     .arg(comboProfile->currentText())
+                     .arg(comboAlternative->currentData().toInt()));
 }
 
 void CRouterBRouter::routerSelected() { getBRouterVersion(); }
 
 bool CRouterBRouter::hasFastRouting() {
-  return setup->installMode == CRouterBRouterSetup::eModeLocal && setup->isLocalBRouterValid &&
-         checkFastRecalc->isChecked();
+  return setup->installMode == CRouterBRouterSetup::eModeLocal && setup->isLocalBRouterValid;
 }
 
 QNetworkRequest CRouterBRouter::getRequest(const QVector<QPointF>& routePoints, const QList<IGisItem*>& nogos) const {
@@ -571,7 +567,6 @@ void CRouterBRouter::updateBRouterStatus() const {
     labelStatus->setText(tr("online"));
     toolConsole->setVisible(false);
     toolToggleBRouter->setVisible(false);
-    checkFastRecalc->setVisible(false);
     textBRouterOutput->clear();
     textBRouterOutput->setVisible(false);
   }

--- a/src/qmapshack/gis/rte/router/CRouterSetup.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterSetup.cpp
@@ -37,6 +37,9 @@ CRouterSetup::CRouterSetup(QWidget* parent) : QWidget(parent) {
   stackedWidget->addWidget(new CRouterRoutino(this));
   stackedWidget->addWidget(new CRouterBRouter(this));
 
+  // Force initial "currentIndexChanged" signal for auto-routing initialization
+  comboRouter->setCurrentIndex(-1);
+
   connect(comboRouter, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
           &CRouterSetup::slotSelectRouter);
 
@@ -60,8 +63,9 @@ bool CRouterSetup::hasFastRouting() {
 void CRouterSetup::slotSelectRouter(int i) {
   stackedWidget->setCurrentIndex(i);
   IRouter* router = dynamic_cast<IRouter*>(stackedWidget->currentWidget());
-  if (router != nullptr) {
+  if (router) {
     router->routerSelected();
+    emit sigHasFastRouting(hasFastRouting());
   }
 }
 
@@ -92,4 +96,7 @@ QString CRouterSetup::getOptions() {
 
 void CRouterSetup::setRouterTitle(const router_e router, const QString title) {
   comboRouter->setItemText(router, title);
+  if (comboRouter->currentIndex() == router) {
+    emit sigHasFastRouting(hasFastRouting());
+  }
 }

--- a/src/qmapshack/gis/rte/router/CRouterSetup.h
+++ b/src/qmapshack/gis/rte/router/CRouterSetup.h
@@ -40,6 +40,9 @@ class CRouterSetup : public QWidget, private Ui::IRouterSetup {
 
   void setRouterTitle(router_e, QString title);
 
+ signals:
+  void sigHasFastRouting (bool on);
+
  private slots:
   void slotSelectRouter(int i);
 

--- a/src/qmapshack/gis/rte/router/IRouterBRouter.ui
+++ b/src/qmapshack/gis/rte/router/IRouterBRouter.ui
@@ -92,31 +92,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="checkFastRecalc">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>on-the-fly routing</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <layout class="QHBoxLayout" name="horizontalLayout_2"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -165,7 +141,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -218,7 +194,7 @@
      <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -240,7 +216,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
@@ -186,14 +186,11 @@ void CRouterBRouterLocal::updateLocalBRouterStatus() const {
       }
     }
 
-    brouter.checkFastRecalc->setEnabled(true);
     brouter.toolToggleBRouter->setEnabled(true);
   } else {
     brouter.labelStatus->setText(tr("not installed"));
     brouter.toolConsole->setVisible(false);
     brouter.toolToggleBRouter->setEnabled(false);
-    brouter.checkFastRecalc->setEnabled(false);
   }
   brouter.toolToggleBRouter->setVisible(true);
-  brouter.checkFastRecalc->setVisible(true);
 }

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterSetupWizard.cpp
@@ -592,7 +592,7 @@ void CRouterBRouterSetupWizard::updateOnlineDetails() const {
     labelOnlineVersion->setText(tr("BRouter-Version: not accessible"));
   } else {
     labelOnlineVersion->setText(
-        tr("BRouter-Version: %1.%2.%3").arg(setup->versionMajor).arg(setup->versionMinor).arg(setup->versionMinor));
+        tr("BRouter-Version: %1.%2.%3").arg(setup->versionMajor).arg(setup->versionMinor).arg(setup->versionPatch));
   }
   if (isError) {
     textOnlineDetails->setText(error + ": " + errorDetails);

--- a/src/qmapshack/mouse/line/IMouseEditLine.cpp
+++ b/src/qmapshack/mouse/line/IMouseEditLine.cpp
@@ -26,6 +26,7 @@
 #include "gis/CGisDraw.h"
 #include "gis/GeoMath.h"
 #include "gis/IGisLine.h"
+#include "gis/rte/router/CRouterSetup.h"
 #include "gis/rte/router/CRouterOptimization.h"
 #include "gis/trk/CGisItemTrk.h"
 #include "helpers/CDraw.h"
@@ -123,6 +124,9 @@ void IMouseEditLine::commonSetup() {
       scrOptEditLine->toolTrackRoute->setChecked(true);
       break;
   }
+
+  connect(&CRouterSetup::self(), &CRouterSetup::sigHasFastRouting, this, &IMouseEditLine::slotHasFastRouting);
+  slotHasFastRouting(CRouterSetup::self().hasFastRouting());
 
   slotMovePoint();
 }
@@ -310,6 +314,14 @@ void IMouseEditLine::slotTrackRouting() {
   canvas->reportStatus(key.item,
                        tr("<b>Track Routing</b><br/>Connect points with a line from a loaded track if possible.<br/>"));
   canvas->reportStatus("Routino", QString());
+}
+
+void IMouseEditLine::slotHasFastRouting(bool on) {
+  if (scrOptEditLine->toolAutoRoute->isChecked() && !on) {
+    scrOptEditLine->toolNoRoute->setChecked(true);
+  }
+  scrOptEditLine->toolAutoRoute->setEnabled(on);
+  scrOptEditLine->toolAutoRoute->setCheckable(on);
 }
 
 void IMouseEditLine::slotOptimize() {

--- a/src/qmapshack/mouse/line/IMouseEditLine.h
+++ b/src/qmapshack/mouse/line/IMouseEditLine.h
@@ -101,6 +101,11 @@ class IMouseEditLine : public IMouse {
   void slotVectorRouting();
   void slotTrackRouting();
 
+  /**
+     @brief Enable/disable auto-routing
+   */
+  void slotHasFastRouting(bool on);
+
   void slotOptimize();
 
   virtual void slotAbort() = 0;

--- a/src/qmapshack/mouse/line/IScrOptEditLine.ui
+++ b/src/qmapshack/mouse/line/IScrOptEditLine.ui
@@ -235,7 +235,7 @@
         <item>
          <widget class="QToolButton" name="toolAutoRoute">
           <property name="toolTip">
-           <string>Use auto-routing to between points. (Key: A)</string>
+           <string>Use auto-routing in between points. (Key: A)</string>
           </property>
           <property name="text">
            <string>A</string>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#793

### What you have done:
[comment]: # (Describe roughly.)
- Remove BRouter's obsolete "on-the-fly routing" checkbox: 
 auto-routing is now always usable with _offline_ routers and is never usable with _online_ router
- Replace checkbox by a hint in case of auto-routing not available with BRouter
- Disable/enable "A" button depending on router's auto-routing capability: 
  -  at begin of editing line 
  - while editing line by signaling new router's auto-routing capability after router switch
- Fix incorrect BRouter-Web version shown in BRouter setup window
- Fix alternate index count in tooltip of calculated route: was 1 to high
 index 0 = original, index n = n-th alternative
- Fix line edit "A" button tooltip's incomplete phrase

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Switch between routers "Routino (offline)", "BRouter (online)" and "BRouter (offline)"
 at begin of line editing and during line editing and notice:
 that line edit "A" button is enabled or disabled according to router's auto-routing capability
 that line editing does only use auto-routing when "A" button is enabled and checked.
2. Notice correct BRouter-Web version in BRouter-Web setup window (currently version 1.7.0)
3. Calculate route using a BRouter alternative and check tooltip of calculated route:
  alternative "0" is shown when calculated with alternative "original",
  alternative "n" is shown when calculated with alternative "n-th  alternative"
4. Hover over line edit "A" button and notice a grammatically correct phrase.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes and no: opening brackets are not on a new line but keeping appearance of rest of file 

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
