### PR TITLE
[QMS-811] Fix 2 fatal tooltip errors with wayland platform

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-807] No *.qm files when UPDATE_TRANSLATIONS=OFF
 [QMS-809] Improve POI category selection initial layout
+[QMS-811] Fix 2 fatal tooltip errors with wayland platform
 
 V1.18.0
 [QMS-558] Support for MTP devices

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -815,7 +815,7 @@ void CCanvas::slotToolTip() {
     }
   }
   QPoint p = mapToGlobal(posToolTip + QPoint(32, 0));
-  QToolTip::showText(p, str);
+  QToolTip::showText(p, str, this);
 }
 
 void CCanvas::slotCheckTrackOnFocus() {

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelectArea.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelectArea.cpp
@@ -53,7 +53,7 @@ bool CRouterBRouterTilesSelectArea::event(QEvent* event) {
       currentTile = tile;
     }
 
-    QToolTip::showText(helpEvent->globalPos(), tileToolTip);
+    QToolTip::showText(helpEvent->globalPos(), tileToolTip, this);
     return true;
   }
   return QWidget::event(event);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#811

### What you have done:
[comment]: # (Describe roughly.)

Fixed 2 fatal tooltip errors occuring with wayland platform
while hovering over
1. POI icons - file `CCanvas.cpp`
2. BRouter offline tile areas - file `CRouterBRouterTilesSelectArea.cpp`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Error 1:
Follow steps **To Reproduce** of issue #811 and notice any more neither of problems described there.

Error 2:
1. Follow steps to **Setup BRouter local installation/offline** until BRouter tile selection window is shown
2. Hover over tiles and notice tooltips popping up
   This was and still is working as expected. 
3. Select at least one tile to download
4. Hit "Cancel" button
5. In confirmation dialog window hit "Continue with Setup" button
6. Hover over tiles and notice tooltips popping up 
  This is now working as expected while before same problems did occur as described there.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
