### PR TITLE
[QMS-927] Strange "shadow configuration" behavior

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-907] Fix: Bad UX with progress dialog and wait cursor
 [QMS-920] Support {z}/{x}/{y} template params in TMS ServerUrl
 [QMS-922] macOS warning "no file found for translations ... (using default)."
+[QMS-927] Strange "shadow configuration" behavior
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -875,6 +875,7 @@ void CMainWindow::slotCloneCanvas() {
   }
 
   QTemporaryFile temp;
+  openFileCheckSuccess(QIODevice::ReadWrite, temp);
   QSettings view(temp.fileName(), QSettings::IniFormat);
   view.clear();
 

--- a/src/qmapshack/dem/CDemItem.cpp
+++ b/src/qmapshack/dem/CDemItem.cpp
@@ -198,6 +198,7 @@ void CDemItem::deactivate() {
   // save current configuration into
   // the shadow configuration
   QTemporaryFile file;
+  openFileCheckSuccess(QIODevice::ReadWrite, file);
   QSettings cfg(file.fileName(), QSettings::IniFormat);
   demfile->saveConfig(cfg);
   configToShadowConfig(cfg);
@@ -248,6 +249,7 @@ bool CDemItem::activate() {
   // setup DEM with settings stored in
   // the shadow config
   QTemporaryFile file;
+  openFileCheckSuccess(QIODevice::ReadWrite, file);
   QSettings cfg(file.fileName(), QSettings::IniFormat);
 
   shadowConfigToConfig(cfg);

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -31,6 +31,7 @@
 #include "map/CMapVRT.h"
 #include "map/CMapWMTS.h"
 #include "map/IMapProp.h"
+#include "misc.h"
 
 QRecursiveMutex CMapItem::mutexActiveMaps;
 
@@ -205,6 +206,7 @@ void CMapItem::deactivate() {
   // save current configuration into
   // the shadow configuration
   QTemporaryFile file;
+  openFileCheckSuccess(QIODevice::ReadWrite, file);
   QSettings cfg(file.fileName(), QSettings::IniFormat);
   mapfile->saveConfig(cfg);
   configToShadowConfig(cfg);
@@ -267,6 +269,7 @@ bool CMapItem::activate() {
   // setup map with settings stored in
   // the shadow config
   QTemporaryFile file;
+  openFileCheckSuccess(QIODevice::ReadWrite, file);
   QSettings cfg(file.fileName(), QSettings::IniFormat);
 
   shadowConfigToConfig(cfg);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#927

### What you have done:
[comment]: # (Describe roughly.)

Make the behavior of QTemporaryFile variables conform to the Qt documentation:
In order to get a temporary filename assigned to `QTemporaryFile file` variable,
open `file` **before** accessing filename by `file.fileName()`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS and activate map(s) and/or dem(s)
2. On any operating system:
    Verify that QMS behaves exactly as before.
    On macOS operating system:
    Verify that messages `[warning] Empty filename passed to function` have disappeared
    appearing at each map/dem activation before.    

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
