### PR TITLE
[QMS-996] Fix: POIs not displayed (macOS)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-990] Fix: Toolbar menu item(s) too small, "View" menu item missing (macOS)
 [QMS-992] Fix: Changing items does not update the map view
 [QMS-994] Fix: QMapTool not callable from QMapShack (macOS)
+[QMS-996] Fix: POIs not displayed (macOS)
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/poi/CPoiFilePOI.cpp
+++ b/src/qmapshack/poi/CPoiFilePOI.cpp
@@ -114,10 +114,10 @@ void CPoiFilePOI::draw(IDrawContext::buffer_t& buf) {
   // This is running in it's own thread, not the main thread.
   // Use CPoiFilePOI::mutex whenever you access data shared between
   // the main thread and this thread. Do not block it more than
-  // neccessary.
+  // necessary.
 
   // do that on a regular base while you draw the buffer
-  // to abort drawing ass soon as possible if there is
+  // to abort drawing as soon as possible if there is
   // another draw request pending
   if (poi->needsRedraw()) {
     return;
@@ -165,7 +165,7 @@ void CPoiFilePOI::draw(IDrawContext::buffer_t& buf) {
         if (poi->needsRedraw()) {
           return;
         }
-        for (quint64 poiToDrawID : std::as_const(loadedPoisByArea)[categoryID][minLonM10][minLatM10]) {
+        for (quint64 poiToDrawID : std::as_const(loadedPoisByArea[categoryID][minLonM10][minLatM10])) {
           const CPoiItemPOI& poiToDraw = loadedPois[poiToDrawID];
           QPointF pt = poiToDraw.getCoordinates();
           poi->convertRad2Px(pt);
@@ -285,12 +285,12 @@ void CPoiFilePOI::findPoisIn(const QRectF& degRect, QSet<IPoiItem>& pois, QList<
     for (int minLonM10 = qFloor(degRect.left() * 10); minLonM10 <= qFloor(degRect.right() * 10); minLonM10++) {
       for (int minLatM10 = qFloor(degRect.bottom() * 10); minLatM10 <= qFloor(degRect.top() * 10); minLatM10++) {
         // Imagine the user moves the screen in an l-shape while updating the selection rectangle. It is possible that
-        // some tiles are not laded then
+        // some tiles are not loaded then
         if (!loadedPoisByArea.contains(categoryID) || !loadedPoisByArea[categoryID].contains(minLonM10) ||
             !loadedPoisByArea[categoryID][minLonM10].contains(minLatM10)) {
           loadPOIsFromFile(categoryID, minLonM10, minLatM10);
         }
-        for (quint64 poiFoundID : std::as_const(loadedPoisByArea)[categoryID][minLonM10][minLatM10]) {
+        for (quint64 poiFoundID : std::as_const(loadedPoisByArea[categoryID][minLonM10][minLatM10])) {
           const CPoiItemPOI& poiItemFound = loadedPois[poiFoundID];
           if (!copiedItems.contains(poiItemFound.getKey())) {
             // Maybe look through the whole code of selecting items from a map to avoid this conversion


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#996

### What you have done:
[comment]: # (Describe roughly.)

Changed setting of parentheses of std::as_const expression for iteration loop not working on macOS.
Verified that change has no negative effect on Linux and Windows.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS on macOS
2. Activate POI file
3. Select one or more POI categories
4. See that POIs for selected categories are displayed

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
