### PR TITLE
[QMS-672] Fix track point timestamps to QDateTime UTC conversion

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+V1.XX.X
+[QMS-672] Fix track point timestamps to QDateTime UTC conversion
 [QMS-841] Fix waypoint names to match the Garmin symbols
 [QMS-843] Add waypoint icons
 [QMS-847] Remove duplicate Parking Area waypoint icon

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -651,68 +651,8 @@ void IUnit::seconds2time(quint32 ttime, QString& val, QString& unit) const {
 }
 
 bool IUnit::parseTimestamp(const QString& time, QDateTime& datetime) {
-  int tzoffset;
-  datetime = parseTimestamp(time, tzoffset);
-
+  datetime = QDateTime::fromString(time, Qt::ISODateWithMs);
   return datetime.isValid();
-}
-
-QDateTime IUnit::parseTimestamp(const QString& timetext, int& tzoffset) {
-  static const QRegularExpression tzRE("[-+]\\d\\d:\\d\\d$");
-  int i;
-
-  tzoffset = 0;
-  bool applyTzOffset = false;
-
-  QString format = "yyyy-MM-dd'T'hh:mm:ss";
-
-  i = timetext.indexOf(".");
-  if (i != NOIDX) {
-    if (timetext[i + 1] == '0') {
-      format += ".zzz";
-    } else {
-      format += ".z";
-    }
-  }
-
-  // trailing "Z" explicitly declares the timestamp to be UTC
-  if (timetext.indexOf("Z") != NOIDX) {
-    format += "'Z'";
-    applyTzOffset = true;
-  } else if ((i = timetext.indexOf(tzRE)) != NOIDX) {
-    // trailing timezone offset [-+]HH:MM present
-    // This does not match the original intentions of the GPX
-    // file format but appears to be found occasionally in
-    // the wild.  Try our best parsing it.
-
-    // add the literal string to the format so fromString()
-    // will succeed
-    format += "'";
-    format += timetext.right(6);
-    format += "'";
-
-    // calculate the offset
-    int offsetHours(timetext.mid(i + 1, 2).toUInt());
-    int offsetMinutes(timetext.mid(i + 4, 2).toUInt());
-    if (timetext[i] == '-') {
-      tzoffset = -(60 * offsetHours + offsetMinutes);
-    } else {
-      tzoffset = 60 * offsetHours + offsetMinutes;
-    }
-    tzoffset *= 60;  // seconds
-    applyTzOffset = true;
-  }
-
-  QDateTime datetime = QDateTime::fromString(timetext, format);
-
-  if (applyTzOffset) {
-    datetime.setTimeZone(QTimeZone::fromSecondsAheadOfUtc(tzoffset));
-  } else {  // if timetext has no 'Z' and no [-+]HH:MM then this is local time then simply switch to UTC without
-            // applying any offset
-    datetime = datetime.toUTC();
-  }
-
-  return datetime;
 }
 
 QString IUnit::datetime2string(const QDateTime& time, time_format_e format, const QPointF& pos) {

--- a/src/qmapshack/units/IUnit.h
+++ b/src/qmapshack/units/IUnit.h
@@ -147,8 +147,6 @@ class IUnit : public QObject {
 
   static slope_mode_e slopeMode;
 
-  static QDateTime parseTimestamp(const QString& timetext, int& tzoffset);
-
   static tz_mode_e timeZoneMode;
   static QByteArray timeZone;
   static bool useShortFormat;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#672

### What you have done:
[comment]: # (Describe roughly.)

Replaced  track point ISO 8601 timestamps to QDateTime UTC conversion by one-liner
_QDateTime::fromString(time, Qt::ISODateWithMs)_

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Set your PC's time zone to whatever, e.g. to 'Australia/Melbourne'
2. Run QMS
3. Set QMS internal time zone to whatever
4. Import GPX example files attached to issue report
5. Regardless of time zone(s), have no "Invalid points" messages any more 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
