### PR TITLE
[QMS-985] Add copy button to projects on a GPS device

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-974] Add vendor list to waypoint icons
 [QMS-978] Fix: Invalid gdal "nodata" handling (QMapShack/QMapTool/qmt_map2jnx)
 [QMS-980] Configure content and size of the items in the workspace list
+[QMS-985] Add copy button to projects on a GPS device
 
 V1.20.0
 [QMS-627] Add possibility to move views & renaming views with double click

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -61,6 +61,7 @@ class CGisListWks : public QTreeWidget {
 
  public slots:
   void slotLoadWorkspace();
+  void slotCopyProject();
 
  signals:
   void sigChanged();
@@ -119,7 +120,6 @@ class CGisListWks : public QTreeWidget {
   void slotEditPrxWpt();
   void slotSyncDB();
   void slotSetSortMode(IGisProject::sorting_folder_e mode, bool checked);
-  void slotCopyProject();
   void slotSymWpt();
   void slotEleWptTrk();
   void slotAutoSaveProject(bool on);

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -537,7 +537,7 @@ void CGisWorkspace::copyItemByKey(const IGisItem::key_t& key) {
     return;
   }
 
-  IGisProject* project = selectProject(true);
+  IGisProject* project = selectProject(false);
   if (nullptr == project) {
     return;
   }
@@ -550,7 +550,7 @@ void CGisWorkspace::copyItemByKey(const IGisItem::key_t& key) {
 IGisProject* CGisWorkspace::copyItemsByKey(const QList<IGisItem::key_t>& keys) {
   QMutexLocker lock(&IGisItem::mutexItems);
 
-  IGisProject* project = selectProject(true);
+  IGisProject* project = selectProject(false);
   if (nullptr == project) {
     return nullptr;
   }

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -182,6 +182,11 @@ std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect, QRect, QRect> CWksIt
         left -= buttonWidth + kMargin;
       }
     }
+  } else if (isOnDevice == true) {
+    if (item.holdUiFocus(opt)) {
+      rectSave.setRect(left, buttonTop, buttonWidth, buttonHeight);
+      left -= buttonWidth + kMargin;
+    }
   }
   // As rectName should span up to the right of the last button left has
   // to be corrected by a button width.
@@ -404,19 +409,25 @@ void CWksItemDelegate::paintProject(QPainter* p, const QStyleOptionViewItem& opt
   const float opacityOfFocusBasedItems = item.getOpacityOfFocusBasedItems();
 
   if (rectSave.isValid()) {
-    // draw save/ auto save button
-    if (item.isChanged() && !item.isAutoSave()) {
-      // show save button
-      drawToolButton(p, opt, rectSave, QIcon(":/icons/32x32/Save.png"), true, false);
+    if (item.isOnDevice() == false) {
+      // draw save/ auto save button
+      if (item.isChanged() && !item.isAutoSave()) {
+        // show save button
+        drawToolButton(p, opt, rectSave, QIcon(":/icons/32x32/Save.png"), true, false);
+      } else {
+        p->setOpacity(opacityOfFocusBasedItems);
+        if (item.isAutoSave()) {
+          // show auto save button pressed, to disable autosave
+          drawToolButton(p, opt, rectSave, QIcon(":/icons/32x32/AutoSaveA.png"), true, true);
+        } else if (item.canSave()) {
+          // show auto save button only if project can be saved
+          drawToolButton(p, opt, rectSave, QIcon(":/icons/32x32/AutoSaveNoA.png"), true, false);
+        }
+        p->setOpacity(1.0);
+      }
     } else {
       p->setOpacity(opacityOfFocusBasedItems);
-      if (item.isAutoSave()) {
-        // show auto save button pressed, to disable autosave
-        drawToolButton(p, opt, rectSave, QIcon(":/icons/32x32/AutoSaveA.png"), true, true);
-      } else if (item.canSave()) {
-        // show auto save button only if project can be saved
-        drawToolButton(p, opt, rectSave, QIcon(":/icons/32x32/AutoSaveNoA.png"), true, false);
-      }
+      drawToolButton(p, opt, rectSave, QIcon(":/icons/32x32/Copy.png"), true, false);
       p->setOpacity(1.0);
     }
   }
@@ -739,22 +750,26 @@ bool CWksItemDelegate::mousePressProject(QMouseEvent* me, const QStyleOptionView
     emit sigUpdateCanvas();
     return true;
   } else if (rectSave.contains(me->pos())) {
-    if (item.isAutoSave()) {
-      item.setAutoSave(false);
-    } else {
-      if (item.isChanged()) {
-        IGisProject* project = dynamic_cast<IGisProject*>(&item);
-        if (project == nullptr) {
-          return false;
-        }
-        if (project->canSave()) {
-          project->save();
-        } else {
-          project->saveAs();
-        }
+    if (item.isOnDevice() == false) {
+      if (item.isAutoSave()) {
+        item.setAutoSave(false);
       } else {
-        item.setAutoSave(true);
+        if (item.isChanged()) {
+          IGisProject* project = dynamic_cast<IGisProject*>(&item);
+          if (project == nullptr) {
+            return false;
+          }
+          if (project->canSave()) {
+            project->save();
+          } else {
+            project->saveAs();
+          }
+        } else {
+          item.setAutoSave(true);
+        }
       }
+    } else {
+      treeWidget->slotCopyProject();
     }
     return true;
   } else if (rectAutoSyncDev.contains(me->pos())) {
@@ -857,14 +872,19 @@ bool CWksItemDelegate::helpEventProject(const QPoint& pos, const QPoint& posGlob
     }
     return true;
   } else if (rectSave.contains(pos)) {
-    if (item.isChanged() && !item.isAutoSave()) {
-      QToolTip::showText(posGlobal, toRichText(tr("Save project.")), view, {}, 3000);
-    } else {
-      if (item.isAutoSave()) {
-        QToolTip::showText(posGlobal, toRichText(tr("Disable auto save.")), view, {}, 3000);
-      } else if (item.canSave()) {
-        QToolTip::showText(posGlobal, toRichText(tr("Enable auto save.")), view, {}, 3000);
+    if (item.isOnDevice() == false) {
+      if (item.isChanged() && !item.isAutoSave()) {
+        QToolTip::showText(posGlobal, toRichText(tr("Save project.")), view, {}, 3000);
+      } else {
+        if (item.isAutoSave()) {
+          QToolTip::showText(posGlobal, toRichText(tr("Disable auto save.")), view, {}, 3000);
+        } else if (item.canSave()) {
+          QToolTip::showText(posGlobal, toRichText(tr("Enable auto save.")), view, {}, 3000);
+        }
       }
+    } else {
+      QToolTip::showText(posGlobal, toRichText(tr("Copy content of project into a project in the workspace.")), view,
+                         {}, 3000);
     }
     return true;
   } else if (rectAutoSyncDev.contains(pos)) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#985

### What you have done:
[comment]: # (Describe roughly.)

Add a copy button to a project on a GPS device. The project must have the focus.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* connect a GPS device
* click on a project located on the device
* copy button should be visible 
* pressing the button copies the content of the project to the specified project in the workspace.
* this should work for multiple selected projects on a device, too


### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
