### PR TITLE
[QMS-967] Fix and extend locale handling

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ V1.XX.X
 [QMS-955] Fix: GDAL plugin driven maps not working (Windows & macOS)
 [QMS-961] Replace PROJ4 by PROJ wherever publicly visible
 [QMS-962] Fix: Offline help's full text search index missing (Linux & macOS)
+[QMS-967] Fix and extend locale handling
 
 V1.19.0
 [QMS-869] Convert track to area

--- a/src/qmapshack/locale/qmapshack.ts
+++ b/src/qmapshack/locale/qmapshack.ts
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
-        <source>File with QMapShack configuration.</source>
+        <source>QMapShack application locale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
-        <source>file</source>
+        <source>code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <source>File with QMapShack configuration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <source>file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_ca.ts
+++ b/src/qmapshack/locale/qmapshack_ca.ts
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>Fitxer amb configuració QMapShack.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>Fitxer</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Fitxers per a utilitzar més endavant.</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_cs.ts
+++ b/src/qmapshack/locale/qmapshack_cs.ts
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>Soubor s nastavením pro QMapShack.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>Soubor</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Soubory pro pozdější potřebu.</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_de.ts
+++ b/src/qmapshack/locale/qmapshack_de.ts
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation>Gebietsschema von QMapShack.</translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation>Code</translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>Datei mit QMapShack Einstellungen.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>Datei</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Dateien für den späteren Gebrauch.</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_es.ts
+++ b/src/qmapshack/locale/qmapshack_es.ts
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>Archivo con la configuración de QMapShack.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Archivos para uso futuro.</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_fr.ts
+++ b/src/qmapshack/locale/qmapshack_fr.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fr">
+<TS version="2.1" language="fr_FR">
 <context>
     <name>CAbout</name>
     <message>
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation>Localisation de QMapShack.</translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>Fichier de configuration QMS.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>fichier</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Fichiers pour usage futur.</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_it.ts
+++ b/src/qmapshack/locale/qmapshack_it.ts
@@ -241,16 +241,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>File di configurazione di QMapShack.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>file</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Files per versioni future.</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_nl.ts
+++ b/src/qmapshack/locale/qmapshack_nl.ts
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>Bestand met QMapShack. configuratie.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>bestand</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Bestanden voor toekomstig gebruik.</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_ru.ts
+++ b/src/qmapshack/locale/qmapshack_ru.ts
@@ -239,16 +239,26 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>QMapShack application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>File with QMapShack configuration.</source>
         <translation>Файл с конфигурацией QMapShack.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="38"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
         <source>file</source>
         <translation>файл</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="41"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="44"/>
         <source>Files for future use.</source>
         <translation>Файлы для будущего использования.</translation>
     </message>

--- a/src/qmapshack/setup/CAppOpts.h
+++ b/src/qmapshack/setup/CAppOpts.h
@@ -29,11 +29,12 @@ class CAppOpts {
   const bool debug;     // -d, print debug messages
   const bool logfile;   // -f, print debug messages to logfile
   const bool nosplash;  // -n, do not display splash screen
+  const QString locale;
   const QString configfile;
   const QStringList arguments;
 
-  CAppOpts(bool doDebug, bool doLogfile, bool noSplash, const QString& config, const QStringList& args)
-      : debug(doDebug), logfile(doLogfile), nosplash(noSplash), configfile(config), arguments(args) {}
+  CAppOpts(bool doDebug, bool doLogfile, bool noSplash, const QString& locale, const QString& config, const QStringList& args)
+      : debug(doDebug), logfile(doLogfile), nosplash(noSplash), locale(locale), configfile(config), arguments(args) {}
 };
 
 extern CAppOpts* qlOpts;

--- a/src/qmapshack/setup/CCommandProcessor.cpp
+++ b/src/qmapshack/setup/CCommandProcessor.cpp
@@ -35,6 +35,9 @@ CAppOpts* CCommandProcessor::processOptions(const QStringList& arguments) {
   QCommandLineOption nosplashOption(QStringList() << "n" << "no-splash", tr("Do not show splash screen."));
   parser.addOption(nosplashOption);
 
+  QCommandLineOption localeOption(QStringList() << "l" << "locale", tr("QMapShack application locale."), tr("code"));
+  parser.addOption(localeOption);
+
   QCommandLineOption configOption(QStringList() << "c" << "config", tr("File with QMapShack configuration."), tr("file"));
   parser.addOption(configOption);
 
@@ -43,5 +46,5 @@ CAppOpts* CCommandProcessor::processOptions(const QStringList& arguments) {
   parser.process(arguments);
 
   return new CAppOpts(parser.isSet(debugOption), parser.isSet(logfileOption), parser.isSet(nosplashOption),
-                      parser.value(configOption), parser.positionalArguments());
+                      parser.value(localeOption), parser.value(configOption), parser.positionalArguments());
 }

--- a/src/qmapshack/setup/IAppSetup.cpp
+++ b/src/qmapshack/setup/IAppSetup.cpp
@@ -82,21 +82,25 @@ QString IAppSetup::path(QString path, QString subdir, bool mkdir, QString debugN
 }
 
 void IAppSetup::prepareTranslator(QString translationPath, QString translationPrefix) {
-  QString locale = QLocale::system().name();
+  QString locale = qlOpts->locale != nullptr ? qlOpts->locale : QLocale::system().name();
   QDir dir(translationPath);
-  if (!QFile::exists(dir.absoluteFilePath(translationPrefix + locale))) {
+  if (!QFile::exists(dir.absoluteFilePath(translationPrefix + locale + ".qm"))) {
     locale = locale.left(2);
   }
-  qDebug() << "locale" << locale;
+  if (QFile::exists(dir.absoluteFilePath(translationPrefix + locale + ".qm"))) {
+    qDebug() << "locale" << locale;
+  } else {
+    qDebug() << "locale" << locale << "not found (using default).";
+  }
 
   QApplication* app = (QApplication*)QCoreApplication::instance();
   QTranslator* qtTranslator = new QTranslator(app);
   if (qtTranslator->load(translationPrefix + locale, translationPath)) {
     app->installTranslator(qtTranslator);
-    qDebug() << "using file '" + translationPath + "/" + translationPrefix + locale + ".qm' for translations.";
+    qDebug() << "using file '" + qtTranslator->filePath() + "' for translations.";
   } else {
-    qWarning() << "no file found for translations '" + translationPath + "/" + translationPrefix + locale +
-                      "' (using default).";
+    qWarning() << "no translations found for file '" + translationPath + "/" + translationPrefix + locale +
+                      ".qm' (using default).";
   }
 }
 

--- a/src/qmaptool/locale/qmaptool.ts
+++ b/src/qmaptool/locale/qmaptool.ts
@@ -28,11 +28,21 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="39"/>
-        <source>File with QMapTool configuration.</source>
+        <source>QMapTool application locale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
+        <source>File with QMapTool configuration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>file</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_de.ts
+++ b/src/qmaptool/locale/qmaptool_de.ts
@@ -28,11 +28,21 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>QMapTool application locale.</source>
+        <translation>Gebietsschema von QMapTool.</translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>code</source>
+        <translation>Code</translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>File with QMapTool configuration.</source>
         <translation>Eine Datei mit einer QMapTool-Konfiguration.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>file</source>
         <translation>Datei</translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_es.ts
+++ b/src/qmaptool/locale/qmaptool_es.ts
@@ -28,11 +28,21 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>QMapTool application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>File with QMapTool configuration.</source>
         <translation>Archivo con la configuración de QMapTool.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>file</source>
         <translation>archivo</translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_it.ts
+++ b/src/qmaptool/locale/qmaptool_it.ts
@@ -28,11 +28,21 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>QMapTool application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>File with QMapTool configuration.</source>
         <translation>File con configurazione QMapTool.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>file</source>
         <translation>file</translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_ru.ts
+++ b/src/qmaptool/locale/qmaptool_ru.ts
@@ -28,11 +28,21 @@
     </message>
     <message>
         <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>QMapTool application locale.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>File with QMapTool configuration.</source>
         <translation>Файл с конфигурацией QMapTool.</translation>
     </message>
     <message>
-        <location filename="../setup/CCommandProcessor.cpp" line="39"/>
+        <location filename="../setup/CCommandProcessor.cpp" line="42"/>
         <source>file</source>
         <translation>файл</translation>
     </message>

--- a/src/qmaptool/setup/CAppOpts.h
+++ b/src/qmaptool/setup/CAppOpts.h
@@ -29,11 +29,12 @@ class CAppOpts {
   const bool debug;     // -d, print debug messages
   const bool logfile;   // -f, print debug messages to logfile
   const bool nosplash;  // -n, do not display splash screen
+  const QString locale;
   const QString configfile;
   const QStringList arguments;
 
-  CAppOpts(bool doDebug, bool doLogfile, bool noSplash, const QString& config, const QStringList& args)
-      : debug(doDebug), logfile(doLogfile), nosplash(noSplash), configfile(config), arguments(args) {}
+  CAppOpts(bool doDebug, bool doLogfile, bool noSplash, const QString& locale, const QString& config, const QStringList& args)
+      : debug(doDebug), logfile(doLogfile), nosplash(noSplash), locale(locale), configfile(config), arguments(args) {}
 };
 
 extern CAppOpts* qlOpts;

--- a/src/qmaptool/setup/CCommandProcessor.cpp
+++ b/src/qmaptool/setup/CCommandProcessor.cpp
@@ -36,6 +36,9 @@ CAppOpts* CCommandProcessor::processOptions(const QStringList& arguments) {
   QCommandLineOption nosplashOption(QStringList() << "n" << "no-splash", tr("Do not show splash screen."));
   parser.addOption(nosplashOption);
 
+  QCommandLineOption localeOption(QStringList() << "l" << "locale", tr("QMapTool application locale."), tr("code"));
+  parser.addOption(localeOption);
+
   QCommandLineOption configOption(QStringList() << "c" << "config", tr("File with QMapTool configuration."), tr("file"));
   parser.addOption(configOption);
 
@@ -44,5 +47,5 @@ CAppOpts* CCommandProcessor::processOptions(const QStringList& arguments) {
   parser.process(arguments);
 
   return new CAppOpts(parser.isSet(debugOption), parser.isSet(logfileOption), parser.isSet(nosplashOption),
-                      parser.value(configOption), parser.positionalArguments());
+                      parser.value(localeOption), parser.value(configOption), parser.positionalArguments());
 }

--- a/src/qmaptool/setup/IAppSetup.cpp
+++ b/src/qmaptool/setup/IAppSetup.cpp
@@ -115,21 +115,25 @@ QString IAppSetup::path(QString path, QString subdir, bool mkdir, QString debugN
 }
 
 void IAppSetup::prepareTranslator(QString translationPath, QString translationPrefix) {
-  QString locale = QLocale::system().name();
+  QString locale = qlOpts->locale != nullptr ? qlOpts->locale : QLocale::system().name();
   QDir dir(translationPath);
-  if (!QFile::exists(dir.absoluteFilePath(translationPrefix + locale))) {
+  if (!QFile::exists(dir.absoluteFilePath(translationPrefix + locale + ".qm"))) {
     locale = locale.left(2);
   }
-  qDebug() << "locale" << locale;
+  if (QFile::exists(dir.absoluteFilePath(translationPrefix + locale + ".qm"))) {
+    qDebug() << "locale" << locale;
+  } else {
+    qDebug() << "locale" << locale << "not found (using default).";
+  }
 
   QApplication* app = (QApplication*)QCoreApplication::instance();
   QTranslator* qtTranslator = new QTranslator(app);
   if (qtTranslator->load(translationPrefix + locale, translationPath)) {
     app->installTranslator(qtTranslator);
-    qDebug() << "using file '" + translationPath + "/" + translationPrefix + locale + ".qm' for translations.";
+    qDebug() << "using file '" + qtTranslator->filePath() + "' for translations.";
   } else {
-    qWarning() << "no file found for translations '" + translationPath + "/" + translationPrefix + locale +
-                      "' (using default).";
+    qWarning() << "no translations found for file '" + translationPath + "/" + translationPrefix + locale +
+                      ".qm' (using default).";
   }
 }
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#967

### What you have done:
[comment]: # (Describe roughly.)

Fixed and extended locale handling:
- Checking for existence of Qt & QMS/QMT locale files fixed
- Debug output of used Qt & QMS/QMT locale fixed
- Added additional optional command line parameter to override application's default locale

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Case 1:
1. set locale by environment variable LANG (Windows & Linux OS) different from operating systems's default
2. Run QMS with debug switch **-d**
3. Verify that QMS either uses given locale or uses fallback if locale does not exist

Case 2:
1. Run QMS with debug switch **-d** and optional parameter **-l \<locale>**
2. Verify that QMS either uses given locale or uses fallback if locale does not exist

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
