### PR TITLE
[QMS-990] Fix: Toolbar menu item(s) too small, "View" menu item missing (macOS)

### DIFF
--- a/MacOSX/build-routino.sh
+++ b/MacOSX/build-routino.sh
@@ -49,7 +49,7 @@ function buildRoutino {
         -e 's|-Wl,-R.|-Wl,-rpath,.|g' \
         Makefile.conf
 
-    make clean
+    #make clean
     make CLANG=1 LDFLAGS_SONAME=""
 }
 

--- a/MacOSX/resources/qms-style.qss
+++ b/MacOSX/resources/qms-style.qss
@@ -15,6 +15,21 @@ QToolBar > QToolButton {
     height: 24px;
 }
 
+/* QToolButton with menu: additional space for arrow button */
+QToolBar > QToolButton[popupMode="1"] {
+    padding-right: 12px;
+}
+
+/* QToolButton with menu: arrow button width */
+QToolBar > QToolButton::menu-button {
+    width: 10px;
+}
+
+/* QToolButton with menu: arrow width within arrow button */
+QToolBar > QToolButton::menu-arrow {
+    width: 8px;
+}
+
 QToolBar > QToolButton:checked {
     border: 1px solid #cdcdcd;
     background-color: #d7d7d7;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-990] Fix: Toolbar menu item(s) too small, "View" menu item missing (macOS)
+
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons
 [QMS-949] Fix: List no geo search or database lost & found in project selection dialog

--- a/src/qmapshack/IMainWindow.ui
+++ b/src/qmapshack/IMainWindow.ui
@@ -1076,6 +1076,9 @@
    <property name="toolTip">
     <string>Setup Map Icon Sizes</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::MenuRole::NoRole</enum>
+   </property>
   </action>
  </widget>
  <customwidgets>


### PR DESCRIPTION


<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#990

### What you have done:
[comment]: # (Describe roughly.)

1. Modified Qt style sheet **qms-style.qss** used on platform macOS to customize toolbar items:
   Added padding for toolbar items with menus to hold arrow button.
2. Changed macOS specific action property **menuRole** to **NoRole** in file **src/qmapshack/IMainWindow.ui**

In addition:
Modified script **MacOSX/build-routino.sh** to not re-build routino completely if already built.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Verify that issues described in [QMS-#990](https://github.com/Maproom/qmapshack/issues/990) are fixed.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
