### PR TITLE
[QMS-953] Fix geo cache symbols on map

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ V1.XX.X
 [QMS-941] Request QMS to close gracefully from command line
 [QMS-945] Redesign project icons
 [QMS-946] New workspace widget design
-
+[QMS-953] Fix geo cache symbols on map
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -25,6 +25,7 @@
 #include "gis/IWksItem.h"
 #include "gis/prj/IGisProject.h"
 #include "gis/search/CGeoSearch.h"
+#include "gis/wpt/CGisItemWpt.h"
 #include "helpers/CDraw.h"
 
 constexpr int kMargin = 1;
@@ -464,6 +465,13 @@ void CWksItemDelegate::paintItem(QPainter* p, const QStyleOptionViewItem& opt, c
     p->drawText(rectStatus.adjusted(0, -1, 0, 1), Qt::AlignLeft | Qt::AlignTop, tags.values().join(", "));
   }
 
+  const CGisItemWpt* wpt = dynamic_cast<const CGisItemWpt*>(&item);
+  if (wpt != nullptr && wpt->isGeocache()) {
+    // draw cache name
+    p->setFont(fontStatus);
+    p->drawText(rectStatus.adjusted(0, -1, 0, 1), Qt::AlignLeft | Qt::AlignTop, wpt->getGeoCache().name);
+  }
+
   // draw icon
   QIcon(item.getIcon()).paint(p, rectIcon, Qt::AlignCenter, iconMode);
 
@@ -583,7 +591,9 @@ bool CWksItemDelegate::mousePressProject(QMouseEvent* me, const QStyleOptionView
     if (project == nullptr) {
       return false;
     }
-    treeWidget->setUserFocus(project->getKey(), !project->hasUserFocus());
+    if ((opt.state & QStyle::State_HasFocus) != 0) {
+      treeWidget->setUserFocus(project->getKey(), !project->hasUserFocus());
+    }
     return true;
   }
 

--- a/src/qmapshack/gis/wpt/CGisItemWpt.cpp
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.cpp
@@ -189,6 +189,14 @@ void CGisItemWpt::genKey() const {
   IGisItem::genKey();
 }
 
+const QString& CGisItemWpt::getIconName() const {
+  if (geocache.hasData) {
+    return geocache.type;
+  } else {
+    return wpt.sym;
+  }
+}
+
 QString CGisItemWpt::getLastName(const QString& name) {
   SETTINGS;
   QString lastName = name;

--- a/src/qmapshack/gis/wpt/CGisItemWpt.h
+++ b/src/qmapshack/gis/wpt/CGisItemWpt.h
@@ -232,7 +232,7 @@ class CGisItemWpt : public IGisItem {
 
   qint32 getElevation() const { return wpt.ele; }
   qreal getProximity() const { return proximity; }
-  const QString& getIconName() const { return wpt.sym; }
+  const QString& getIconName() const;
   const QString& getComment() const override { return wpt.cmt; }
   const QString& getDescription() const override { return wpt.desc; }
   const geocache_t& getGeoCache() const { return geocache; }
@@ -256,7 +256,7 @@ class CGisItemWpt : public IGisItem {
   void mouseDragged(const QPoint& start, const QPoint& last, const QPoint& pos);
   void dragFinished(const QPoint& pos);
   void leftClicked(const QPoint& pos);
-  bool isGeocache() { return geocache.hasData; }
+  bool isGeocache() const { return geocache.hasData; }
 
   bool hasRadius() { return proximity < NOFLOAT; }
 

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -1412,7 +1412,7 @@ void CWptIconManager::init() {
       {tr("traditional cache")}
     },
     {
-      {16,16}, "Multi-Cache", "://icons/geocaching/icons/multi.png",
+      {16,16}, "Multi-cache", "://icons/geocaching/icons/multi.png",
       {tr("geocache")},
       {tr("multi cache")}
     },
@@ -1422,9 +1422,29 @@ void CWptIconManager::init() {
       {tr("unknown cache")}
     },
     {
+      {16,16}, "Letterbox Hybrid", "://icons/geocaching/icons/letterbox.png",
+      {tr("geocache")},
+      {tr("letterbox cache")}
+    },
+    {
       {16,16}, "Wherigo Cache", "://icons/geocaching/icons/wherigo.png",
       {tr("geocache")},
       {tr("wherigo cache")}
+    },
+    {
+      {16,16}, "Earthcache", "://icons/geocaching/icons/earth.png",
+      {tr("geocache")},
+      {tr("earthcache")}
+    },
+    {
+      {16,16}, "Virtual Cache", "://icons/geocaching/icons/virtual.png",
+      {tr("geocache")},
+      {tr("virtual cache")}
+    },
+    {
+      {16,16}, "Webcam Cache", "://icons/geocaching/icons/webcam.png",
+      {tr("geocache")},
+      {tr("webcam cache")}
     },
     {
       {16,16}, "Event Cache", "://icons/geocaching/icons/event.png",
@@ -1447,33 +1467,12 @@ void CWptIconManager::init() {
       {tr("cache in trash out event")}
     },
     {
-      {16,16}, "Earthcache", "://icons/geocaching/icons/earth.png",
-      {tr("geocache")},
-      {tr("earthcache")}
-    },
-    {
-      {16,16}, "Letterbox Cache", "://icons/geocaching/icons/letterbox.png",
-      {tr("geocache")},
-      {tr("letterbox cache")}
-    },
-    {
-      {16,16}, "Virtual Cache", "://icons/geocaching/icons/virtual.png",
-      {tr("geocache")},
-      {tr("virtual cache")}
-    },
-    {
-      {16,16}, "Webcam Cache", "://icons/geocaching/icons/webcam.png",
-      {tr("geocache")},
-      {tr("webcam cache")}
-    },
-
-    {
       {16,16}, "gray_Traditional Cache", "://icons/geocaching/icons/gray_Traditional Cache.png",
       {tr("geocache")},
       {tr("traditional cache")}
     },
     {
-      {16,16}, "gray_Multi-Cache", "://icons/geocaching/icons/gray_Multi-Cache.png",
+      {16,16}, "gray_Multi-cache", "://icons/geocaching/icons/gray_Multi-Cache.png",
       {tr("geocache")},
       {tr("multi cache")}
     },


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#953

### What you have done:
[comment]: # (Describe roughly.)

CGisItemWpt::getIconName() only returned the name stores in wpt.sym. However it has to return the name stored in geocache.type in case the waypoint is a geocache. Also fix symbol name for multies.

Bonus: Trivial cache name is now part of the status line.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Open a pocket query from geocaching.com and check if all caches have the correct cache  symbol on the map.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
