### PR TITLE
[QMS-992] Changing items does not update the map view

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-990] Fix: Toolbar menu item(s) too small, "View" menu item missing (macOS)
+[QMS-992] Fix: Changing items does not update the map view
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -343,6 +343,11 @@ void IDem::slopecolor(QVector<float>& data, qreal w, qreal h, QImage& img) const
       fillWindow(data, n, m, wp2, win);
       qreal slope = slopeOfWindowInterp(win, eWinsize3x3, 0, 0);
 
+      if (slope == NOFLOAT) {
+        scan[n - 1] = 0;
+        continue;
+      }
+
       const qreal* currentSlopeStepTable = getCurrentSlopeStepTable();
 
       if (slope > currentSlopeStepTable[4]) {

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -551,7 +551,7 @@ void CGisListWks::dropEvent(QDropEvent* e) {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
   const QList<QTreeWidgetItem*>& items = selectedItems();
-  if (items.isEmpty()) {    
+  if (items.isEmpty()) {
     return;
   }
 
@@ -1552,16 +1552,10 @@ void CGisListWks::slotItemDoubleClicked(QTreeWidgetItem* item, int) {
   }
 }
 
-void CGisListWks::slotItemChanged(QTreeWidgetItem* /*item*/, int column) {
+void CGisListWks::slotItemChanged(QTreeWidgetItem* /*item*/, int /*column*/) {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
-
-  /// @todo CWksItemDelegate: this clears the top left selection information whenever
-  /// a project is checked or unchecked.
-
-  // if (column == eColumnCheckBox) {
-  //   CGisWorkspace::self().slotWksItemSelectionReset();
-  //   emit sigChanged();
-  // }
+  CGisWorkspace::self().slotWksItemSelectionReset();
+  emit sigChanged();
 }
 
 void CGisListWks::slotEditItem() {

--- a/src/qmapshack/gis/IWksItem.cpp
+++ b/src/qmapshack/gis/IWksItem.cpp
@@ -61,6 +61,7 @@ void IWksItem::updateItem() {
   if (tree == nullptr) {
     return;
   }
+  emit tree->itemChanged(this, 0);
   QWidget* viewport = tree->viewport();
   if (viewport == nullptr) {
     return;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#992

### What you have done:
[comment]: # (Describe roughly.)

* emit the QTreeWidget::itemChanged signal whenever an item is changed
* forward signal QTreeWidget::itemChanged to CGisListWks::sigChanged()

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
