### PR TITLE
[QMS-907] Fix: Bad UX with progress dialog and wait cursor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-896] BRouter setup installation folder & outstanding download counter issues
 [QMS-899] Flash active indicator of map/dem items while rendered.
+[QMS-907] Fix: Bad UX with progress dialog and wait cursor
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -72,7 +72,13 @@ class CGisListWksEditLock {
  public:
   CGisListWksEditLock(bool waitCursor, QRecursiveMutex& mutex) : mutex(mutex), waitCursor(waitCursor) {
     if (waitCursor) {
-      CCanvas::setOverrideCursor(Qt::WaitCursor, "CGisListWksEditLock");
+      // Only switch to wait cursor if there is no progress dialog allready started.
+      if (CProgressDialog::self() == nullptr) {
+        CCanvas::setOverrideCursor(Qt::WaitCursor, "CGisListWksEditLock");
+      } else {
+        // set to false to stop dtor from removing the wait cursor.
+        this->waitCursor = false;
+      }
     }
     mutex.lock();
   }
@@ -794,7 +800,6 @@ void CGisListWks::slotLoadWorkspace() {
       }
     }
     PROGRESS_SETUP(tr("Loading workspace. Please wait."), 0, total, this);
-    progress.show();
     quint32 progCnt = 0;
 
     while (query.next()) {

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -577,7 +577,6 @@ IGisProject* CGisWorkspace::copyItemsByKey(const QList<IGisItem::key_t>& keys) {
   project->blockUpdateItems(true);
   int cnt = 1;
   PROGRESS_SETUP(tr("Copy items..."), 0, keys.count(), this);
-  progress.show();
   for (const IGisItem::key_t& key : keys) {
     PROGRESS(cnt++, break);
     IGisItem* gisItem = getItemByKey(key);

--- a/src/qmapshack/helpers/CProgressDialog.cpp
+++ b/src/qmapshack/helpers/CProgressDialog.cpp
@@ -26,7 +26,7 @@
 
 QStack<CProgressDialog*> CProgressDialog::stackSelf;
 
-#define DELAY 1000
+#define DELAY 500
 
 CProgressDialog::CProgressDialog(const QString text, int min, int max, QWidget* parent) : QDialog(parent) {
   stackSelf.push(this);
@@ -61,6 +61,7 @@ CProgressDialog::CProgressDialog(const QString text, int min, int max, QWidget* 
     show();
   });
   timer->start(DELAY);
+  CCanvas::setOverrideCursor(Qt::ArrowCursor, "CProgressDialog");
 }
 
 CProgressDialog* CProgressDialog::self() {
@@ -75,6 +76,7 @@ CProgressDialog::~CProgressDialog() {
   if (!stackSelf.isEmpty()) {
     stackSelf.top()->goOn();
   }
+  CCanvas::restoreOverrideCursor("~CProgressDialog");
 }
 
 void CProgressDialog::pause() {
@@ -89,11 +91,9 @@ void CProgressDialog::goOn() {
   if (timer->isActive()) {
     return;
   }
-  if (timeElapsed <= DELAY) {
-    timer->start(DELAY - timeElapsed);
-  } else {
-    show();
-  }
+  // after restarting a paused timer we assume the timer would have expired in the meanwhile. Therefore start it again
+  // to expire asap.
+  timer->start(1);
 }
 
 void CProgressDialog::setAllVisible(bool yes) {
@@ -112,9 +112,7 @@ void CProgressDialog::reject() {
 }
 
 void CProgressDialog::setValue(int val) {
-  if (time.elapsed() > DELAY) {
-    QApplication::processEvents();
-  }
+  QApplication::processEvents();
   progressBar->setValue(val);
   labelTime->setText(tr("Elapsed time: %1 seconds.").arg(time.elapsed() / 1000.0, 0, 'f', 0));
 }

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
   // make sure this is the one and only instance on the system
   CSingleInstanceProxy s(qlOpts->arguments);
 
-  QSplashScreen* splash = nullptr;
+  QPointer<QSplashScreen> splash = nullptr;
   if (!qlOpts->nosplash) {
     QPixmap pic(":/pics/splash.png");
     QPainter p(&pic);
@@ -68,8 +68,12 @@ int main(int argc, char** argv) {
   w.show();
 
   if (nullptr != splash) {
-    splash->finish(&w);
-    delete splash;
+    QTimer::singleShot(1500, splash, [splash, &w]() {
+      if (!splash.isNull()) {
+        splash->finish(&w);
+        delete splash;
+      }
+    });
   }
 
   return app.exec();

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -616,15 +616,9 @@ void CMapIMG::readBasics() {
   }
 #endif  // DEBUG_SHOW_SECT_DESC
 
-  int cnt = 1;
-  int tot = subfiles.count();
-
-  PROGRESS_SETUP(tr("Loading %1").arg(QFileInfo(filename).fileName()), 0, tot, CMainWindow::getBestWidgetForParent());
-
   maparea = QRectF();
   QMap<QString, subfile_desc_t>::iterator subfile = subfiles.begin();
   while (subfile != subfiles.end()) {
-    PROGRESS(cnt++, throw exce_t(errAbort, tr("User abort: ") + filename));
     if ((*subfile).parts.contains("GMP")) {
       throw exce_t(errFormat,
                    tr("File is NT format. QMapShack is unable to read map files with NT format: ") + filename);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#907

### What you have done:
[comment]: # (Describe roughly.)

* Stop switching to wait cursor in CGisListWksEditLock when a progress dialog is active.
* Remove calls to QProgressDialog::show() from outside QProgressDialog
* ctor and dtor of QProgressDialog switch to cursor to normal arrow.
* simplify late show() of QProgressDialog 
* QProgressDialog process events without delay

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Load a lot of items, preferably tracks, into the workspace. Use Garmin maps and DEM to stress the system. 

UX of startup should be much smoother. Temporary short stalls are expected. Cursor should end up as the expected cursor in the map canvas.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
