### PR TITLE
[QMS-924] Enhance debug output by command line and configuration path

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-907] Fix: Bad UX with progress dialog and wait cursor
 [QMS-920] Support {z}/{x}/{y} template params in TMS ServerUrl
 [QMS-922] macOS warning "no file found for translations ... (using default)."
+[QMS-924] Enhance debug output by command line and configuration path
 [QMS-927] Strange "shadow configuration" behavior
 
 V1.19.0

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -21,11 +21,19 @@
 
 #include "CMainWindow.h"
 #include "CSingleInstanceProxy.h"
+#include "helpers/CSettings.h"
 #include "setup/CAppOpts.h"
 #include "setup/IAppSetup.h"
 #include "version.h"
 
 int main(int argc, char** argv) {
+  // preserve "original" argument list
+  int argCnt = argc;
+  char** argVal = new char*[argCnt];
+  for (int i = 0; i < argCnt; i++) {
+    argVal[i] = argv[i];
+  }
+
   QApplication app(argc, argv);
 
   QCoreApplication::setApplicationName("QMapShack");
@@ -36,6 +44,21 @@ int main(int argc, char** argv) {
   IAppSetup* env = IAppSetup::getPlatformInstance();
   env->processArguments();
   env->initLogHandler();
+
+  // useful debug info
+  {
+    qDebug().nospace() << "Qt versions: " << "build=" << QT_VERSION_STR << ", runtime=" << qVersion();
+    QString argList("");
+    for (int i = 1; i < argCnt; i++) {
+      argList += " \"" + QString(argVal[i]) + "\"";
+    }
+    qDebug() << "Executable path:" << QFileInfo(argVal[0]).absoluteFilePath();
+    qDebug().noquote().nospace() << "Argument list:" << argList;
+    SETTINGS;
+    qDebug() << "Configuration path:" << cfg.fileName();
+  }
+  delete[] argVal;
+
   env->initQMapShack();
 
   // setup default proxy


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#924

### What you have done:
[comment]: # (Describe roughly.)

Added useful debug informations:
- Qt versions used for build & for runtime
- Absolute path of QMS executable
- Full argument list passed to QMS
- Configuration path used for save/restore

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS with debug switch "-d"
2. See above informations

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
