### PR TITLE
[QMS-857] Fix crash in track profile using QT >6.10

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-850] Add custom icons from external icons folder and subfolders
 [QMS-851] Fix GIS item bubbles get transparent
 [QMS-855] Code cleanup: Convert waypoint icon map into a list
+[QMS-857] Fix crash in track profile using QT >6.10
 [QMS-859] Add waypoint icons
 [QMS-861] Add action to clear the waypoint icon history 
 [QMS-863] Fixing QFILE_MAYBE_NODISCARD warnings for Qt 6.10 and more recent

--- a/src/qmapshack/plot/CPlot.cpp
+++ b/src/qmapshack/plot/CPlot.cpp
@@ -81,6 +81,10 @@ void CPlot::updateData() {
 }
 
 void CPlot::setMouseFocus(const CTrackData::trkpt_t* ptMouseMove) {
+  if (noOrBadData()) {
+    return;
+  }
+
   if (nullptr == ptMouseMove || getX == nullptr || getY == nullptr) {
     if (posMouse1 != NOPOINT) {
       posMouse1 = NOPOINT;

--- a/src/qmapshack/plot/CPlotAxis.h
+++ b/src/qmapshack/plot/CPlotAxis.h
@@ -21,6 +21,8 @@
 
 #include <QObject>
 
+#include "units/IUnit.h"
+
 class QFontMetrics;
 
 class CPlotAxis : public QObject {
@@ -69,7 +71,7 @@ class CPlotAxis : public QObject {
   virtual void getLimits(qreal& limMin, qreal& limMax, qreal& useMin, qreal& useMax);
 
   inline int val2pt(qreal val) const {
-    if (scale == 0) {
+    if (scale == 0 || scale == INFINITY || val == NOFLOAT) {
       return 0;
     }
     return qRound((val - usedMin) * scale);

--- a/src/qmapshack/plot/IPlot.h
+++ b/src/qmapshack/plot/IPlot.h
@@ -65,6 +65,7 @@ class IPlot : public QWidget, public INotifyTrk {
   void slotAddTrkPtInfo();
 
  protected:
+  bool noOrBadData();
   void setXTicScale(qreal scale);
   void setYLabel(const QString& str);
   void setXLabel(const QString& str);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#857

### What you have done:
[comment]: # (Describe roughly.)

Added quite a bunch of sanity checks in the code. 

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Use profile plots excessively.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
