### PR TITLE
Strange project's tree view items spacing behaviour

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-896] BRouter setup installation folder & outstanding download counter issues
 [QMS-899] Flash active indicator of map/dem items while rendered.
+[QMS-906] Strange project's tree view items spacing behaviour
 [QMS-907] Fix: Bad UX with progress dialog and wait cursor
 
 V1.19.0

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -271,6 +271,7 @@ set( SRCS
     poi/CPoiList.cpp
     poi/CPoiPathSetup.cpp
     poi/CPoiPropSetup.cpp
+    poi/CPoiTreeWidgetCategories.cpp
     poi/IPoiFile.cpp
     poi/IPoiProp.cpp
     print/CPrintDialog.cpp
@@ -642,6 +643,7 @@ set( HDRS
     poi/CPoiList.h
     poi/CPoiPathSetup.h
     poi/CPoiPropSetup.h
+    poi/CPoiTreeWidgetCategories.h
     poi/IPoiFile.h
     poi/IPoiItem.h
     poi/IPoiProp.h

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -648,6 +648,11 @@ void CGisListWks::dropEvent(QDropEvent* e) {
   emit sigChanged();
 }
 
+void CGisListWks::scrollTo(const QModelIndex &index, ScrollHint hint) {
+  QTreeView::scrollTo(index, hint);
+  horizontalScrollBar()->setValue(0);
+}
+
 void CGisListWks::addProject(IGisProject* proj) {
   if (!proj->isValid()) {
     return;

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -71,6 +71,7 @@ class CGisListWks : public QTreeWidget {
  protected:
   void dragMoveEvent(QDragMoveEvent* e) override;
   void dropEvent(QDropEvent* e) override;
+  void scrollTo(const QModelIndex &index, ScrollHint hint = EnsureVisible) override;
 
  private slots:
   void slotSaveWorkspace();

--- a/src/qmapshack/poi/CPoiTreeWidgetCategories.cpp
+++ b/src/qmapshack/poi/CPoiTreeWidgetCategories.cpp
@@ -1,0 +1,26 @@
+/**********************************************************************************************
+    Copyright (C) 2025 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#include "poi/CPoiTreeWidgetCategories.h"
+
+CPoiTreeWidgetCategories::CPoiTreeWidgetCategories(QWidget *parent) : QTreeWidget(parent) {}
+
+void CPoiTreeWidgetCategories::scrollTo(const QModelIndex &index, ScrollHint hint) {
+  QTreeView::scrollTo(index, hint);
+  horizontalScrollBar()->setValue(0);
+}

--- a/src/qmapshack/poi/CPoiTreeWidgetCategories.h
+++ b/src/qmapshack/poi/CPoiTreeWidgetCategories.h
@@ -1,0 +1,35 @@
+/**********************************************************************************************
+    Copyright (C) 2025 Oliver Eichler <oliver.eichler@gmx.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef CPOITREEWIDGETCATEGORIES_H
+#define CPOITREEWIDGETCATEGORIES_H
+
+#include <QScrollBar>
+#include <QTreeWidget>
+
+class CPoiTreeWidgetCategories : public QTreeWidget {
+  Q_OBJECT
+ public:
+  CPoiTreeWidgetCategories(QWidget *parent);
+  virtual ~CPoiTreeWidgetCategories() = default;
+
+ protected:
+  void scrollTo(const QModelIndex &index, ScrollHint hint = EnsureVisible) override;
+};
+
+#endif  // CPOITREEWIDGETCATEGORIES_H

--- a/src/qmapshack/poi/IPoiPropSetup.ui
+++ b/src/qmapshack/poi/IPoiPropSetup.ui
@@ -35,14 +35,14 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change opacity of map&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QTreeWidget" name="treeWidgetCategories">
+    <widget class="CPoiTreeWidgetCategories" name="treeWidgetCategories">
      <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
+      <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
      </property>
      <property name="wordWrap">
       <bool>false</bool>
@@ -64,6 +64,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CPoiTreeWidgetCategories</class>
+   <extends>QTreeWidget</extends>
+   <header>poi/CPoiTreeWidgetCategories.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#906

### What you have done:
[comment]: # (Describe roughly.)

Override project item tree's horizontal scrolling at item selection.
Make sure that tree's first column containing icons stays fully visible.
Visibility is required to keep vertical spacing suitable to icon's height instead of font's height.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open project in project viewer
2. Scroll viewer horizontally
3. Select item
4. See that viewer is automatically scrolled horizontally and item's icon stays or becomes fully visible
5. Edit item and close item editor
6. See that item's icon is still fully visible and vertical spacing of items did not change.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
