### PR TITLE
[QMS-994] Fix: QMapTool not callable from QMapShack (macOS)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-990] Fix: Toolbar menu item(s) too small, "View" menu item missing (macOS)
 [QMS-992] Fix: Changing items does not update the map view
+[QMS-994] Fix: QMapTool not callable from QMapShack (macOS)
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/setup/CAppSetupMac.cpp
+++ b/src/qmapshack/setup/CAppSetupMac.cpp
@@ -38,23 +38,16 @@ const QString CAppSetupMac::relBinDir         = "Tools";                   // ap
 const QString CAppSetupMac::relLogDir         = "Library/Logs";            // home
 
 void CAppSetupMac::extendPath() {
-  const QProcessEnvironment& env = QProcessEnvironment::systemEnvironment();
-  const QStringList& envlist = env.toStringList();
-  QString value = "";
-  for (int i = 0; i < envlist.size(); i++) {
-    QString entry = envlist[i];
-    if (entry.startsWith("PATH=")) {
-      int index = entry.indexOf("=");
-
-      if (index != -1) {
-        value = entry.right(entry.length() - (index + 1)) + ":";
-      }
-      break;
-    }
-  }
+  QString value = qEnvironmentVariable("PATH", "");
+  // append Tools path
   const QString& binDir = getApplicationDir(relBinDir).absolutePath();
-  qDebug() << "BIN" << binDir;
-  value += binDir;
+  qDebug() << "Tools path:" << binDir;
+  value += ":" + binDir;
+  // append expected QMapTool path
+  QString qmtDir = QCoreApplication::applicationDirPath();
+  qmtDir.replace("QMapShack.app", "QMapTool.app");
+  qDebug() << "QMapTool path:" << qmtDir;
+  value += ":" + qmtDir;
   qputenv("PATH", value.toLatin1().constData());
 }
 

--- a/src/qmaptool/setup/CAppSetupMac.cpp
+++ b/src/qmaptool/setup/CAppSetupMac.cpp
@@ -37,23 +37,11 @@ const QString CAppSetupMac::relBinDir         = "Tools";                   // ap
 const QString CAppSetupMac::relLogDir         = "Library/Logs";            // home
 
 void CAppSetupMac::extendPath() {
-  const QProcessEnvironment& env = QProcessEnvironment::systemEnvironment();
-  const QStringList& envlist = env.toStringList();
-  QString value = "";
-  for (int i = 0; i < envlist.size(); i++) {
-    QString entry = envlist[i];
-    if (entry.startsWith("PATH=")) {
-      int index = entry.indexOf("=");
-
-      if (index != -1) {
-        value = entry.right(entry.length() - (index + 1)) + ":";
-      }
-      break;
-    }
-  }
+  QString value = qEnvironmentVariable("PATH", "");
+  // append Tools path
   const QString& binDir = getApplicationDir(relBinDir).absolutePath();
-  qDebug() << "BIN" << binDir;
-  value += binDir;
+  qDebug() << "Tools path:" << binDir;
+  value += ":" + binDir;
   qputenv("PATH", value.toLatin1().constData());
 
   prepareToolPaths();


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#994

### What you have done:
[comment]: # (Describe roughly.)

Extended QMapShack's PATH environment variable by QMapTool's expected executable directory:
- Get QMapShack's executable directory,
- replace path component "QMapShack.app" by "QMapTool.app",
- append replaced path to QMapShack's PATH environment variable

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS
2. Select "Tool" menu item "Start QMapTool"
3. See QMapTool running

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
