### PR TITLE
[QMS-884] Add command line option to query QMS version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-876] Ghost track at right click of highlighted track
 [QMS-878] BRouter: no route time, no turn points, no navigation instructions
 [QMS-882] Add visibility indicator to maps and DEM
+[QMS-884] Add command line option to query QMS version
 
 V1.18.2
 [QMS-672] Fix track point timestamps to QDateTime UTC conversion

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv) {
   QCoreApplication::setApplicationName("QMapShack");
   QCoreApplication::setOrganizationName("QLandkarte");
   QCoreApplication::setOrganizationDomain("qlandkarte.org");
+  QCoreApplication::setApplicationVersion(VER_STR);
 
   IAppSetup* env = IAppSetup::getPlatformInstance();
   env->processArguments();

--- a/src/qmapshack/setup/CCommandProcessor.cpp
+++ b/src/qmapshack/setup/CCommandProcessor.cpp
@@ -20,43 +20,27 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
-#include <iostream>
 
 CAppOpts* CCommandProcessor::processOptions(const QStringList& arguments) {
   QCommandLineParser parser;
-  QCommandLineOption helpOption = parser.addHelpOption();  // h help
+  parser.addHelpOption();
+  parser.addVersionOption();
 
-  QCommandLineOption debugOption(QStringList() << "d"
-                                               << "debug",
-                                 tr("Print debug output to console."));
+  QCommandLineOption debugOption(QStringList() << "d" << "debug", tr("Print debug output to console."));
   parser.addOption(debugOption);
 
-  QCommandLineOption logfileOption(QStringList() << "f"
-                                                 << "logfile",
-                                   tr("Print debug output to logfile (temp. path)."));
+  QCommandLineOption logfileOption(QStringList() << "f" << "logfile", tr("Print debug output to logfile (temp. path)."));
   parser.addOption(logfileOption);
 
-  QCommandLineOption nosplashOption(QStringList() << "n"
-                                                  << "no-splash",
-                                    tr("Do not show splash screen."));
+  QCommandLineOption nosplashOption(QStringList() << "n" << "no-splash", tr("Do not show splash screen."));
   parser.addOption(nosplashOption);
 
-  QCommandLineOption configOption(QStringList() << "c"
-                                                << "config",
-                                  tr("File with QMapShack configuration."), tr("file"));
+  QCommandLineOption configOption(QStringList() << "c" << "config", tr("File with QMapShack configuration."), tr("file"));
   parser.addOption(configOption);
 
   parser.addPositionalArgument("files", tr("Files for future use."));
 
-  if (!parser.parse(arguments)) {
-    std::cerr << parser.errorText().toUtf8().constData();
-    std::cerr << parser.helpText().toUtf8().constData();
-    exit(1);
-  }
-  if (parser.isSet(helpOption)) {
-    std::cout << parser.helpText().toUtf8().constData();
-    exit(0);
-  }
+  parser.process(arguments);
 
   return new CAppOpts(parser.isSet(debugOption), parser.isSet(logfileOption), parser.isSet(nosplashOption),
                       parser.value(configOption), parser.positionalArguments());


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#884

### What you have done:
[comment]: # (Describe roughly.)

Add command line option **-v** to query QMS version
Display help, including generic Qt options for command line option **--help-all**

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS with command line option **-v** or **--version**
2. Get QMS version in console
3. Run QMS with command line option **--help-all**
4. Get all program options, including generic Qt options

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
