### PR TITLE
[QMS-831] CMainWindow.cpp compile error on OS Windows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-824] Non-square icons unaligned, aspect ratio ignored
 [QMS-826] Fix: "to next" values missing in project diary
 [QMS-829] Broken online DEM freezes application
+[QMS-831] Fix: CMainWindow.cpp compile error on OS Windows
 
 V1.18.0
 [QMS-558] Support for MTP devices

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -70,11 +70,11 @@
 #include "version.h"
 
 #ifdef Q_OS_WIN64
+#include <windows.h>
 #include <dbt.h>
 #include <guiddef.h>
 #include <initguid.h>
 #include <usbiodef.h>
-#include <windows.h>
 
 #include "device/CDeviceWatcherWindows.h"
 #endif  // Q_OS_WIN64


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#831

### What you have done:
[comment]: # (Describe roughly.)
Moving statement `#include <windows.h>` back to previous position before statement `#include <dbt.h>` .


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Try to build project `qmapshack` with Visual Studio 2022
2. See that build is successful.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
