### PR TITLE
[QMS-851] Hide screen option bubbles when tool button is triggered.

### DIFF
--- a/src/qmapshack/gis/ovl/CScrOptOvlArea.cpp
+++ b/src/qmapshack/gis/ovl/CScrOptOvlArea.cpp
@@ -55,36 +55,42 @@ CScrOptOvlArea::~CScrOptOvlArea() {}
 
 void CScrOptOvlArea::slotEditDetails() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editItemByKey(key);
   close();
 }
 
 void CScrOptOvlArea::slotCopy() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().copyItemByKey(key);
   close();
 }
 
 void CScrOptOvlArea::slotDelete() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().delItemByKey(key);
   close();
 }
 
 void CScrOptOvlArea::slotEdit() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editAreaByKey(key);
   close();
 }
 
 void CScrOptOvlArea::slotNogo() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().toggleNogoItem(key);
   close();
 }
 
 void CScrOptOvlArea::slotTags() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().tagItemsByKey({key});
   close();
 }

--- a/src/qmapshack/gis/rte/CScrOptRte.cpp
+++ b/src/qmapshack/gis/rte/CScrOptRte.cpp
@@ -65,66 +65,77 @@ CScrOptRte::~CScrOptRte() {}
 
 void CScrOptRte::slotEditDetails() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editItemByKey(key);
   close();
 }
 
 void CScrOptRte::slotDelete() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().delItemByKey(key);
   close();
 }
 
 void CScrOptRte::slotCopy() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().copyItemByKey(key);
   close();
 }
 
 void CScrOptRte::slotCalc() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().calcRteByKey(key);
   close();
 }
 
 void CScrOptRte::slotReset() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().resetRteByKey(key);
   close();
 }
 
 void CScrOptRte::slotEdit() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editRteByKey(key);
   close();
 }
 
 void CScrOptRte::slotReverse() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().reverseRteByKey(key);
   close();
 }
 
 void CScrOptRte::slotInstruction(bool on) {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().focusRteByKey(on, key);
   close();
 }
 
 void CScrOptRte::slotToTrack() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().convertRouteToTrack(key);
   close();
 }
 
 void CScrOptRte::slotNogo() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().toggleNogoItem(key);
   close();
 }
 
 void CScrOptRte::slotTags() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().tagItemsByKey({key});
   close();
 }

--- a/src/qmapshack/gis/trk/CScrOptTrk.cpp
+++ b/src/qmapshack/gis/trk/CScrOptTrk.cpp
@@ -87,54 +87,63 @@ CScrOptTrk::~CScrOptTrk() {}
 
 void CScrOptTrk::slotDelete() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().delItemByKey(key);
   close();
 }
 
 void CScrOptTrk::slotCopy() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().copyItemByKey(key);
   close();
 }
 
 void CScrOptTrk::slotEditDetails() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editItemByKey(key);
   close();
 }
 
 void CScrOptTrk::slotProfile(bool on) {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().focusTrkByKey(on, key);
   close();
 }
 
 void CScrOptTrk::slotCut() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().cutTrkByKey(key);
   close();
 }
 
 void CScrOptTrk::slotEdit() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editTrkByKey(key);
   close();
 }
 
 void CScrOptTrk::slotReverse() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().reverseTrkByKey(key);
   close();
 }
 
 void CScrOptTrk::slotCombine() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().combineTrkByKey(key);
   close();
 }
 
 void CScrOptTrk::slotRange() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   mouse = nullptr;
   CGisWorkspace::self().rangeTrkByKey(key);
   close();
@@ -142,50 +151,56 @@ void CScrOptTrk::slotRange() {
 
 void CScrOptTrk::slotActivity() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CActivityTrk::getMenu(key, this, true);
   close();
 }
 
 void CScrOptTrk::slotColor() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().colorTrkByKey({key});
   close();
 }
 
 void CScrOptTrk::slotCopyWithWpt() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().copyTrkWithWptByKey(key);
   close();
 }
 
 void CScrOptTrk::slotNogo() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().toggleNogoItem(key);
   close();
 }
 
 void CScrOptTrk::slotAddElevation() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().addEleToWptTrkByKey({key});
   close();
 }
 
 void CScrOptTrk::slotAddInfo() {
-  close();
-
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().addTrkInfoByKey(key);
+  close();
 }
 
 void CScrOptTrk::slotToRoute() {
-  close();
-
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().convertTrackToRoute(key);
+  close();
 }
 
 void CScrOptTrk::slotTags() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().tagItemsByKey({key});
   close();
 }

--- a/src/qmapshack/gis/wpt/CScrOptWpt.cpp
+++ b/src/qmapshack/gis/wpt/CScrOptWpt.cpp
@@ -71,78 +71,91 @@ CScrOptWpt::~CScrOptWpt() {}
 
 void CScrOptWpt::slotDelete() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().delItemByKey(key);
   close();
 }
 
 void CScrOptWpt::slotEdit() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editItemByKey(key);
   close();
 }
 
 void CScrOptWpt::slotCopy() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().copyItemByKey(key);
   close();
 }
 
 void CScrOptWpt::slotCoordToClipboard() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().copyWptCoordByKey(key);
   close();
 }
 
 void CScrOptWpt::slotMove() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().moveWptByKey(key);
   close();
 }
 
 void CScrOptWpt::slotProj() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().projWptByKey(key);
   close();
 }
 
 void CScrOptWpt::slotBubble() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().toggleWptBubble(key);
   close();
 }
 
 void CScrOptWpt::slotDeleteRadius() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().deleteWptRadius(key);
   close();
 }
 
 void CScrOptWpt::slotNogoArea() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().toggleNogoItem(key);
   close();
 }
 
 void CScrOptWpt::slotEditRadius() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().editWptRadius(key);
   close();
 }
 
 void CScrOptWpt::slotAddElevation() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().addEleToWptTrkByKey({key});
   close();
 }
 
 void CScrOptWpt::slotSearchWeb() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().searchWebByKey(key);
   close();
 }
 
 void CScrOptWpt::slotTags() {
   CScrOptSemaphoreLocker lock(*this);
+  hide();
   CGisWorkspace::self().tagItemsByKey({key});
   close();
 }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#851

### What you have done:
[comment]: # (Describe roughly.)

Screen options are hidden when a tool button is clicked.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use screen options. They disappear the moment you press one of their tool buttons

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
