### PR TITLE
[QMS-809] Improve POI category selection initial layout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-807] No *.qm files when UPDATE_TRANSLATIONS=OFF
+[QMS-809] Improve POI category selection initial layout
 
 V1.18.0
 [QMS-558] Support for MTP devices

--- a/src/qmapshack/poi/CPoiPropSetup.cpp
+++ b/src/qmapshack/poi/CPoiPropSetup.cpp
@@ -31,6 +31,9 @@ CPoiPropSetup::CPoiPropSetup(IPoiFile* poifile, CPoiDraw* poi) : IPoiProp(poifil
 
   poifile->addTreeWidgetItems(treeWidgetCategories);
   treeWidgetCategories->sortItems(eTreeColumnDisplayName, Qt::SortOrder::AscendingOrder);
+  treeWidgetCategories->header()->setSectionResizeMode(0,QHeaderView::ResizeToContents);
+  treeWidgetCategories->resizeColumnToContents(1);
+
   connect(treeWidgetCategories, SIGNAL(itemChanged(QTreeWidgetItem*, int)), poifile,
           SLOT(slotCheckedStateChanged(QTreeWidgetItem*)));
 }

--- a/src/qmapshack/poi/IPoiPropSetup.ui
+++ b/src/qmapshack/poi/IPoiPropSetup.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>244</width>
-    <height>94</height>
+    <width>350</width>
+    <height>209</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -52,7 +52,7 @@
      </property>
      <column>
       <property name="text">
-       <string>Selected</string>
+       <string notr="true"/>
       </property>
      </column>
      <column>


### PR DESCRIPTION

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#809

### What you have done:
[comment]: # (Describe roughly.)

- Replace first column's heading "Selected" by an empty string
- Adjust first column to it's content, making it's width fixed and as small as necessary,
 giving category names maximum space and improve their readability
- Resize second column to it's content, showing a horizontal scrollbar as needed

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)


1.  Activate one item of POI collection
2. Open active POI collection item to see list of categories
3. See that first column is as small as necessary
4. See horizontal scrollbar when needed

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
