### PR TITLE
[QMS-899] Flash active indicator of map/dem items while rendered.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-896] BRouter setup installation folder & outstanding download counter issues
+[QMS-899] Flash active indicator of map/dem items while rendered.
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/qmapshack/dem/CDemDraw.cpp
+++ b/src/qmapshack/dem/CDemDraw.cpp
@@ -339,7 +339,9 @@ void CDemDraw::drawt(buffer_t& currentBuffer) {
         continue;
       }
 
+      item->setProcessing(true);
       item->getDemFile()->draw(currentBuffer);
+      item->setProcessing(false);
     }
   }
   CDemItem::mutexActiveDems.unlock();

--- a/src/qmapshack/dem/CDemItem.cpp
+++ b/src/qmapshack/dem/CDemItem.cpp
@@ -271,3 +271,9 @@ void CDemItem::setAccess(const QString& ele) {
     widget->setAccess(ele);
   }
 }
+
+void CDemItem::setProcessing(bool on) {
+  if (!widget.isNull()) {
+    widget->setProcessing(on);
+  }
+}

--- a/src/qmapshack/dem/CDemItem.h
+++ b/src/qmapshack/dem/CDemItem.h
@@ -148,7 +148,20 @@ class CDemItem : public QObject, public QTreeWidgetItem {
    */
   bool activate();
 
+  /**
+   * @brief Indicate to the user the item has been accessed by an elevtion request
+   * @param ele   The elevation from the access ass tring
+   */
   void setAccess(const QString& ele);
+
+  /**
+   * @brief Indicate to the user the item is used for processing data (e.g. rendering hillshading)
+   *
+   * Should be called before and after any lengthy operation.
+   *
+   * @param on
+   */
+  void setProcessing(bool on);
 
  signals:
   void sigChanged();

--- a/src/qmapshack/map/CMapDraw.cpp
+++ b/src/qmapshack/map/CMapDraw.cpp
@@ -405,7 +405,9 @@ void CMapDraw::drawt(IDrawContext::buffer_t& currentBuffer) /* override */
         continue;
       }
 
+      item->setProcessing(true);
       item->getMapfile()->draw(currentBuffer);
+      item->setProcessing(false);
       seenActiveMap = true;
     }
   }

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -284,3 +284,9 @@ bool CMapItem::activate() {
   setStatus(CMapItemWidget::eStatus::Active);
   return true;
 }
+
+void CMapItem::setProcessing(bool on) {
+  if (!widget.isNull()) {
+    widget->setProcessing(on);
+  }
+}

--- a/src/qmapshack/map/CMapItem.h
+++ b/src/qmapshack/map/CMapItem.h
@@ -148,6 +148,15 @@ class CMapItem : public QObject, public QTreeWidgetItem {
    */
   bool activate();
 
+  /**
+   * @brief Indicate to the user the item is used for processing data (e.g. rendering hillshading)
+   *
+   * Should be called before and after any lengthy operation.
+   *
+   * @param on
+   */
+  void setProcessing(bool on);
+
  signals:
   void sigChanged();
   // emitted if the tree widget item's widget was destroyed

--- a/src/qmapshack/widgets/CFadingLabel.cpp
+++ b/src/qmapshack/widgets/CFadingLabel.cpp
@@ -28,7 +28,7 @@ CFadingLabel::CFadingLabel(QWidget* parent) : QLabel(parent) {
   setGraphicsEffect(effect);
 
   fadeAnim = new QPropertyAnimation(effect, "opacity", this);
-  fadeAnim->setEasingCurve(QEasingCurve::InOutSine);
+  fadeAnim->setEasingCurve(QEasingCurve::InOutQuad);
 }
 
 void CFadingLabel::fadeOut(int duration) {

--- a/src/qmapshack/widgets/CLedIndicator.cpp
+++ b/src/qmapshack/widgets/CLedIndicator.cpp
@@ -27,13 +27,13 @@ CLedIndicator::CLedIndicator(QWidget* parent)
   // --- Color animation ---
   m_colorAnim = new QPropertyAnimation(this, "animatedColor", this);
   m_colorAnim->setDuration(250);
-  m_colorAnim->setEasingCurve(QEasingCurve::InOutSine);
+  m_colorAnim->setEasingCurve(QEasingCurve::InOutQuad);
   connect(m_colorAnim, &QPropertyAnimation::finished, this, [this]() { setAnimatedColor(m_targetColor); });
 
   // --- Opacity animation ---
   m_opacityAnim = new QPropertyAnimation(this, "opacity", this);
   m_opacityAnim->setDuration(250);
-  m_opacityAnim->setEasingCurve(QEasingCurve::InOutSine);
+  m_opacityAnim->setEasingCurve(QEasingCurve::InOutQuad);
 }
 
 QColor CLedIndicator::color() const { return m_targetColor; }
@@ -72,16 +72,34 @@ void CLedIndicator::setOpacity(qreal o) {
 // --- hide/show animations ---
 void CLedIndicator::animateHide() {
   m_opacityAnim->stop();
+  m_opacityAnim->setDuration(250);
   m_opacityAnim->setStartValue(m_opacity);
   m_opacityAnim->setEndValue(0.0);
+  m_opacityAnim->setLoopCount(1);
   m_opacityAnim->start();
 }
 
 void CLedIndicator::animateShow() {
   m_opacityAnim->stop();
+  m_opacityAnim->setDuration(250);
   m_opacityAnim->setStartValue(m_opacity);
   m_opacityAnim->setEndValue(1.0);
+  m_opacityAnim->setLoopCount(1);
   m_opacityAnim->start();
+}
+
+void CLedIndicator::animateFlash(bool on) {
+  m_opacityAnim->stop();
+  if (on) {
+    m_opacityAnim->setDuration(500);
+    m_opacityAnim->setStartValue(1.0);
+    m_opacityAnim->setEndValue(0.0);
+    m_opacityAnim->setLoopCount(-1);
+    m_opacityAnim->setDirection(QAbstractAnimation::Forward);
+    m_opacityAnim->start();
+  } else {
+    animateShow();
+  }
 }
 
 void CLedIndicator::paintEvent(QPaintEvent*) {

--- a/src/qmapshack/widgets/CLedIndicator.h
+++ b/src/qmapshack/widgets/CLedIndicator.h
@@ -42,6 +42,7 @@ class CLedIndicator final : public QWidget {
   // hide/show animations
   void animateHide();
   void animateShow();
+  void animateFlash(bool on);
 
   qreal opacity() const;
   void setOpacity(qreal o);

--- a/src/qmapshack/widgets/CMapItemWidget.cpp
+++ b/src/qmapshack/widgets/CMapItemWidget.cpp
@@ -75,6 +75,9 @@ CMapItemWidget::CMapItemWidget(const QString& typeIMap) : typeIMap(typeIMap) {
   connect(buttonActivate, &QToolButton::clicked, this, &CMapItemWidget::sigActivate);
   connect(buttonActivate, &QToolButton::toggled, this, &CMapItemWidget::slotSetChecked);
   connect(timerAccess, &QTimer::timeout, this, [this]() { labelAccess->fadeOut(1000); });
+
+  // cross-thread signalling. Signal is triggered by draw thread, indicator animation has to be triggered in main thread
+  connect(this, &CMapItemWidget::sigSetProcessing, this, [this](bool on) { indicatorVisibility->animateFlash(on); });
 }
 
 CMapItemWidget::~CMapItemWidget() { /*qDebug() << "~CMapItemWidget()" << labelName->text();*/ }
@@ -89,6 +92,12 @@ void CMapItemWidget::setAccess(const QString& ele) {
   labelAccess->setText(ele);
   labelAccess->fadeIn(1);
   timerAccess->start();
+}
+
+void CMapItemWidget::setProcessing(bool on) {
+  // use signal to decouple threads when setProcessing()
+  // is called from a thread not the main application thread
+  emit sigSetProcessing(on);
 }
 
 void CMapItemWidget::setStatus(eStatus status) {

--- a/src/qmapshack/widgets/CMapItemWidget.h
+++ b/src/qmapshack/widgets/CMapItemWidget.h
@@ -55,8 +55,12 @@ class CMapItemWidget : public QWidget {
 
   void setAccess(const QString& ele);
 
+  void setProcessing(bool on);
+
  signals:
   void sigActivate(bool);
+  // signal used internally to decouple threads
+  void sigSetProcessing(bool);
 
  public slots:
   void slotScaleChanged(const QPointF& scale);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#899

### What you have done:
[comment]: # (Describe roughly.)

* flashing animation to LED indicator
* add API to CMapItem and CDemItem to set the processing state (on/off)
* route API for processing state to enable/disable flashing of visibility indicator in item widget

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Enable hill shading for a DEM
* zoom out until rendering takes some seconds.
* the indicator should flash while the indicator in the map is rotating

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
