### PR TITLE
[QMS-896] BRouter setup installation folder & outstanding download counter issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-896] BRouter setup installation folder & outstanding download counter issues
+
 V1.19.0
 [QMS-869] Convert track to area
 [QMS-871] Partly fix: Routino & installation folder name with non-ASCII characters

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelect.h
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterTilesSelect.h
@@ -42,7 +42,7 @@ class CRouterBRouterTilesSelect : public QWidget {
   void initialize();
   void cancelDownload() const;
 
-  static QString formatSize(const qint64 size);
+  static QString formatSize(const quint64 size);
   static QPoint tileFromFileName(const QString& fileName);
   static QString fileNameFromTile(const QPoint tile);
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#896

### What you have done:
[comment]: # (Describe roughly.)

BRouter setup installation folder issue:
Now looking for any valid _brouter*.jar_ file in installation folder, not only for exactly _brouter.jar_ named file.

BRouter outstanding tiles download counter issue:
Add some missing variable initializations
Use now unsigned integers to format size values
Fix counting number and size of **still** outstanding tiles to be downloaded

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See how to reproduce issues described in issue report [#896](https://github.com/Maproom/qmapshack/issues/896)
and verify that issues have been fixed. 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
