### PR TITLE
[QMS-797] Enhance USB MTP to support generic devices

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -37,6 +37,7 @@ V1.XX.X
 [QMS-791] Error determining BRouter-Web (online) version
 [QMS-793] Auto-routing with BRouter & minor fixes
 [QMS-794] Fix: Links to local files in Waypoint on-screen dialog not opening
+[QMS-797] Enhance USB MTP to support generic devices
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -349,6 +349,7 @@ set( SRCS
     device/CDeviceAccessGvfsMtp.cpp
     device/CDeviceGarminMtp.cpp
     device/CDeviceGarminArchiveMtp.cpp
+    device/CDeviceGenericMtp.cpp
     device/dbus/org.kde.kmtp.Daemon.cpp
     device/dbus/org.kde.kmtp.Device.cpp
     device/dbus/org.kde.kmtp.Storage.cpp
@@ -713,6 +714,7 @@ set( HDRS
     device/CDeviceAccessGvfsMtp.h
     device/CDeviceGarminMtp.h
     device/CDeviceGarminArchiveMtp.h
+    device/CDeviceGenericMtp.h
     device/IDeviceAccess.h
     device/dbus/org.kde.kmtp.Daemon.h
     device/dbus/org.kde.kmtp.Device.h

--- a/src/qmapshack/device/CDeviceAccessGvfsMtp.cpp
+++ b/src/qmapshack/device/CDeviceAccessGvfsMtp.cpp
@@ -45,15 +45,8 @@ CDeviceAccessGvfsMtp::CDeviceAccessGvfsMtp(const GVFSMount& mount, const QString
 
 QPixmap CDeviceAccessGvfsMtp::getIcon(const QString& iconPath) {
   QPixmap pixmap;
-  QString ip;
-  ip = (iconPath != "") ? iconPath : QString("Garmintriangletm.ico"); // Some GARMIN devices has .ico
-  if (dir.exists(ip)) {
-    pixmap.load(dir.filePath(ip));
-  } else {
-    ip = "Garmintriangletm.icon"; // Some other GARMIN devices has .icon
-    if (dir.exists(ip)) {
-      pixmap.load(dir.filePath(ip));
-    }
+  if (dir.exists(iconPath)) {
+    pixmap.load(dir.filePath(iconPath));
   }
   return pixmap;
 }

--- a/src/qmapshack/device/CDeviceAccessGvfsMtp.h
+++ b/src/qmapshack/device/CDeviceAccessGvfsMtp.h
@@ -32,7 +32,7 @@ class CDeviceAccessGvfsMtp : public IDeviceAccess {
   CDeviceAccessGvfsMtp(const GVFSMount& mount, const QString& storagePath, QObject* parent);
   virtual ~CDeviceAccessGvfsMtp() = default;
 
-  QPixmap getIcon(const QString& iconPath = "") override;
+  QPixmap getIcon(const QString& iconPath) override;
   QString decription() override;
 
   bool readFileFromStorage(const QString& path, QFile& file) override;

--- a/src/qmapshack/device/CDeviceAccessGvfsMtp.h
+++ b/src/qmapshack/device/CDeviceAccessGvfsMtp.h
@@ -32,7 +32,7 @@ class CDeviceAccessGvfsMtp : public IDeviceAccess {
   CDeviceAccessGvfsMtp(const GVFSMount& mount, const QString& storagePath, QObject* parent);
   virtual ~CDeviceAccessGvfsMtp() = default;
 
-  QPixmap getIcon() override;
+  QPixmap getIcon(const QString& iconPath = "") override;
   QString decription() override;
 
   bool readFileFromStorage(const QString& path, QFile& file) override;
@@ -47,5 +47,4 @@ class CDeviceAccessGvfsMtp : public IDeviceAccess {
   QDir pathOnDevice;
 };
 
-#endif //CDEVICEACCESSGVFSMTP_H
-
+#endif  // CDEVICEACCESSGVFSMTP_H

--- a/src/qmapshack/device/CDeviceAccessKMtp.cpp
+++ b/src/qmapshack/device/CDeviceAccessKMtp.cpp
@@ -43,17 +43,9 @@ CDeviceAccessKMtp::CDeviceAccessKMtp(const QDBusObjectPath& objectPathStorage, Q
 QPixmap CDeviceAccessKMtp::getIcon(const QString& iconPath) {
   QPixmap pixmap;
   QTemporaryFile icon;
-  QString ip;
-  ip = (iconPath != "") ? iconPath : QString("Garmintriangletm.ico"); // Some GARMIN devices has .ico
-  if (readFileFromStorage(dir.filePath(ip), icon)) {
+  if (readFileFromStorage(dir.filePath(iconPath), icon)) {
     icon.open();
     pixmap.loadFromData(icon.readAll());
-  } else {
-    ip = "Garmintriangletm.icon"; // Some other GARMIN devices has .icon
-    if (readFileFromStorage(dir.filePath(ip), icon)) {
-      icon.open();
-      pixmap.loadFromData(icon.readAll());
-    }
   }
   return pixmap;
 }

--- a/src/qmapshack/device/CDeviceAccessKMtp.cpp
+++ b/src/qmapshack/device/CDeviceAccessKMtp.cpp
@@ -32,17 +32,28 @@ CDeviceAccessKMtp::CDeviceAccessKMtp(const QDBusObjectPath& objectPathStorage, Q
   for (const KMTPFile& file : topLevelFiles) {
     if (file.isFolder() && (file.filename().toUpper() == "GARMIN")) {
       dir.setPath("/" + file.filename());
-      break;
+      return;
     }
   }
+
+  // No GARMIN directory is found, so we assume it is a Generic one, set the data directory to the top level
+  dir.setPath("/");
 }
 
-QPixmap CDeviceAccessKMtp::getIcon() {
+QPixmap CDeviceAccessKMtp::getIcon(const QString& iconPath) {
   QPixmap pixmap;
   QTemporaryFile icon;
-  if (readFileFromStorage(dir.filePath("Garmintriangletm.ico"), icon)) {
+  QString ip;
+  ip = (iconPath != "") ? iconPath : QString("Garmintriangletm.ico"); // Some GARMIN devices has .ico
+  if (readFileFromStorage(dir.filePath(ip), icon)) {
     icon.open();
     pixmap.loadFromData(icon.readAll());
+  } else {
+    ip = "Garmintriangletm.icon"; // Some other GARMIN devices has .icon
+    if (readFileFromStorage(dir.filePath(ip), icon)) {
+      icon.open();
+      pixmap.loadFromData(icon.readAll());
+    }
   }
   return pixmap;
 }

--- a/src/qmapshack/device/CDeviceAccessKMtp.h
+++ b/src/qmapshack/device/CDeviceAccessKMtp.h
@@ -30,7 +30,7 @@ class CDeviceAccessKMtp : public IDeviceAccess {
   CDeviceAccessKMtp(const QDBusObjectPath& objectPathStorage, QObject* parent);
   virtual ~CDeviceAccessKMtp() = default;
 
-  QPixmap getIcon(const QString& iconPath = "") override;
+  QPixmap getIcon(const QString& iconPath) override;
   QString decription() override;
 
   bool readFileFromStorage(const QString& path, QFile& file) override;

--- a/src/qmapshack/device/CDeviceAccessKMtp.h
+++ b/src/qmapshack/device/CDeviceAccessKMtp.h
@@ -30,7 +30,7 @@ class CDeviceAccessKMtp : public IDeviceAccess {
   CDeviceAccessKMtp(const QDBusObjectPath& objectPathStorage, QObject* parent);
   virtual ~CDeviceAccessKMtp() = default;
 
-  QPixmap getIcon() override;
+  QPixmap getIcon(const QString& iconPath = "") override;
   QString decription() override;
 
   bool readFileFromStorage(const QString& path, QFile& file) override;

--- a/src/qmapshack/device/CDeviceGarminMtp.cpp
+++ b/src/qmapshack/device/CDeviceGarminMtp.cpp
@@ -42,8 +42,15 @@ void CDeviceGarminMtp::setup() {
   if (!device->foundValidStoragePath()) {
     return;
   }
-  // Try to read the icon from the device
-  const QPixmap& pixmap = device->getIcon();
+
+  QPixmap pixmap;
+  const QStringList& files = device->listFilesOnStorage("");
+  if (files.contains("Garmintriangletm.ico")) {
+    pixmap = device->getIcon("Garmintriangletm.ico");
+  } else if (files.contains("Garmintriangletm.icon")) {
+    pixmap = device->getIcon("Garmintriangletm.icon");
+  }
+
   if (!pixmap.isNull()) {
     setIcon(CGisListWks::eColumnIcon, pixmap);
   }

--- a/src/qmapshack/device/CDeviceGenericMtp.cpp
+++ b/src/qmapshack/device/CDeviceGenericMtp.cpp
@@ -1,0 +1,171 @@
+/**********************************************************************************************
+    Copyright (C) 2021 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#include "device/CDeviceGenericMtp.h"
+
+#include "device/CDeviceAccessGvfsMtp.h"
+#include "device/CDeviceAccessKMtp.h"
+#include "gis/CGisListWks.h"
+#include "gis/fit2/CFit2Project.h"
+#include "gis/gpx/CGpxProject.h"
+
+// Used by gvfs
+CDeviceGenericMtp::CDeviceGenericMtp(const GVFSMount& mount, const QString& storagePath, const QString& key,
+                                     QTreeWidget* parent)
+    : IDevice("", eTypeGenericMtp, key, parent), QObject(parent) {
+  device = new CDeviceAccessGvfsMtp(mount, storagePath, this);
+  setup();
+}
+
+// Used by kiod6
+CDeviceGenericMtp::CDeviceGenericMtp(const QDBusObjectPath& objectPathStorage, const QString& key, QTreeWidget* parent)
+    : IDevice("", eTypeGenericMtp, key, parent), QObject(parent) {
+  device = new CDeviceAccessKMtp(objectPathStorage, this);
+  setup();
+}
+
+void CDeviceGenericMtp::setup() {
+  if (!device->foundValidStoragePath()) {
+    return;
+  }
+
+  QString description(tr("Unknown MTP"));
+
+  // Read information from QmsMtpDevice.json
+  QTemporaryFile jFile;
+  if (device->readFileFromStorage(kQmsMtpDeviceJson, jFile) && jFile.open()) {
+    QJsonParseError error;
+    const QJsonDocument& jDoc = QJsonDocument::fromJson(jFile.readAll(), &error);
+    if (error.error != QJsonParseError::NoError) {
+      qWarning() << error.errorString();
+      return;
+    }
+
+    const QJsonObject& jObj = jDoc.object();
+    description = jObj.value("description").toString();
+    QDir rootPath(jObj.value("rootPath").toString());
+    const QStringList& exportPathsRelativ = jObj.value("exportPaths").toVariant().toStringList();
+    const QStringList& importPathsRelativ = jObj.value("importPaths").toVariant().toStringList();
+    const QString& icon = jObj.value("icon").toString();
+
+    // Try to read the icon from the device
+    const QString& iconPath = QDir::cleanPath(rootPath.filePath(icon));
+    const QPixmap& pixmap = device->getIcon(iconPath);
+    if (!pixmap.isNull()) {
+      setIcon(CGisListWks::eColumnIcon, pixmap);
+    }
+
+    for (const QString& path : exportPathsRelativ) {
+      const QString& _path = QDir::cleanPath(rootPath.filePath(path));
+      createProjectsFromFiles(_path);
+      exportPaths << _path;
+    }
+
+    for (const QString& path : importPathsRelativ) {
+      createProjectsFromFiles(QDir::cleanPath(rootPath.filePath(path)));
+    }
+  }
+  setText(CGisListWks::eColumnName, QString("%1 (%2)").arg(description, device->decription()));
+}
+
+bool CDeviceGenericMtp::removeFromDevice(const QString& filename) {
+  qDebug() << "CDeviceGenericMtp::removeFromDevice(" << filename << ")";
+  return device->removeFileFromStorage(filename);
+}
+
+void CDeviceGenericMtp::insertCopyOfProject(IGisProject* project) {
+  for (const QString& path : exportPaths) {
+    const QString& filename = createFileName(project, path, ".gpx");
+    qDebug() << "CDeviceGenericMtp::insertCopyOfProject(" << filename << ")";
+
+    CGpxProject* gpx = new CGpxProject(filename, project, this);
+    if (!gpx->isValid()) {
+      delete gpx;
+      return;
+    }
+
+    QTemporaryFile file;
+    file.open();  // saveAs will close the file
+    if (!CGpxProject::saveAs(file, filename, *gpx, false)) {
+      delete gpx;
+      return;
+    }
+
+    if (!device->sendFileToStorage(filename, file)) {
+      delete gpx;
+      return;
+    }
+
+    // move new project to top of any sub-folder/sub-device item
+    reorderProjects(gpx);
+  }
+}
+
+void CDeviceGenericMtp::createProjectsFromFiles(const QString& subdirectory) {
+  static const QStringList knownSuffix = {"gpx", "fit"};
+  QDir d(subdirectory);
+
+  const QStringList& files = device->listFilesOnStorage(subdirectory);
+  for (const QString& file : files) {
+    const QString suffix = QFileInfo(file).suffix().toLower();
+    if (knownSuffix.contains(suffix)) {
+      QTemporaryFile tempFile;
+      if (!device->readFileFromStorage(d.filePath(file), tempFile)) {
+        return;
+      }
+      tempFile.open();
+      IGisProject* project = nullptr;
+      if (suffix == "gpx") {
+        project = new CGpxProject(tempFile, d.filePath(file), this);
+      } else if (suffix == "fit") {
+        project = new CFit2Project(tempFile, d.filePath(file), this);
+      }
+      if (project && !project->isValid()) {
+        delete project;
+      }
+    }
+  }
+}
+
+QString CDeviceGenericMtp::createFileName(IGisProject* project, const QString& path, const QString& suffix) const {
+  return QDir(path).filePath(simplifiedName(project) + suffix);
+}
+
+QString CDeviceGenericMtp::simplifiedName(IGisProject* project) const {
+  static const QRegularExpression re("[^A-Za-z0-9_]");
+  return project->getName().remove(re);
+}
+
+void CDeviceGenericMtp::reorderProjects(IGisProject* project) {
+  // move new project to top of any sub-folder/sub-device item
+  int newIdx = NOIDX;
+  const int myIdx = childCount() - 1;
+  for (int i = myIdx - 1; i >= 0; i--) {
+    IDevice* device = dynamic_cast<IDevice*>(child(i));
+    if (0 == device) {
+      break;
+    }
+
+    newIdx = i;
+  }
+
+  if (newIdx != NOIDX) {
+    takeChild(myIdx);
+    insertChild(newIdx, project);
+  }
+}

--- a/src/qmapshack/device/CDeviceGenericMtp.h
+++ b/src/qmapshack/device/CDeviceGenericMtp.h
@@ -1,0 +1,62 @@
+/**********************************************************************************************
+    Copyright (C) 2021 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CDEVICEGENERICMTP_H
+#define CDEVICEGENERICMTP_H
+
+#include <functional>
+
+#include "device/IDevice.h"
+
+class QDBusObjectPath;
+class IDeviceAccess;
+class GVFSMount;
+
+class CDeviceGenericMtp : public IDevice, private QObject {
+  Q_DECLARE_TR_FUNCTIONS(CDeviceGenericMtp)
+ public:
+  CDeviceGenericMtp(const QDBusObjectPath& objectPathStorage, const QString& key, QTreeWidget* parent);
+
+  CDeviceGenericMtp(const GVFSMount& mount, const QString& storagePath, const QString& key, QTreeWidget* parent);
+
+  virtual ~CDeviceGenericMtp() = default;
+
+  bool removeFromDevice(const QString& filename);
+
+  static constexpr const char* kQmsMtpDeviceJson = "QmsMtpDevice.json";
+
+ protected:
+  void insertCopyOfProject(IGisProject* project) override;
+
+ private:
+  struct readFromPath_t {
+    QString format;
+    QString dir;
+  };
+
+  void setup();
+  void createProjectsFromFiles(const QString& subdirectory);
+  QString createFileName(IGisProject* project, const QString& path, const QString& suffix) const;
+  QString simplifiedName(IGisProject* project) const;
+  void reorderProjects(IGisProject* project);
+
+  IDeviceAccess* device;
+  QStringList exportPaths;
+};
+
+#endif  // CDEVICEGENERICMTP_H

--- a/src/qmapshack/device/CDeviceWatcherLinux.h
+++ b/src/qmapshack/device/CDeviceWatcherLinux.h
@@ -19,6 +19,7 @@
 #ifndef CDEVICEWATCHERLINUX_H
 #define CDEVICEWATCHERLINUX_H
 
+#include "device/IDevice.h"
 #include "device/IDeviceWatcher.h"
 #include "device/dbus/org.gtk.vfs.MTPVolumeMonitor.h"
 #include "device/dbus/org.gtk.vfs.MountTracker.h"
@@ -48,8 +49,8 @@ class CDeviceWatcherLinux : public IDeviceWatcher {
 
  private:
   QString readMountPoint(const QString& path);
-  void addKMtpDevice(org::kde::kmtp::Device& device, const QString &deviceKey);
-  void addGVFSMtpDevice(const GVFSMount& mount, const QStringList& storages);
+  void addKMtpDevice(org::kde::kmtp::Device& device, const QString& deviceKey, IDevice::type_e deviceType);
+  void addGVFSMtpDevice(const GVFSMount& mount, const QStringList& storages, IDevice::type_e deviceType);
 
   org::kde::kmtp::Daemon* kMtpDaemon;
   QMap<QString, QStringList> knownMtpDevices;

--- a/src/qmapshack/device/IDevice.h
+++ b/src/qmapshack/device/IDevice.h
@@ -31,7 +31,7 @@ class CDeviceGarmin;
 class IDevice : public QTreeWidgetItem {
   Q_DECLARE_TR_FUNCTIONS(IDevice)
  public:
-  enum type_e { eTypeNone = 0, eTypeGarmin = 1, eTypeTwoNav = 2, eTypeGarminMtp = 3, eTypeVirtual = 4 };
+  enum type_e { eTypeNone = 0, eTypeGarmin = 1, eTypeTwoNav = 2, eTypeGarminMtp = 3, eTypeVirtual = 4, eTypeGenericMtp = 5 };
 
   IDevice(const QString& path, type_e type, const QString& key, QTreeWidget* parent);
   IDevice(const QString& path, const QString& key, IDevice* parent);

--- a/src/qmapshack/device/IDeviceAccess.h
+++ b/src/qmapshack/device/IDeviceAccess.h
@@ -42,7 +42,7 @@ class IDeviceAccess : public QObject {
    * @param iconPath    a path to to the icon or empty for the GARMIN icon
    * @return A valid pixmap ion success or an empty one if no icon has been found.
    */
-  virtual QPixmap getIcon(const QString& iconPath = "") = 0;
+  virtual QPixmap getIcon(const QString& iconPath) = 0;
   /**
    * @brief A user readable description of the storage
    */

--- a/src/qmapshack/device/IDeviceAccess.h
+++ b/src/qmapshack/device/IDeviceAccess.h
@@ -36,12 +36,13 @@ class IDeviceAccess : public QObject {
    * A valid path usually is a path that has a folder named Garmin.
    *
    */
-  virtual bool foundValidStoragePath() const { return !dir.dirName().isEmpty(); }
+  virtual bool foundValidStoragePath() const { return !dir.absolutePath().isEmpty(); }
   /**
-   * @brief Get an icon from the storage if any
+   * @brief Get an icon from the storage if any - for generic icon path
+   * @param iconPath    a path to to the icon or empty for the GARMIN icon
    * @return A valid pixmap ion success or an empty one if no icon has been found.
    */
-  virtual QPixmap getIcon() = 0;
+  virtual QPixmap getIcon(const QString& iconPath = "") = 0;
   /**
    * @brief A user readable description of the storage
    */

--- a/src/qmapshack/gis/IGisItem.cpp
+++ b/src/qmapshack/gis/IGisItem.cpp
@@ -681,9 +681,10 @@ QString IGisItem::html2Dev(const QString& str, bool strictGpx11) {
     return "";
   }
 
-  return (isOnDevice() == IDevice::eTypeGarmin) || (isOnDevice() == IDevice::eTypeGarminMtp) || strictGpx11
-             ? removeHtml(str)
-             : str;
+  return (isOnDevice() == IDevice::eTypeGarmin)
+                 || (isOnDevice() == IDevice::eTypeGarminMtp)
+                 || (isOnDevice() == IDevice::eTypeGenericMtp)
+                 || strictGpx11 ? removeHtml(str) : str;
 }
 
 QString IGisItem::toLink(bool isReadOnly, const QString& href, const QString& str, const QString& key) {

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -919,7 +919,9 @@ void IGisItem::writeWpt(QDomElement& xml, const wpt_t& wpt, bool strictGpx11) {
   writeXml(xml, "name", wpt.name);
   writeXml(xml, "cmt", html2Dev(wpt.cmt, strictGpx11));
   writeXml(xml, "desc", html2Dev(wpt.desc, strictGpx11));
-  if ((isOnDevice() != IDevice::eTypeGarmin) || (isOnDevice() != IDevice::eTypeGarminMtp)) {
+  if ((isOnDevice() != IDevice::eTypeGarmin)
+      || (isOnDevice() != IDevice::eTypeGarminMtp)
+      || (isOnDevice() != IDevice::eTypeGenericMtp)) {
     writeXml(xml, "src", wpt.src);
   }
   writeXml(xml, "link", wpt.links);

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -24,6 +24,7 @@
 
 #include "CMainWindow.h"
 #include "device/CDeviceGarminMtp.h"
+#include "device/CDeviceGenericMtp.h"
 #include "device/IDevice.h"
 #include "gis/CGisDraw.h"
 #include "gis/CGisListWks.h"
@@ -141,8 +142,9 @@ IGisProject* IGisProject::create(const QString filename, CGisListWks* parent) {
 }
 
 QString IGisProject::html2Dev(const QString& str) {
-  return (isOnDevice() == IDevice::eTypeGarmin) || (isOnDevice() == IDevice::eTypeGarminMtp) ? IGisItem::removeHtml(str)
-                                                                                             : str;
+  return (isOnDevice() == IDevice::eTypeGarmin)
+                 || (isOnDevice() == IDevice::eTypeGarminMtp)
+                 || (isOnDevice() == IDevice::eTypeGenericMtp) ? IGisItem::removeHtml(str) : str;
 }
 
 bool IGisProject::askBeforClose() {
@@ -786,9 +788,14 @@ void IGisProject::umount() {
 
 bool IGisProject::remove() {
 #ifdef Q_OS_LINUX
-  CDeviceGarminMtp* mtp = dynamic_cast<CDeviceGarminMtp*>(parent());
-  if (mtp != nullptr) {
-    return mtp->removeFromDevice(filename);
+  CDeviceGarminMtp* mtpGarmin = dynamic_cast<CDeviceGarminMtp*>(parent());
+  if (mtpGarmin != nullptr) {
+    return mtpGarmin->removeFromDevice(filename);
+  } else {
+    CDeviceGenericMtp* mtpGeneric = dynamic_cast<CDeviceGenericMtp*>(parent());
+    if (mtpGeneric != nullptr) {
+      return mtpGeneric->removeFromDevice(filename);
+    }
   }
 #endif
 


### PR DESCRIPTION
### What is the linked issue for this pull request:
[QMS-797](https://github.com/Maproom/qmapshack/issues/797)

### What you have done:
Establish an integration for USB MTP generic devices (Wahho, Hammerhead, mobile phones, etc.) similar to the already existing integration for GARMIN USB MTP devices.

Tested on:
Linux Fedora Workstation 41, GNOME/Wayland for gvfs support
Linux Fedora Workstation 42, KDE/Wayland for kiod6 support

### Steps to perform a simple smoke test:
You need a USB MTP devices
1. Create a JSON file `QmsMtpDevice.json` in the top level storage directory
2. Adapt the JSON file according to your GPS file directory structure
3. Create the GPS file directory structure
4. Optional: Copy an icon to the QMS data directory structure and reference the path in the JSON file  
5. Start QMS
==> You should see the generic device in the workspace tree
6. Perform your actions: Copy, Delete, Sync, ...

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):
- [x] yes

### Is every user facing string in a tr() macro?
- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.
- [x] yes, I didn't forget to change changelog.txt