### PR TITLE
[QMS-920] Support {z}/{x}/{y} template params in TMS ServerUrl

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-920] Support {z}/{x}/{y} template params in TMS ServerUrl
 [QMS-817] Mac OS X app crash on every quit
 [QMS-896] BRouter setup installation folder & outstanding download counter issues
 [QMS-899] Flash active indicator of map/dem items while rendered.

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -107,6 +107,10 @@ CMapTMS::CMapTMS(const QString& filename, CMapDraw* parent) : IMapOnline(parent)
     layers[idx].minZoomLevel = minZoomLevel;
     layers[idx].maxZoomLevel = maxZoomLevel;
 
+    layers[idx].strUrl.replace("{z}", "%1", Qt::CaseInsensitive);
+    layers[idx].strUrl.replace("{x}", "%2", Qt::CaseInsensitive);
+    layers[idx].strUrl.replace("{y}", "%3", Qt::CaseInsensitive);
+
     if (xmlLayer.namedItem("Title").isElement()) {
       layers[idx].title = xmlLayer.namedItem("Title").toElement().text();
     } else {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

[QMS-920](https://github.com/Maproom/qmapshack/issues/920)

### What you have done:
[comment]: # (Describe roughly.)

When reading TMS files, all instances of {z}, {x} and {y} in `ServerUrl` are replaced by %1, %2, %3. The rest of the code remains unchanged.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Add and enable the following TMS map layer
```xml
<TMS>
    <Title>CyclingTitle</Title>
    <MinZoomLevel>0</MinZoomLevel>
    <MaxZoomLevel>17</MaxZoomLevel>
    <Layer idx="0">
        <Title>Cycling</Title>
        <ServerUrl>https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png</ServerUrl>
    </Layer>
    <Copyright>Map data: (c) OpenStreetMap contributors, ODbL | Rendering: (c) OpenTopoMap, CC-BY-SA | Trails by tile.waymarkedtrails.org</Copyright>
</TMS>
```
2. See map tiles being fetched successfully

Before this patch, you would have seen the following debug logs
```
2026-01-12 14:46:00.117 [warning] QString::arg: Argument missing: "https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png", 13
2026-01-12 14:46:00.117 [warning] QString::arg: Argument missing: "https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png", 4314
2026-01-12 14:46:00.117 [warning] QString::arg: Argument missing: "https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png", 2769
2026-01-12 14:46:00.197 [debug] Request to "https://tile.waymarkedtrails.org/cycling/%7Bz%7D/%7Bx%7D/%7By%7D.png" failed: "Error transferring https://tile.waymarkedtrails.org/cycling/%7Bz%7D/%7Bx%7D/%7By%7D.png - server replied with status code 404"
```

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
