### PR TITLE
[QMS-891] Fix  BRouter tile selection map no longer available

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-884] Add command line option to query QMS version
 [QMS-887] Fix Map/DEM description and buttons disappear from list
 [QMS-889] Indicate which DEM is used to resolve elevation
+[QMS-891] Fix  BRouter tile selection map no longer available
 
 V1.18.2
 [QMS-672] Fix track point timestamps to QDateTime UTC conversion

--- a/src/qmapshack/dem/CDemItem.cpp
+++ b/src/qmapshack/dem/CDemItem.cpp
@@ -70,7 +70,10 @@ void CDemItem::slotActivate(bool yes) {
   emit sigChanged();
 }
 
-void CDemItem::setName(const QString& name) { widget->setName(name); }
+void CDemItem::setName(const QString& name) {
+  widget->setName(name);
+  setText(0, name);
+}
 
 void CDemItem::setStatus(CMapItemWidget::eStatus status) { widget->setStatus(status); }
 

--- a/src/qmapshack/dem/CDemList.cpp
+++ b/src/qmapshack/dem/CDemList.cpp
@@ -42,7 +42,6 @@ void CDemTreeWidget::dragEnterEvent(QDragEnterEvent* e) {
   QTreeWidget::dragEnterEvent(e);
 }
 void CDemTreeWidget::dragLeaveEvent(QDragLeaveEvent* e) {
-  qDebug() << "CMapTreeWidget::dragLeaveEvent";
   CDemItem* item = dynamic_cast<CDemItem*>(currentItem());
   if (item) {
     item->showChildren(false);
@@ -55,9 +54,6 @@ void CDemTreeWidget::dragLeaveEvent(QDragLeaveEvent* e) {
     QPointer<CDemItem> pMap(item);
     restoreItemWidgetDelayed(item);
   }
-
-  setCurrentItem(nullptr);
-  emit sigChanged();
 }
 
 void CDemTreeWidget::dropEvent(QDropEvent* e) {

--- a/src/qmapshack/map/CMapDraw.cpp
+++ b/src/qmapshack/map/CMapDraw.cpp
@@ -217,6 +217,7 @@ void CMapDraw::buildMapList(const QString& filename) {
   CMapItem* item = createMapItem(filename, "");
   mapList->addMap(item);
   item->activate();
+  canvas->zoom(30);
 }
 
 void CMapDraw::saveConfig(QSettings& cfg) /* override */

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -76,7 +76,10 @@ void CMapItem::slotActivate(bool yes) {
   emit sigChanged();
 }
 
-void CMapItem::setName(const QString& name) { widget->setName(name); }
+void CMapItem::setName(const QString& name) {
+  widget->setName(name);
+  setText(0, name);
+}
 
 void CMapItem::setStatus(CMapItemWidget::eStatus status) { widget->setStatus(status); }
 

--- a/src/qmapshack/map/CMapList.cpp
+++ b/src/qmapshack/map/CMapList.cpp
@@ -55,9 +55,6 @@ void CMapTreeWidget::dragLeaveEvent(QDragLeaveEvent* e) {
     item->showChildren(true);
     restoreItemWidgetDelayed(item);
   }
-
-  setCurrentItem(nullptr);
-  emit sigChanged();
 }
 
 void CMapTreeWidget::dropEvent(QDropEvent* e) {

--- a/src/qmapshack/widgets/CMapItemWidget.cpp
+++ b/src/qmapshack/widgets/CMapItemWidget.cpp
@@ -32,6 +32,7 @@ constexpr Qt::GlobalColor kColorOut = Qt::lightGray;
 constexpr Qt::GlobalColor kColorIn = Qt::darkGreen;
 
 CMapItemWidget::CMapItemWidget(const QString& typeIMap) : typeIMap(typeIMap) {
+  setAutoFillBackground(true);
   labelName = new QLabel(this);
   labelName->setAttribute(Qt::WA_TransparentForMouseEvents, true);
   labelStatus = new QLabel(tr("unknown"), this);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#891

### What you have done:
[comment]: # (Describe roughly.)

Enforce zoom level in CMapDraw::buildMapList()

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
