### PR TITLE
macos cmake: increase minimum cmake version

### DIFF
--- a/MacOSX/helpers/otoolrecursive/CMakeLists.txt
+++ b/MacOSX/helpers/otoolrecursive/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20.0)
 
 project(otoolrecursive LANGUAGES CXX)
 


### PR DESCRIPTION
This gets rid of a deprecation warning, the helper tool already does get build with >=3.20.0 because the main cmake file requires that.

Related-to: https://github.com/Maproom/qmapshack/issues/721

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#

### What you have done:
[comment]: # (Describe roughly.)



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open whatever
2. Click here

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
