### PR TITLE
[QMS-826] Fix: "to next" values missing in project diary

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-812] Set user defined sizes for waypoint and POI icons
 [QMS-820] Add app specific icon to qmapshack/qmaptool exes on platform Windows
 [QMS-824] Non-square icons unaligned, aspect ratio ignored
+[QMS-826] Fix: "to next" values missing in project diary
 
 V1.18.0
 [QMS-558] Support for MTP devices

--- a/src/qmapshack/IAbout.ui
+++ b/src/qmapshack/IAbout.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>IAbout</class>
  <widget class="QDialog" name="IAbout">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>580</width>
-    <height>442</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>About....</string>
   </property>
@@ -149,6 +141,12 @@
      </item>
      <item>
       <widget class="QLabel" name="labelContributors">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>-</string>
        </property>

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -449,7 +449,7 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor, QList<CGisItemTrk*>& trks, QL
 
     cnt = 1;
     for (CGisItemWpt* wpt : wpts) {
-      PROGRESS(n++, return );
+      PROGRESS(n++, return);
 
       addIcon(table, eSym1, cnt, wpt->getDisplayIcon(), wpt->getKey().item, wpt->isReadOnly(), printable);
       table->cellAt(cnt, eInfo1).firstCursorPosition().insertHtml(wpt->getInfo(IGisItem::eFeatureShowName));
@@ -478,7 +478,7 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor, QList<CGisItemTrk*>& trks, QL
     cnt = 1;
 
     for (CGisItemTrk* trk : trks) {
-      PROGRESS(n++, return );
+      PROGRESS(n++, return);
 
       addIcon(table, eSym1, cnt, trk->getDisplayIcon(), trk->getKey().item, trk->isReadOnly(), printable);
 
@@ -558,8 +558,7 @@ struct wpt_info_t {
 QList<wpt_info_t> CDetailsPrj::getWptInfo(const CGisItemTrk& trk) const {
   int cnt = 1;
   const CTrackData::trkpt_t* lastTrkpt = nullptr;
-  QList<wpt_info_t> wptInfo;
-  wpt_info_t* lastWptInfo = nullptr;
+  QVector<wpt_info_t> wptInfo;
   bool hasValidTime = trk.getTimeStart().isValid();
 
   const CTrackData& t = trk.getTrackData();
@@ -616,7 +615,8 @@ QList<wpt_info_t> CDetailsPrj::getWptInfo(const CGisItemTrk& trk) const {
     info.ascent1 = trkpt.ascent;
     info.descent1 = trkpt.descent;
 
-    if (lastWptInfo != nullptr) {
+    if (wptInfo.size() > 1) {
+      wpt_info_t* lastWptInfo = &(*(wptInfo.end() - 2));
       lastWptInfo->distance2 = trkpt.distance - lastTrkpt->distance;
       lastWptInfo->elapsedSeconds2 = trkpt.elapsedSeconds - lastTrkpt->elapsedSeconds;
       lastWptInfo->ascent2 = trkpt.ascent - lastTrkpt->ascent;
@@ -629,7 +629,6 @@ QList<wpt_info_t> CDetailsPrj::getWptInfo(const CGisItemTrk& trk) const {
     info.descent3 = trk.getTotalDescent() - trkpt.descent;
 
     lastTrkpt = &trkpt;
-    lastWptInfo = &wptInfo.last();
   }
 
   return wptInfo;
@@ -740,7 +739,7 @@ void CDetailsPrj::drawByTrack(QTextCursor& cursor, QList<CGisItemTrk*>& trks, QL
 
     int cnt = 1;
     for (const wpt_info_t& info : wptInfo) {
-      PROGRESS(n++, return );
+      PROGRESS(n++, return);
 
       addIcon(table, eSym2, cnt, info.icon, info.key.item, info.isReadOnly, printable);
       table->cellAt(cnt, eInfo2).firstCursorPosition().insertHtml(getNameAndTime(info, *trk));
@@ -807,7 +806,7 @@ void CDetailsPrj::drawByDetails(QTextCursor& cursor, QList<CGisItemTrk*>& trks, 
 
     int cnt = 1;
     for (const wpt_info_t& info : wptInfo) {
-      PROGRESS(n++, return );
+      PROGRESS(n++, return);
 
       // 1st column
       addIcon(table, eSym2, cnt, info.icon, info.key.item, info.isReadOnly, printable);
@@ -868,7 +867,7 @@ void CDetailsPrj::drawArea(QTextCursor& cursor, QList<CGisItemOvlArea*>& areas, 
 
   int cnt = 1;
   for (CGisItemOvlArea* area : areas) {
-    PROGRESS(n++, return );
+    PROGRESS(n++, return);
 
     addIcon(table, eSym1, cnt, area->getDisplayIcon(), area->getKey().item, area->isReadOnly(), printable);
     table->cellAt(cnt, eInfo1).firstCursorPosition().insertHtml(area->getInfo(IGisItem::eFeatureShowName));
@@ -900,7 +899,7 @@ void CDetailsPrj::drawRoute(QTextCursor& cursor, QList<CGisItemRte*>& rtes, CPro
 
   int cnt = 1;
   for (CGisItemRte* rte : rtes) {
-    PROGRESS(n++, return );
+    PROGRESS(n++, return);
 
     addIcon(table, eSym1, cnt, rte->getDisplayIcon(), rte->getKey().item, rte->isReadOnly(), printable);
     table->cellAt(cnt, eInfo1).firstCursorPosition().insertHtml(rte->getInfo(IGisItem::eFeatureShowName));


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#826

### What you have done:
[comment]: # (Describe roughly.)

Somehow referencing items of a list/vector by a pointer while appending the list/vector is a bad idea. Therefore create a temporary pointer on-the-fly if the list is large enough


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
