### PR TITLE
[QMS-941] Request QMS to close gracefully from command line

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ V1.XX.X
 [QMS-932] Invalid Qt basic translation files setup on Linux & macOS
 [QMS-936] Bad "Close" icon on view tabs (macOS only!)
 [QMS-939] Outdated referenced repository in file MacOSX/README.md
+[QMS-941] Request QMS to close gracefully from command line
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/qmapshack/setup/CAppSetupLinux.h
+++ b/src/qmapshack/setup/CAppSetupLinux.h
@@ -32,6 +32,9 @@ class CAppSetupLinux : public IAppSetup {
   QString logDir() override;
   QString findExecutable(const QString& name) override { return QStandardPaths::findExecutable(name); }
   QString helpFile() override;
+
+ private:
+  static void closeOnSIGTERM();
 };
 
 #endif  // CAPPSETUPLINUX_H

--- a/src/qmapshack/setup/CAppSetupMac.h
+++ b/src/qmapshack/setup/CAppSetupMac.h
@@ -37,6 +37,7 @@ class CAppSetupMac : public IAppSetup {
   QDir getApplicationDir(QString subdir);
   void migrateDirContent(QString dest);
   void extendPath();
+  static void closeOnSIGTERM();
 
   static QString relTranslationDir;
   static QString relRoutinoDir;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#941

### What you have done:
[comment]: # (Describe roughly.)

On Linux and macOS:
Install a signal handler to catch SIGTERM signal.
Close application gracefully with saving anything on caught signal.

On Windows:
Install a native event filter to catch WM_CLOSE signal.
Close application gracefully with saving anything on caught signal.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

On Linux and macOS:
1. Run QMS and get process id
2. Open 1 ore more toplevel windows
3. Run UNIX command `kill -SIGTERM <process id>` from command line
4. Verify that QMS closes with saving anything

On Windows:
1. Run QMS and get process id
2. Open 1 ore more toplevel windows
3. Run Windows command `TASKKILL /PID <process id>` from command line
4. Verify that QMS closes with saving anything

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
