### PR TITLE
[QMS-807] Fix: No *.qm files when UPDATE_TRANSLATIONS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ option(BUILD_FOR_LOCAL_SYSTEM "Build for local system ONLY (resulting binary mig
 ###############################################################################################
 # Translation options
 ###############################################################################################
-option(UPDATE_TRANSLATIONS "Update translation files" ON)
+option(UPDATE_TRANSLATIONS "Update translation files" OFF)
 option(UPDATE_TRANSLATIONS_PURGE_OBSOLETE "Remove obsolete translations" OFF)
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-807] No *.qm files when UPDATE_TRANSLATIONS=OFF
+
 V1.18.0
 [QMS-558] Support for MTP devices
 [QMS-648] Porting to Qt6

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -887,7 +887,6 @@ set(MAININP
     ${HDRS}
     ${UI_HDRS}
     ${RC_SRCS}
-    ${${APPLICATION_NAME}_QM_FILES}
     ${${APPLICATION_NAME}_DESKTOP_FILES}
 )
 
@@ -922,18 +921,20 @@ if(${UPDATE_TRANSLATIONS_PURGE_OBSOLETE})
 else()
     set(UPDATE_OPTIONS )
 endif()
+
+set( TRANSLATIONS
+    locale/${APPLICATION_NAME}.ts
+    locale/${APPLICATION_NAME}_ca.ts
+    locale/${APPLICATION_NAME}_cs.ts
+    locale/${APPLICATION_NAME}_de.ts
+    locale/${APPLICATION_NAME}_es.ts
+    locale/${APPLICATION_NAME}_fr.ts
+    locale/${APPLICATION_NAME}_it.ts
+    locale/${APPLICATION_NAME}_nl.ts
+    locale/${APPLICATION_NAME}_ru.ts
+)
+
 if(${UPDATE_TRANSLATIONS})
-    set( TRANSLATIONS
-        locale/${APPLICATION_NAME}.ts
-        locale/${APPLICATION_NAME}_ca.ts
-        locale/${APPLICATION_NAME}_cs.ts
-        locale/${APPLICATION_NAME}_de.ts
-        locale/${APPLICATION_NAME}_es.ts
-        locale/${APPLICATION_NAME}_fr.ts
-        locale/${APPLICATION_NAME}_it.ts
-        locale/${APPLICATION_NAME}_nl.ts
-        locale/${APPLICATION_NAME}_ru.ts
-    )
 
     qt_add_translations(${APPLICATION_NAME}
         TS_FILES ${TRANSLATIONS}
@@ -943,8 +944,22 @@ if(${UPDATE_TRANSLATIONS})
         LUPDATE_OPTIONS ${UPDATE_OPTIONS}
     )
     add_dependencies(${APPLICATION_NAME} ${APPLICATION_NAME}_lupdate)
-endif()
+else(${UPDATE_TRANSLATIONS})
+    qt_add_lrelease(
+        TS_FILES  ${TRANSLATIONS}
+        QM_FILES_OUTPUT_VARIABLE ${APPLICATION_NAME}_QM_FILES
+    )
+    qt_add_resources(${APPLICATION_NAME} "translations"
+        PREFIX "/locale"
+        BASE "${CMAKE_CURRENT_BINARY_DIR}"
+        FILES "${${APPLICATION_NAME}_QM_FILES}"
+    )
+endif(${UPDATE_TRANSLATIONS})
 
+
+###############################################################################################
+# Compile definitions
+###############################################################################################
 target_compile_definitions(${APPLICATION_NAME} PUBLIC
     -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
     -DVER_MINOR=${PROJECT_VERSION_MINOR}
@@ -958,6 +973,9 @@ if(${DEVELOPMENT_VERSION})
     )
 endif(${DEVELOPMENT_VERSION})
 
+###############################################################################################
+# Libraries
+###############################################################################################
 if(Qt6DBus_FOUND)
     set(DBUS_LIB Qt6::DBus)
 else(Qt6DBus_FOUND)

--- a/src/qmaptool/CMakeLists.txt
+++ b/src/qmaptool/CMakeLists.txt
@@ -200,7 +200,6 @@ set(MAININP
     ${HDRS}
     ${UI_HDRS}
     ${RC_SRCS}
-    ${${APPLICATION_NAME}_QM_FILES}
     ${${APPLICATION_NAME}_DESKTOP_FILES}
 )
 
@@ -232,15 +231,15 @@ if(${UPDATE_TRANSLATIONS_PURGE_OBSOLETE})
 else()
     set(UPDATE_OPTIONS )
 endif()
-if(${UPDATE_TRANSLATIONS})
-    set( TRANSLATIONS
-        locale/${APPLICATION_NAME}.ts
-        locale/${APPLICATION_NAME}_de.ts
-        locale/${APPLICATION_NAME}_es.ts
-        locale/${APPLICATION_NAME}_it.ts
-        locale/${APPLICATION_NAME}_ru.ts
-    )
+set( TRANSLATIONS
+    locale/${APPLICATION_NAME}.ts
+    locale/${APPLICATION_NAME}_de.ts
+    locale/${APPLICATION_NAME}_es.ts
+    locale/${APPLICATION_NAME}_it.ts
+    locale/${APPLICATION_NAME}_ru.ts
+)
 
+if(${UPDATE_TRANSLATIONS})
     qt_add_translations(${APPLICATION_NAME}
         TS_FILES ${TRANSLATIONS}
         QM_FILES_OUTPUT_VARIABLE ${APPLICATION_NAME}_QM_FILES
@@ -249,7 +248,17 @@ if(${UPDATE_TRANSLATIONS})
         LUPDATE_OPTIONS ${UPDATE_OPTIONS}
     )
     add_dependencies(${APPLICATION_NAME} ${APPLICATION_NAME}_lupdate)
-endif()
+else(${UPDATE_TRANSLATIONS})
+    qt_add_lrelease(
+        TS_FILES  ${TRANSLATIONS}
+        QM_FILES_OUTPUT_VARIABLE ${APPLICATION_NAME}_QM_FILES
+    )
+    qt_add_resources(${APPLICATION_NAME} "translations"
+        PREFIX "/locale"
+        BASE "${CMAKE_CURRENT_BINARY_DIR}"
+        FILES "${${APPLICATION_NAME}_QM_FILES}"
+    )
+endif(${UPDATE_TRANSLATIONS})
 
 
 target_compile_definitions(${APPLICATION_NAME} PUBLIC

--- a/src/qmt_rgb2pct/CMakeLists.txt
+++ b/src/qmt_rgb2pct/CMakeLists.txt
@@ -72,12 +72,12 @@ if(${UPDATE_TRANSLATIONS_PURGE_OBSOLETE})
 else()
     set(UPDATE_OPTIONS )
 endif()
-if(${UPDATE_TRANSLATIONS})
-    set( TRANSLATIONS
-        locale/${APPLICATION_NAME}.ts
-        locale/${APPLICATION_NAME}_de.ts
-    )
+set( TRANSLATIONS
+    locale/${APPLICATION_NAME}.ts
+    locale/${APPLICATION_NAME}_de.ts
+)
 
+if(${UPDATE_TRANSLATIONS})
     qt_add_translations(${APPLICATION_NAME}
         TS_FILES ${TRANSLATIONS}
         QM_FILES_OUTPUT_VARIABLE ${APPLICATION_NAME}_QM_FILES
@@ -86,7 +86,17 @@ if(${UPDATE_TRANSLATIONS})
         LUPDATE_OPTIONS ${UPDATE_OPTIONS}
     )
     add_dependencies(${APPLICATION_NAME} ${APPLICATION_NAME}_lupdate)
-endif()
+else(${UPDATE_TRANSLATIONS})
+    qt_add_lrelease(
+        TS_FILES  ${TRANSLATIONS}
+        QM_FILES_OUTPUT_VARIABLE ${APPLICATION_NAME}_QM_FILES
+    )
+    qt_add_resources(${APPLICATION_NAME} "translations"
+        PREFIX "/locale"
+        BASE "${CMAKE_CURRENT_BINARY_DIR}"
+        FILES "${${APPLICATION_NAME}_QM_FILES}"
+    )
+endif(${UPDATE_TRANSLATIONS})
 
 
 target_compile_definitions(${APPLICATION_NAME} PUBLIC


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#807

### What you have done:
[comment]: # (Describe roughly.)

* Make UPDATE_TRANSLATIONS default off
* Add else branch when UPDATE_TRANSLATIONS=OFF to process *qm files

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
