### PR TITLE
[QMS-847] Remove duplicate Parking Area waypoint icon

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 [QMS-841] Fix waypoint names to match the Garmin symbols
 [QMS-843] Add waypoint icons
+[QMS-847] Remove duplicate Parking Area waypoint icon
 
 V1.18.1
 [QMS-659] POI file error and version handling

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -143,7 +143,6 @@ void CWptIconManager::init() {
   wptIcons["Number 9, Red"] = icon_t("://icons/waypoints/32x32/Number9Red.png", 16, 16);
   wptIcons["Number 9, Blue"] = icon_t("://icons/waypoints/32x32/Number9Blue.png", 16, 16);
   wptIcons["Number 9, Green"] = icon_t("://icons/waypoints/32x32/Number9Green.png", 16, 16);
-  wptIcons["Parking Area"] = icon_t("://icons/cache/32x32/parking.png", 16, 16);
   wptIcons["Trail Head"] = icon_t("://icons/cache/32x32/trailhead.png", 16, 16);
   wptIcons["Sad Face"] = icon_t("://icons/cache/32x32/dnf.png", 16, 16);
   wptIcons["Contact, Smiley"] = icon_t("://icons/cache/32x32/found.png", 16, 16);


### PR DESCRIPTION
### What is the linked issue for this pull request:

QMS-#847

### What you have done:

Removed the icon using the geocaching set which is not consistent with the icon used for Parking, Pay.

### Steps to perform a simple smoke test:

1. `grep "Parking Area" src/qmapshack/helpers/CWptIconManager.cpp`
2. See single result

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
