### PR TITLE
[QMS-799] Fix QMS icon shown in Dash for GNOME/Wayland

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ V1.XX.X
 [QMS-793] Auto-routing with BRouter & minor fixes
 [QMS-794] Fix: Links to local files in Waypoint on-screen dialog not opening
 [QMS-797] Enhance USB MTP to support generic devices
+[QMS-799] Fix QMS icon shown in Dash for GNOME/Wayland
 
 V1.17.1
 [QMS-547] Fixed: QMS freezes on zoom when activating multi-layered online maps

--- a/qmapshack.desktop
+++ b/qmapshack.desktop
@@ -21,3 +21,4 @@ GenericName[ru]= Администрация GPS данных и карт
 Keywords=map;GPS;geocaching;waypoints;tracks;
 MimeType=application/x-gpx;
 StartupNotify=true
+StartupWMClass=org.qlandkarte.qmapshack

--- a/qmaptool.desktop
+++ b/qmaptool.desktop
@@ -11,3 +11,4 @@ GenericName=Tool to create raster maps
 Keywords=map;raster;referencing
 MimeType=application/x-tif;
 StartupNotify=true
+StartupWMClass=org.qlandkarte.qmaptool


### PR DESCRIPTION
### What is the linked issue for this pull request:
[QMS-799](https://github.com/Maproom/qmapshack/issues/799)

### What you have done:
Add StartupWMClass entry to .desktop files for qmapshack and qmaptool.

### Steps to perform a simple smoke test:
1. Start QMS with GNOME/Wayland
2. Check that icon in dash is linked to the QMS app

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):
- [x] yes

### Is every user facing string in a tr() macro?
- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.
- [x] yes, I didn't forget to change changelog.txt
