### PR TITLE
[QMS-978] Fix: Invalid gdal "nodata" handling (QMapShack/QMapTool/qmt_map2jnx)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons
 [QMS-971] Fix: macOS: Wrong user data paths
+[QMS-978] Fix: Invalid gdal "nodata" handling (QMapShack/QMapTool/qmt_map2jnx)
 
 V1.20.0
 [QMS-627] Add possibility to move views & renaming views with double click

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -76,15 +76,10 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibili
 
     int success = 0;
     qreal idx = pBand->GetNoDataValue(&success);
-    if (success) {
-      if ((idx >= 0) && (idx < colortable.size())) {
-        QColor tmp(colortable[idx]);
-        tmp.setAlpha(0);
-        colortable[idx] = tmp.rgba();
-      } else {
-        qDebug() << "Index for no data value is out of bound";
-        return;
-      }
+    if (success && (idx >= 0) && (idx < colortable.size())) {
+      QColor tmp(colortable[idx]);
+      tmp.setAlpha(0);
+      colortable[idx] = tmp.rgba();
     }
   }
 

--- a/src/qmaptool/helpers/CGdalFile.cpp
+++ b/src/qmaptool/helpers/CGdalFile.cpp
@@ -81,16 +81,11 @@ void CGdalFile::load(const QString& filename) {
 
     int success = 0;
     qreal idx = pBand->GetNoDataValue(&success);
-    if (success) {
-      if ((idx >= 0) && (idx < colortable.size())) {
-        QColor tmp(colortable[idx]);
-        tmp.setAlpha(0);
-        colortable[idx] = tmp.rgba();
-        hasNoData = idx;
-      } else {
-        qDebug() << "Index for no data value is out of bound";
-        return;
-      }
+    if (success && (idx >= 0) && (idx < colortable.size())) {
+      QColor tmp(colortable[idx]);
+      tmp.setAlpha(0);
+      colortable[idx] = tmp.rgba();
+      hasNoData = idx;
     }
   }
   qDebug() << "hasNoData" << hasNoData;

--- a/src/qmt_map2jnx/main.cpp
+++ b/src/qmt_map2jnx/main.cpp
@@ -667,7 +667,7 @@ int main(int argc, char** argv) {
     int success = 0;
     int idx = (int)pBand->GetNoDataValue(&success);
 
-    if (success) {
+    if (success && (idx >= 0) && (idx < file.colortable.size())) {
       file.colortable[idx] &= 0x00FFFFFF;
     }
   }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#978

### What you have done:
[comment]: # (Describe roughly.)

QMapShack and QMapTool:
Treat out of range "nodata" value same as no "nodata" value.
Do not reject VRT containing an out of range "nodata" value anymore.

qmt_map2jnx:
Check if returned "nodata" value is out of range.
Do not use out of range "nodata" value as colortable index anymore.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Follow rules in issue [#978](https://github.com/Maproom/qmapshack/issues/978) to reproduce issue.
2. See that issue does not happen anymore.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
