### PR TITLE
[QMS-876] Ghost track at right click of highlighted track

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-869] Convert track to area
 [QMS-871] Partly fix: Routino & installation folder name with non-ASCII characters
+[QMS-876] Ghost track at right click of highlighted track
 
 V1.18.2
 [QMS-672] Fix track point timestamps to QDateTime UTC conversion

--- a/src/qmapshack/mouse/IScrOpt.cpp
+++ b/src/qmapshack/mouse/IScrOpt.cpp
@@ -70,11 +70,6 @@ void IScrOpt::leaveEvent(QEvent* e) {
   }
 }
 
-void IScrOpt::paintEvent(QPaintEvent* e) {
-  QPainter p(this);
-  draw(p);
-}
-
 void IScrOpt::slotLinkActivated(const QString& link) {
   if (link.startsWith("http")) {
     QDesktopServices::openUrl(QUrl(link));

--- a/src/qmapshack/mouse/IScrOpt.h
+++ b/src/qmapshack/mouse/IScrOpt.h
@@ -54,8 +54,6 @@ class IScrOpt : public QWidget {
   // block mouse actions to hit the canvas
   void mouseMoveEvent(QMouseEvent* e) override { e->accept(); }
 
-  void paintEvent(QPaintEvent* e) override;
-
   void moveTo(const QPoint& anchor);
 
   QPoint origin;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#876

### What you have done:
[comment]: # (Describe roughly.)

I have undone commit https://github.com/Maproom/qmapshack/commit/a725ee5421ca421d321e4e0948d9429324eb1d1d (https://github.com/Maproom/qmapshack/issues/851)

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Follow "To Reproduce" instructions described at issue [#876](https://github.com/Maproom/qmapshack/issues/876)
2. Do not see any ghost tracks/areas/waypoints/menu borders on context window any more

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
