### PR TITLE
[QMS-861] Add action to clear the waypoint icon history

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-851] Fix GIS item bubbles get transparent
 [QMS-855] Code cleanup: Convert waypoint icon map into a list
 [QMS-859] Add waypoint icons
+[QMS-861] Add action to clear the waypoint icon history 
 
 V1.18.1
 [QMS-659] POI file error and version handling

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -1244,7 +1244,8 @@ void CWptIconManager::init() {
   QDir dirIcon(
       cfg.value("Paths/externalWptIcons", IAppSetup::getPlatformInstance()->userDataPath("WaypointIcons")).toString());
 
-  QDirIterator it(dirIcon.path(), {"*.bmp", "*.png"}, QDir::Files, QDirIterator::Subdirectories|QDirIterator::FollowSymlinks);
+  QDirIterator it(dirIcon.path(), {"*.bmp", "*.png"}, QDir::Files,
+                  QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
   while (it.hasNext()) {
     it.next();
     const QString& name = QFileInfo(it.fileName()).completeBaseName();
@@ -1356,11 +1357,17 @@ QString CWptIconManager::selectWptIcon(QWidget* parent) {
   QPointer<QMenu> menu = getWptIconMenu(parent);
 
   // add an action that summons the wayoint icon dialog
-  QAction* more = menu->addAction(tr("more..."));
+  QAction* more = menu->addAction(QIcon(":/icons/32x32/SetupWptSym.png"), tr("More..."));
   connect(more, &QAction::triggered, this, [&icon, this](bool) {
     CWptIconDialog dlg(&CMainWindow::self());
     connect(&dlg, &CWptIconDialog::sigSelectedIcon, this, [&icon](const QString& name) { icon = name; });
     dlg.exec();
+  });
+
+  QAction* clear = menu->addAction(QIcon(":/icons/32x32/Cancel.png"), tr("Clear History"));
+  connect(clear, &QAction::triggered, this, [](bool) {
+    SETTINGS;
+    cfg.setValue("Icons/lastIcons", {"Waypoint"});
   });
 
   // display the menu and block until mouse click

--- a/src/qmapshack/widgets/CWptIconSelectWidget.cpp
+++ b/src/qmapshack/widgets/CWptIconSelectWidget.cpp
@@ -157,6 +157,7 @@ void CWptIconSelectWidget::updateIconList(const QString &filter, const QString &
   iconFilterCompleter->setCaseSensitivity(Qt::CaseInsensitive);
   iconFilterCompleter->setFilterMode(Qt::MatchContains);
   iconFilterCompleter->setCompletionMode(QCompleter::UnfilteredPopupCompletion);
+  iconFilterCompleter->setModelSorting(QCompleter::CaseSensitivelySortedModel);
   iconFilter->setCompleter(iconFilterCompleter);
   iconGrid->updateIconList(visibleIcons);
   scrollArea->verticalScrollBar()->setValue(0);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#861

### What you have done:
[comment]: # (Describe roughly.)

* Added action to clear history 
* Fixed icons for actions in waypoint icon menu

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Edit waypoint icon and use entry to clear the list

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
