### PR TITLE
[QMS-851] Fix GIS item bubbles get transparent

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-841] Fix waypoint names to match the Garmin symbols
 [QMS-843] Add waypoint icons
 [QMS-847] Remove duplicate Parking Area waypoint icon
+[QMS-851] Fix GIS item bubbles get transparent
 
 V1.18.1
 [QMS-659] POI file error and version handling

--- a/src/qmapshack/mouse/IScrOpt.cpp
+++ b/src/qmapshack/mouse/IScrOpt.cpp
@@ -70,6 +70,11 @@ void IScrOpt::leaveEvent(QEvent* e) {
   }
 }
 
+void IScrOpt::paintEvent(QPaintEvent* e) {
+  QPainter p(this);
+  draw(p);
+}
+
 void IScrOpt::slotLinkActivated(const QString& link) {
   if (link.startsWith("http")) {
     QDesktopServices::openUrl(QUrl(link));

--- a/src/qmapshack/mouse/IScrOpt.h
+++ b/src/qmapshack/mouse/IScrOpt.h
@@ -20,13 +20,12 @@
 #define ISCROPT_H
 
 #include <QMouseEvent>
-#include <QPixmap>
 #include <QPointer>
-#include <QRect>
 #include <QSemaphore>
 #include <QWidget>
 
 class IMouse;
+class QMouseEvent;
 
 #define SCR_OPT_OFFSET 15
 
@@ -54,6 +53,8 @@ class IScrOpt : public QWidget {
   void mousePressEvent(QMouseEvent* e) override { e->accept(); }
   // block mouse actions to hit the canvas
   void mouseMoveEvent(QMouseEvent* e) override { e->accept(); }
+
+  void paintEvent(QPaintEvent* e);
 
   void moveTo(const QPoint& anchor);
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#851

### What you have done:
[comment]: # (Describe roughly.)

Add paintEvent() to IScrOpt and call the draw() method to redraw the bubble

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
