### PR TITLE
[QMS-893] Fix crash when shutting down app

### DIFF
--- a/src/qmapshack/canvas/IDrawContext.h
+++ b/src/qmapshack/canvas/IDrawContext.h
@@ -168,7 +168,7 @@ class IDrawContext : public QThread {
   bool intNeedsRedraw;
 
   /// the canvas this map object is attached to
-  CCanvas* canvas;
+  QPointer<CCanvas> canvas;
 
   const CCanvas::redraw_e maskRedraw;
   /// map canvas twin buffer

--- a/src/qmapshack/dem/CDemItem.cpp
+++ b/src/qmapshack/dem/CDemItem.cpp
@@ -211,8 +211,6 @@ void CDemItem::deactivate() {
   // maybe used to reflect changes in the icon
   updateIcon();
 
-  // dem->reportStatusToCanvas(text(0), "");
-
   setStatus(CMapItemWidget::eStatus::Inactive);
 }
 

--- a/src/qmapshack/map/CMapDraw.cpp
+++ b/src/qmapshack/map/CMapDraw.cpp
@@ -386,7 +386,11 @@ void CMapDraw::saveMapList(QSettings& cfg) {
   cfg.endGroup();  // map2
 }
 
-void CMapDraw::reportStatusToCanvas(const QString& key, const QString& msg) { canvas->reportStatus(key, msg); }
+void CMapDraw::reportStatusToCanvas(const QString& key, const QString& msg) {
+  if (canvas) {
+    canvas->reportStatus(key, msg);
+  }
+}
 
 void CMapDraw::drawt(IDrawContext::buffer_t& currentBuffer) /* override */
 {

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -218,8 +218,6 @@ void CMapItem::deactivate() {
   // maybe used to reflect changes in the icon
   updateIcon();
 
-  map->reportStatusToCanvas(text(0), "");
-
   setStatus(CMapItemWidget::eStatus::Inactive);
 }
 

--- a/src/qmapshack/map/IMap.h
+++ b/src/qmapshack/map/IMap.h
@@ -160,7 +160,7 @@ class IMap : public IDrawObject {
 
  protected:
   /// the drawcontext this map belongs to
-  CMapDraw* map;
+  QPointer<CMapDraw> map;
 
   /**
       target should always be "EPSG:4326"

--- a/src/qmapshack/map/IMapOnline.cpp
+++ b/src/qmapshack/map/IMapOnline.cpp
@@ -33,7 +33,11 @@ IMapOnline::IMapOnline(CMapDraw* parent) : IMap(eFeatVisibility | eFeatTileCache
   connect(this, &IMapOnline::sigQueueChanged, this, &IMapOnline::slotQueueChanged);
 }
 
-IMapOnline::~IMapOnline() { map->reportStatusToCanvas(name, ""); }
+IMapOnline::~IMapOnline() {
+  if (map) {
+    map->reportStatusToCanvas(name, "");
+  }
+}
 
 bool IMapOnline::httpsCheck(const QString& url) {
   if (url.startsWith("https", Qt::CaseInsensitive) && !QSslSocket::supportsSsl()) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#893

### What you have done:
[comment]: # (Describe roughly.)

Cleanup code.
Use QPointer for safe access.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

App shouldn't crash when closed

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ ] yes, I didn't forget to change changelog.txt

Hot fix,  no change log

