### PR TITLE
[QMS-987] Fix: Menu icons on macOS missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ option(UPDATE_TRANSLATIONS_PURGE_OBSOLETE "Remove obsolete translations" OFF)
 # All OS and compiler specific tweaks
 ###############################################################################################
 if (APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -std=c++11 -stdlib=libc++")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -stdlib=libc++")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -framework Foundation -framework DiskArbitration")
     SET(LINK_FLAGS "${LINK_FLAGS} -framework Foundation -framework DiskArbitration")

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-978] Fix: Invalid gdal "nodata" handling (QMapShack/QMapTool/qmt_map2jnx)
 [QMS-980] Configure content and size of the items in the workspace list
 [QMS-985] Add copy button to projects on a GPS device
+[QMS-987] Fix: Menu icons on macOS missing
 
 V1.20.0
 [QMS-627] Add possibility to move views & renaming views with double click

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char** argv) {
   QCoreApplication::setOrganizationName("QLandkarte");
   QCoreApplication::setOrganizationDomain("qlandkarte.org");
   QCoreApplication::setApplicationVersion(VER_STR);
+  QCoreApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
 
   IAppSetup* env = IAppSetup::getPlatformInstance();
   env->processArguments();

--- a/src/qmaptool/main.cpp
+++ b/src/qmaptool/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv) {
   QCoreApplication::setOrganizationName("QLandkarte");
   QCoreApplication::setOrganizationDomain("qlandkarte.org");
   QCoreApplication::setApplicationVersion(VER_STR);
+  QCoreApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
 
   IAppSetup& env = IAppSetup::createInstance(qApp);
   env.processArguments();

--- a/src/qmt_rgb2pct/main.cpp
+++ b/src/qmt_rgb2pct/main.cpp
@@ -51,15 +51,14 @@ static void loadTranslations() {
   QString translationPath = QCoreApplication::applicationDirPath();
   static const QRegularExpression re("bin$");
   translationPath.replace(re, "share/" APP_STR "/translations");
-  prepareTranslator(resourceDir, "qt_");
+  prepareTranslator(resourceDir, "qtbase_");
   prepareTranslator(translationPath, APP_STR "_");
 #endif
 
-#ifdef Q_OS_OSX
-  // os x
+#ifdef Q_OS_MACOS
   static QString relTranslationDir = "Resources/translations";  // app
   QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
-  prepareTranslator(translationPath, "qt_");
+  prepareTranslator(translationPath, "qtbase_");
   prepareTranslator(translationPath, APP_STR "_");
 #endif
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#987

### What you have done:
[comment]: # (Describe roughly.)

Set global attribute to fix missing menu icons on macOS :
- file **src/qmapshack/main.cpp**
- file **src/qmaptool/main.cpp**

In addition:
- Changed file **CMakeLists.txt**
   - to remove obsolete compiler flag **-std=c++11** for macOS
   - to remove duplicate compiler flag **-Wall** for macOS
- Changed file **src/qmt_rgb2pct/main.cpp**
  - replaced deprecated macro **Q_OS_OSX** by **Q_OS_MACOS**
  - replaced invalid translator prefix **qt_** by **qtbase_**


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS on macOS
2. Right click item in menu bar or right click project item
3. Corresponding menu opens
4. See icons of menu items no longer missing

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
