### PR TITLE
[QMS-817] Mac OS X app crash on every quit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-817] Mac OS X app crash on every quit
 [QMS-896] BRouter setup installation folder & outstanding download counter issues
 [QMS-899] Flash active indicator of map/dem items while rendered.
 [QMS-906] Strange project's tree view items spacing behaviour

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -491,6 +491,10 @@ void CMainWindow::prepareMenuForMac() {
 }
 
 CMainWindow::~CMainWindow() {
+
+  // Invalidate stylesheet to avoid crash after destruction (macOS!)
+  qApp->setStyleSheet("");
+
   CActivityTrk::release();
 
   SETTINGS;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#817

### What you have done:
[comment]: # (Describe roughly.)

Invalidate settings of macOS stylesheet _qms-style.qss_ at begin of QMainWindow destruktor
to prevent QMS from crashing with _Segmentation fault: 11_ at close.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open QMS
2. Activate map(s) and/or dem(s)
3. Close QMS
4. Verify that program ends normally

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
