### PR TITLE
[QMS-939] Outdated referenced repository in file MacOSX/README.md

### DIFF
--- a/MacOSX/README.md
+++ b/MacOSX/README.md
@@ -46,7 +46,7 @@ Parameters to configure build:
 To run the complete build process:
 
 1. Create a directory and cd into this directory. This dir will be referenced as $QMSDEVDIR
-2. clone git repo https://github.com/d029940/qmapshack.git
+2. clone git repo https://github.com/Maproom/qmapshack.git
 3. Check build parameters in ./qmapshack/MacOSX/config.sh
 4. run "sh ./qmapshack/MacOSX/build-all.sh | tee log.txt"
 5. ATTENTION: manual intervention is needed for: - applying admin password while changing dylibs (Apple requirement)

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V1.XX.X
 [QMS-930] No Brouter time for routes without intermediate points
 [QMS-932] Invalid Qt basic translation files setup on Linux & macOS
 [QMS-936] Bad "Close" icon on view tabs (macOS only!)
+[QMS-939] Outdated referenced repository in file MacOSX/README.md
 
 V1.19.0
 [QMS-869] Convert track to area


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#939

### What you have done:
[comment]: # (Describe roughly.)

URL of git repo to clone is now https://github.com/Maproom/qmapshack.git

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open file _MacOSX/README.md_
2. See that URL of repo to clone points to current QMS branch

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
