### PR TITLE
[QMS-834] Non-antialiased scaled track profile

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-826] Fix: "to next" values missing in project diary
 [QMS-829] Broken online DEM freezes application
 [QMS-831] Fix: CMainWindow.cpp compile error on OS Windows
+[QMS-834] Non-antialiased scaled track profile
 
 V1.18.0
 [QMS-558] Support for MTP devices

--- a/src/qmapshack/plot/IPlot.cpp
+++ b/src/qmapshack/plot/IPlot.cpp
@@ -201,6 +201,7 @@ void IPlot::resetZoom() {
 
 void IPlot::paintEvent(QPaintEvent* /*e*/) {
   QPainter p(this);
+  USE_ANTI_ALIASING(p, true);
   draw(p);
 }
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#834

### What you have done:
[comment]: # (Describe roughly.)

Added statement `USE_ANTI_ALIASING(p, true);`
to file `src/qmapshack/plot/IPlot.cpp` procedure `IPlot::paintEvent`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Set environment variable QT_SCALE_FACTOR to a value different from 1.0, e.g. to value 1.25
2. Run QMS within environment
3. Notice entire QMS application's main window is smoothly scaled
4. Create track with waypoints
5. Show track's profile in toplevel window
6. **Notice line edges, icons and text in track's profile window are now smoothly scaled too** 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
