### PR TITLE
[QMS-932] Invalid Qt basic translation files setup on Linux & macOS

### DIFF
--- a/MacOSX/bundle-common-func.sh
+++ b/MacOSX/bundle-common-func.sh
@@ -123,8 +123,8 @@ function copyQtTranslations {
     QT_TRANSLATIONS_DIR=$(find -L $QT_DEV_PATH -type d -name translations | head -n1)
     for i in "${APP_LANG[@]}"
     do
-        #for MOD in qt qtbase qtmultimedia qtquickcontrols2 qtdeclarative
-        for MOD in qt
+        #for MOD in qtbase qtmultimedia qtquickcontrols2 qtdeclarative
+        for MOD in qtbase
         do
             FILE="$QT_TRANSLATIONS_DIR/${MOD}_${i}.qm"
             if [ -f "$FILE" ]; then

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-924] Enhance debug output by command line and configuration path
 [QMS-927] Strange "shadow configuration" behavior
 [QMS-930] No Brouter time for routes without intermediate points
+[QMS-932] Invalid Qt basic translation files setup on Linux & macOS
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/qmapshack/setup/CAppSetupLinux.cpp
+++ b/src/qmapshack/setup/CAppSetupLinux.cpp
@@ -34,7 +34,7 @@ void CAppSetupLinux::initQMapShack() {
   QString translationPath = QCoreApplication::applicationDirPath();
   static const QRegularExpression re("bin$");
   translationPath.replace(re, "share/qmapshack/translations");
-  prepareTranslator(resourceDir, "qt_");
+  prepareTranslator(resourceDir, "qtbase_");
   prepareTranslator(translationPath, "qmapshack_");
 
   // create directories

--- a/src/qmapshack/setup/CAppSetupMac.cpp
+++ b/src/qmapshack/setup/CAppSetupMac.cpp
@@ -58,7 +58,7 @@ void CAppSetupMac::initQMapShack() {
 
   // setup translators
   QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
-  prepareTranslator(translationPath, "qt_");
+  prepareTranslator(translationPath, "qtbase_");
   prepareTranslator(translationPath, "qmapshack_");
 
   // load and apply style sheet

--- a/src/qmaptool/setup/CAppSetupLinux.cpp
+++ b/src/qmaptool/setup/CAppSetupLinux.cpp
@@ -33,7 +33,7 @@ void CAppSetupLinux::initQMapTool() {
   QString translationPath = QCoreApplication::applicationDirPath();
   static const QRegularExpression re("bin$");
   translationPath.replace(re, "share/qmaptool/translations");
-  prepareTranslator(resourceDir, "qt_");
+  prepareTranslator(resourceDir, "qtbase_");
   prepareTranslator(translationPath, "qmaptool_");
 
   // create directories

--- a/src/qmaptool/setup/CAppSetupMac.cpp
+++ b/src/qmaptool/setup/CAppSetupMac.cpp
@@ -57,7 +57,7 @@ void CAppSetupMac::initQMapTool() {
 
   // setup translators
   QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
-  prepareTranslator(translationPath, "qt_");
+  prepareTranslator(translationPath, "qtbase_");
   prepareTranslator(translationPath, "qmaptool_");
 
   migrateDirContent(defaultCachePath());


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#932

### What you have done:
[comment]: # (Describe roughly.)

Fixed `qt_` to `qtbase_` in files

- `src/qmapshack/setup/CAppSetupLinux.cpp`
- `src/qmapshack/setup/CAppSetupMac.cpp`
- `src/qmaptool/setup/CAppSetupLinux.cpp`
- `src/qmaptool/setup/CAppSetupMac.cpp`

Fixed `for MOD in qt` to `for MOD in qtbase` in file `MacOSX/bundle-common-func.sh`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS on macOS with command line argument "-d"
2. See no warning but debug messages of kind
    ```
   2026-01-17 14:37:41.750 [debug] locale "de"
   2026-01-17 14:37:41.750 [debug] "using file '/Users/user/QMapShack/release/QMapShack.app/Contents/Resources/translations/qtbase_de.qm' for translations."
   2026-01-17 14:37:41.750 [debug] locale "de"
   2026-01-17 14:37:41.751 [debug] "using file '/Users/user/QMapShack/release/QMapShack.app/Contents/Resources/translations/qmapshack_de.qm' for translations."
   ```
   where your locale is shown instead of "de". 


### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt