### PR TITLE
[QMS-627] Movable tabs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-627] Add possibility to move views & rennaming views with doubleclick
 [QMS-817] Mac OS X app crash on every quit
 [QMS-896] BRouter setup installation folder & outstanding download counter issues
 [QMS-899] Flash active indicator of map/dem items while rendered.

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -152,6 +152,7 @@ class CMainWindow : public QMainWindow, private Ui::IMainWindow {
   void slotCurrentTabCanvas(int i);
   void slotCurrentTabMaps(int i);
   void slotCurrentTabDem(int i);
+  void slotCurrentTabPoi(int i);
   void slotMousePosition(const QPointF& pos, qreal ele, qreal slope);
   void slotUpdateTabWidgets();
   void slotSetupMapFont();

--- a/src/qmapshack/IMainWindow.ui
+++ b/src/qmapshack/IMainWindow.ui
@@ -45,6 +45,9 @@
       <property name="tabsClosable">
        <bool>true</bool>
       </property>
+      <property name="movable">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
    </layout>
@@ -55,7 +58,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>19</height>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#627

Except adding shortcuts.

__Attention: before testing make a backup of your config__

I didn't changed the changelog so far, because i am unsure about the config handling. In this branch there is a mix of old style config values and  new style config values. The new style writes a [config array](https://doc.qt.io/qt-6/qsettings.html#beginWriteArray) to store the views and reads from the array to get the views in correct order at startup of QMS. But starting QMS writes the old config style back to the config file (not changing the array). Example:

"Old" style in section [Canvas]:
~~~~
Views\OSM-DE\…
[…]
Views\WorldSat\…
[…]
~~~~

If no array can be found in the config this will be read by this this branch. Now you can move "WorldSat" to be shown as the first map view and after closing QMS the config contains instead the array style:
~~~~
Views\1\WorldSat\…
[…]
Views\2\OSM-DE\…
[…]
~~~~

Starting QMS again will read the array and orders the map views accordingly. But during running QMS the config will be rewritten and has now both, the array style followed by the old style. Changes made to map views will only be written to the old style parts. Closing QMS again will rewrite the array with the values from the old style.

This is not a problem at all, i use this branch for some time now without any issues. But i think the mix of old style and array style while running QMS is somehow wrong, if not leading to unexpected bugs.

Any idea to make this better? I am a bit lost here, because currently i have no idea to get a specific entry from the array to write changes to.  Or to map the entries in the array with old style config entries.

If anyone wants to change the code and provide an own branch feel free.

### What you have done:
[comment]: # (Describe roughly.)

- Added possibility to move map view tabs
- Added possibility to rename a map view with double click


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Map views can't be reordered and are sorted alphanumerically by default 
2. Renaming a map vies can only be done be using the main mennu

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
