### PR TITLE
[QMS-918] Inconsistency with route export and reimport

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V1.XX.X
 [QMS-899] Flash active indicator of map/dem items while rendered.
 [QMS-906] Strange project's tree view items spacing behaviour
 [QMS-907] Fix: Bad UX with progress dialog and wait cursor
+[QMS-918] Inconsistency with route export and reimport
 [QMS-920] Support {z}/{x}/{y} template params in TMS ServerUrl
 [QMS-922] macOS warning "no file found for translations ... (using default)."
 [QMS-924] Enhance debug output by command line and configuration path

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -358,23 +358,15 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QLi
       const QDomNodeList& nodes = xml.childNodes();
       for (int i = 0; i < nodes.count(); i++) {
         const QDomNode& node = nodes.at(i);
-        if (!node.isComment()) {
-          continue;
-        }
-        const QString& commentTxt = node.toComment().data();
-        // ' track-length = 180864 filtered ascend = 428 plain-ascend = -172 cost=270249 '
-        static const QRegularExpression rxAscDes(
-            "(\\s*track-length\\s*=\\s*)(-?\\d+)(\\s*)(filtered "
-            "ascend\\s*=\\s*-?\\d+)(\\s*)(plain-ascend\\s*=\\s*-?\\d+)(\\s*)(cost\\s*=\\s*)(-?\\d+)(\\s*)");
-        const QRegularExpressionMatch& match = rxAscDes.match(commentTxt);
-        if (match.hasMatch()) {
-          bool ok;
-          *costs = match.captured(9).toDouble(&ok);
-          if (!ok) {
-            *costs = -1;
+        if (node.isComment()) {
+          const QString& comment = node.toComment().data();
+          // ' track-length = 3181 filtered ascend = 70 plain-ascend = 5 cost=8491 energy=.0kwh time=16m 30s '
+          const QRegularExpressionMatch& match = QRegularExpression("cost\\s*=\\s*(-?\\d+)").match(comment);
+          if (match.hasMatch()) {
+            *costs = match.captured(1).toDouble();
           }
+          break;
         }
-        break;
       }
     }
   } catch (const QString& msg) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#918

### What you have done:
[comment]: # (Describe roughly.)

A) File _src/qmapshack/gis/rte/CGisItemRte.cpp_:
As proposed, BRouter's comment does no longer get set as route's comment and thus no orphaned BRouter comment remains when exporting and re-importing route. Further on, BRouter's comment does not interfere any more with route comment assigned by user.

B)
File _src/qmapshack/gis/rte/router/CRouterBRouter.cpp_:
Simplify extracting _cost_ value from BRouter's comment by regular expression analogous to extracting _time_ value from BRouter's comment in file _src/qmapshack/gis/rte/CGisItemRte.cpp_.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

A)
1. Create route and calculate route using BRouter
2. Do not see line "filtered ascend ..." in route's tooltip any more
3. Edit route and assign a comment
4. Export project to file
5. Close project
6. Re-import exported project from file
7. Verify that user assigned comment is still there

B)
1. Create a route with 2 or more intermediate points
2. Edit route and optimize route using BRouter
3. Verify that route gets optimized 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
