### PR TITLE
[QMS-871] Partial fix: Routino & installation folder name with non-ASCII-characters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-871] Partly fix: Routino & installation folder name with non-ASCII characters
+
 V1.18.2
 [QMS-672] Fix track point timestamps to QDateTime UTC conversion
 [QMS-841] Fix waypoint names to match the Garmin symbols

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -32,6 +32,12 @@
 #include "helpers/CSettings.h"
 #include "setup/IAppSetup.h"
 
+#ifdef Q_OS_WIN
+#define ROUTINO_PATH_ENCODING toLocal8Bit()
+#else
+#define ROUTINO_PATH_ENCODING toUtf8()
+#endif
+
 QPointer<CProgressDialog> CRouterRoutino::progress;
 
 int ProgressFunc(double complete) {
@@ -66,7 +72,7 @@ CRouterRoutino::CRouterRoutino(QWidget* parent) : IRouter(true, parent) {
 
   int res = 0;
   IAppSetup* setup = IAppSetup::getPlatformInstance();
-  res = Routino_ParseXMLTranslations(setup->routinoPath("translations.xml").toUtf8());
+  res = Routino_ParseXMLTranslations(setup->routinoPath("translations.xml").ROUTINO_PATH_ENCODING);
   if (res) {
     QMessageBox::critical(this, "Routino...", xlateRoutinoError(Routino_errno), QMessageBox::Abort);
     return;
@@ -235,11 +241,7 @@ void CRouterRoutino::buildDatabaseList() {
 
       // qDebug() << "buildDatabase Prefix" << prefix;
 
-#ifdef Q_OS_WIN
-      Routino_Database* data = Routino_LoadDatabase(dir.absolutePath().toLocal8Bit(), prefix.toLocal8Bit());
-#else
-      Routino_Database* data = Routino_LoadDatabase(dir.absolutePath().toUtf8(), prefix.toUtf8());
-#endif
+      Routino_Database* data = Routino_LoadDatabase(dir.absolutePath().ROUTINO_PATH_ENCODING, prefix.ROUTINO_PATH_ENCODING);
       qDebug() << "Loaded Routino DB" << dir.absolutePath().toUtf8().data() << "  " << prefix.toUtf8().data();
 
       if (data == nullptr) {
@@ -306,7 +308,7 @@ int CRouterRoutino::loadProfiles(const QString& profilesPath) {
   int res = 0;
   if (currentProfilesPath != profilesPath) {
     currentProfilesPath = profilesPath;
-    res = Routino_ParseXMLProfiles(profilesPath.toUtf8());
+    res = Routino_ParseXMLProfiles(profilesPath.ROUTINO_PATH_ENCODING);
   }
   return res;
 }
@@ -345,11 +347,11 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key) {
     QString strProfile = comboProfile->currentData(Qt::UserRole).toString();
     QString strLanguage = comboLanguage->currentData(Qt::UserRole).toString();
 
-    Routino_Profile* profile = Routino_GetProfile(strProfile.toUtf8());
+    Routino_Profile* profile = Routino_GetProfile(strProfile.ROUTINO_PATH_ENCODING);
     if (profile == NULL) {
       throw tr("Required profile '%1' is not in the current profiles file.").arg(strProfile);
     }
-    Routino_Translation* translation = Routino_GetTranslation(strLanguage.toUtf8());
+    Routino_Translation* translation = Routino_GetTranslation(strLanguage.ROUTINO_PATH_ENCODING);
 
     int res = Routino_ValidateProfile(data, profile);
     if (res != 0) {
@@ -420,11 +422,11 @@ int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
     QString strProfile = comboProfile->currentData(Qt::UserRole).toString();
     QString strLanguage = comboLanguage->currentData(Qt::UserRole).toString();
 
-    Routino_Profile* profile = Routino_GetProfile(strProfile.toUtf8());
+    Routino_Profile* profile = Routino_GetProfile(strProfile.ROUTINO_PATH_ENCODING);
     if (profile == NULL) {
       throw tr("Required profile '%1' is not in the current profiles file.").arg(strProfile);
     }
-    Routino_Translation* translation = Routino_GetTranslation(strLanguage.toUtf8());
+    Routino_Translation* translation = Routino_GetTranslation(strLanguage.ROUTINO_PATH_ENCODING);
 
     int res = Routino_ValidateProfile(data, profile);
     if (res != 0) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#871

As issues mentioned there have different causes, this code fix only covers the Routino problem, issue screenshot 1.

Routino software is using POSIX functions for file access. By default, Microsoft's POSIX implementation is not Unicode aware.
According to [here](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170), **valid** Windows filenames passed to functions depend on system's current ANSI codepage.
System's ANSI codepage can be checked by Windows console command 
`REG QUERY "HKLM\SYSTEM\CurrentControlSet\Control\Nls\CodePage" -v ACP|find /I "ACP"` 
Western Europe ANSI codepage is usually 1252, see it's character set [here](https://en.wikipedia.org/wiki/Windows-1252).

At least since some Windows 10 release, there is a switch called _Beta: Use Unicode UTF-8 for worldwide language support_ to be found at _Settings -> Time & language -> Language & region -> Administrative language settings -> Change system locale_:
<img width="482" height="541" alt="Clipboard 1" src="https://github.com/user-attachments/assets/299db0e8-8d22-4367-b8df-7dbdb972d119" />
When enabled, above console command returns codepage 65001 = Unicode (UTF-8).

To fix issue screenshot 2 too, enable _Use Unicode UTF-8 for worldwide language support_.

### What you have done:
[comment]: # (Describe roughly.)
On Windows OS, all filenames passed from QMS to Routino functions are now using system's local encoding.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Rename QMS installation folder on Windows OS to folder name containing non-ASCII character from current ANSI character set,
  e.g. folder name _qmapshack-installation-äéø_ containing characters "ä", "é", "ø", etc. when your system's ANSI codepage is 1252
  or
  e.g. folder name _qmapshack-installation-äéøαв_ containing characters "ä", "é", "ø", "α", "в" etc. when your system's ANSI codepage is 65001
2. Run QMS from that folder
3. Do not see any more error message about Routino's missing XML language file
4. Verify that Routino router can be configured and is working as expected
5. When ANSI codepage is 65001, verify that tools internally called by QMS like "VRT Builder", "QMapTool", etc. are working as expected

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
