### PR TITLE
[QMS-962] Fix: Offline help's full text search index missing (Linux &…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,8 +19,9 @@ V1.XX.X
 [QMS-945] Add waypoint icons for geocache pocket queries.
 [QMS-946] New workspace widget design
 [QMS-951] New database widget design
-[QMS-953] Fix geo cache symbols on map
-[QMS-955] GDAL plugin driven maps not working (Windows & macOS)
+[QMS-953] Fix: Geo cache symbols on map
+[QMS-955] Fix: GDAL plugin driven maps not working (Windows & macOS)
+[QMS-962] Fix: Offline help's full text search index missing (Linux & macOS)
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/common/help/CHelp.cpp
+++ b/src/common/help/CHelp.cpp
@@ -26,15 +26,52 @@
 #include "help/CHelpSearch.h"
 #include "helpers/CSettings.h"
 
-CHelp::CHelp(const QString& helpfile, const QString& homepage, QWidget* parent) : QDockWidget(tr("Help"), parent) {
+static bool isFileNewer(const QString& originalPath, const QString& copyPath) {
+  QFileInfo originalInfo(originalPath);
+  QFileInfo copyInfo(copyPath);
+
+  // Ensure both files actually exist before comparing
+  if (!originalInfo.exists() || !copyInfo.exists()) {
+    return originalInfo.exists();  // If only original exists, it's "newer"
+  }
+
+  // Direct comparison of QDateTime objects
+  return originalInfo.lastModified() > copyInfo.lastModified();
+}
+
+CHelp::CHelp(const QString& sourceQhc, const QString& homepage, QWidget* parent) : QDockWidget(tr("Help"), parent) {
   setWindowFlag(Qt::Tool, true);
   setAttribute(Qt::WA_DeleteOnClose, true);
 
   splitter = new QSplitter(Qt::Horizontal, this);
 
-  qDebug() << "search help at:" << helpfile;
-  engine = new QHelpEngine(helpfile, this);
+  QFileInfo fi(sourceQhc);
+
+  const QString& userDir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+  QDir().mkpath(userDir);
+
+  const QString& userQhc = QDir(userDir).filePath(fi.baseName() + ".qhc");
+  const QString& sourceQch = fi.dir().filePath(fi.baseName() + ".qch");
+
+  // Copy once if it doesn't exist
+  if (isFileNewer(sourceQhc, userQhc)) {
+    QFile::copy(sourceQhc, userQhc);
+  }
+
+  qDebug() << "compressed help:" << sourceQch;
+  qDebug() << "help collection:" << userQhc;
+  engine = new QHelpEngine(userQhc, this);
   engine->setupData();
+
+  for (const QString& ns : engine->registeredDocumentations()) {
+    engine->unregisterDocumentation(ns);
+  }
+
+  if (!engine->registerDocumentation(sourceQch)) {
+    qWarning() << "failed to register" << sourceQch << "Reason:" << engine->error();
+  }
+
+  qDebug() << "Registered docs:" << engine->registeredDocumentations();
 
   index = new CHelpIndex(engine, this);
   search = new CHelpSearch(engine, this);

--- a/src/common/help/CHelpBrowser.cpp
+++ b/src/common/help/CHelpBrowser.cpp
@@ -37,7 +37,6 @@ void CHelpBrowser::setSource(const QUrl& url) {
 }
 
 QVariant CHelpBrowser::loadResource(int type, const QUrl& name) {
-  qDebug() << name;
   if (name.scheme() == "qthelp") {
     return QVariant(engine->fileData(name));
   } else {


### PR DESCRIPTION
… macOS)

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#962

### What you have done:
[comment]: # (Describe roughly.)

* Copy the help's qhc file into the user's home path.
* Create help engine with this local copy
* Register the system wide qch file to go with the local qhc file

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Simply us the F1 help. 
* Debug output should show you the paths.
* Make sure the search works as described in the ticket 
* The index should be created next to the ghc file

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
