### PR TITLE
[QMS-824] Non-square icons unaligned, aspect ratio ignored

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-811] Fix 2 fatal tooltip errors with wayland platform
 [QMS-812] Set user defined sizes for waypoint and POI icons
 [QMS-820] Add app specific icon to qmapshack/qmaptool exes on platform Windows
+[QMS-824] Non-square icons unaligned, aspect ratio ignored
 
 V1.18.0
 [QMS-558] Support for MTP devices

--- a/src/qmapshack/gis/IGisItem.cpp
+++ b/src/qmapshack/gis/IGisItem.cpp
@@ -596,18 +596,20 @@ void IGisItem::setIcon(const QPixmap& icon) {
 }
 
 void IGisItem::showIcon() {
+  const int& width = icon.width();
+  const int& height = icon.height();
+  // center icon within surrounding square
+  int size = qMax(width, height);
+  displayIcon = QPixmap(size, size);
+  displayIcon.fill(Qt::transparent);
+  QPainter painter(&displayIcon);
+  int dw = (size-width) / 2;
+  int dh = (size-height) / 2;
+  painter.drawPixmap(dw, dh, icon);
   if (isNogo()) {
-    const int& width = icon.width();
-    const int& height = icon.height();
-    displayIcon = QPixmap(width, height);
-    displayIcon.fill(Qt::transparent);
-    QPainter painter(&displayIcon);
-    painter.drawPixmap(0, 0, icon);
-    painter.drawPixmap(width * 0.4, height * 0.4,
+    painter.drawPixmap(width * 0.4 + dw, height * 0.4 + dh,
                        QPixmap("://icons/48x48/NoGo.png")
                            .scaled(width * 0.6, height * 0.6, Qt::KeepAspectRatio, Qt::SmoothTransformation));
-  } else {
-    displayIcon = icon;
   }
   QTreeWidgetItem::setIcon(CGisListWks::eColumnIcon, displayIcon);
 }

--- a/src/qmapshack/plot/IPlot.cpp
+++ b/src/qmapshack/plot/IPlot.cpp
@@ -1098,7 +1098,7 @@ void IPlot::drawTags(QPainter& p) {
       continue;
     }
 
-    QPixmap icon = tag.icon.scaled(iconBarHeight, iconBarHeight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    QPixmap icon = tag.icon.scaled(iconBarHeight, iconBarHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     p.drawPixmap(ptx - icon.width() / 2, 2, icon);
 
     if (pty > bottom) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#824

### What you have done:
[comment]: # (Describe roughly.)

Vertically align non-square project tree icons.
Keep aspect ratio of non-square track profile icons.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Create non-square user defined waypoint icon
2. Create waypoint with built-in square icon and add to project
3. Create waypoint with user defined non-square icon and add to project
4. Create track containing waypoints and add to project
5. See that icons in project tree are now vertically aligned
6. Show track profile in separate window
7. See that aspect ratio of non-square icon is now kept

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
