### PR TITLE
[QMS-930] No Brouter time for routes without intermediate points

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-922] macOS warning "no file found for translations ... (using default)."
 [QMS-924] Enhance debug output by command line and configuration path
 [QMS-927] Strange "shadow configuration" behavior
+[QMS-930] No Brouter time for routes without intermediate points
 
 V1.19.0
 [QMS-869] Convert track to area


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#930

### What you have done:
[comment]: # (Describe roughly.)

Added a workaround to assign time from comment line if starting point's time element is missing.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Follow QMS-#930 issue's guide "To Reproduce" and verify that problem has been fixed.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
