### PR TITLE
[QMS-1004] Progress bar in projects while restoring the workspace

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-994] Fix: QMapTool not callable from QMapShack (macOS)
 [QMS-996] Fix: POIs not displayed (macOS)
 [QMS-998] Add progress bar to GPS devices while loading records
+[QMS-1004] Add progress bar in projects while restoring the workspace
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/device/CDeviceGarmin.cpp
+++ b/src/qmapshack/device/CDeviceGarmin.cpp
@@ -195,7 +195,7 @@ void CDeviceGarmin::createProjectsFromFiles(QString subdirecoty, QString fileEnd
 
             if (project) {
               if (!project->isValid()) {
-                delete project;
+                project->destroyLater();
               } else {
                 project->setVisibility(isVisible());
               }

--- a/src/qmapshack/device/CDeviceGarminArchive.cpp
+++ b/src/qmapshack/device/CDeviceGarminArchive.cpp
@@ -69,7 +69,7 @@ void CDeviceGarminArchive::slotExpanded(QTreeWidgetItem* item) {
               IGisProject* project = new CGpxProject(filename, this);
               if (project) {
                 if (!project->isValid()) {
-                  delete project;
+                  project->destroyLater();
                 } else {
                   project->setVisibility(isVisible());
                 }

--- a/src/qmapshack/device/CDeviceGarminArchiveMtp.cpp
+++ b/src/qmapshack/device/CDeviceGarminArchiveMtp.cpp
@@ -77,7 +77,7 @@ void CDeviceGarminArchiveMtp::slotExpanded(QTreeWidgetItem* item) {
               IGisProject* project = new CGpxProject(tempFile, filename, this);
               if (project) {
                 if (!project->isValid()) {
-                  delete project;
+                  project->destroyLater();
                 } else {
                   project->setVisibility(isVisible());
                 }

--- a/src/qmapshack/device/CDeviceGarminMtp.cpp
+++ b/src/qmapshack/device/CDeviceGarminMtp.cpp
@@ -240,7 +240,7 @@ void CDeviceGarminMtp::createProjectsFromFiles(QString subdirectory, QString ext
             }
             if (project) {
               if (!project->isValid()) {
-                delete project;
+                project->destroyLater();
               } else {
                 project->setVisibility(isVisible());
               }

--- a/src/qmapshack/device/CDeviceGenericMtp.cpp
+++ b/src/qmapshack/device/CDeviceGenericMtp.cpp
@@ -179,7 +179,7 @@ void CDeviceGenericMtp::createProjectsFromFiles(const QString& subdirectory, qui
             }
             if (project) {
               if (!project->isValid()) {
-                delete project;
+                project->destroyLater();
               } else {
                 project->setVisibility(isVisible());
               }

--- a/src/qmapshack/device/CDeviceTwoNav.cpp
+++ b/src/qmapshack/device/CDeviceTwoNav.cpp
@@ -47,7 +47,7 @@ CDeviceTwoNav::CDeviceTwoNav(const QString& path, const QString& key, const QStr
     IGisProject* project = new CTwoNavProject(dirData.absolutePath(), this);
     if (project) {
       if (!project->isValid()) {
-        delete project;
+        project->destroyLater();
       } else {
         project->setVisibility(isVisible());
       }
@@ -59,7 +59,7 @@ CDeviceTwoNav::CDeviceTwoNav(const QString& path, const QString& key, const QStr
     IGisProject* project = new CGpxProject(dirData.absoluteFilePath(entry), this);
     if (project) {
       if (!project->isValid()) {
-        delete project;
+        project->destroyLater();
       } else {
         project->setVisibility(isVisible());
       }
@@ -71,7 +71,7 @@ CDeviceTwoNav::CDeviceTwoNav(const QString& path, const QString& key, const QStr
     IGisProject* project = new CTwoNavProject(dirData.absoluteFilePath(entry), this);
     if (project) {
       if (!project->isValid()) {
-        delete project;
+        project->destroyLater();
       } else {
         project->setVisibility(isVisible());
       }
@@ -85,7 +85,7 @@ CDeviceTwoNav::CDeviceTwoNav(const QString& path, const QString& key, const QStr
     IGisProject* project = new CGpxProject(dirData.absoluteFilePath(entry), this);
     if (project) {
       if (!project->isValid()) {
-        delete project;
+        project->destroyLater();
       } else {
         project->setVisibility(isVisible());
       }
@@ -138,13 +138,13 @@ void CDeviceTwoNav::insertCopyOfProject(IGisProject* project) {
 
   CTwoNavProject* proj = new CTwoNavProject(filename, project, this);
   if (!proj->isValid()) {
-    delete proj;
+    proj->destroyLater();
     return;
   }
 
   if (!proj->save()) {
     proj->remove();
-    delete proj;
+    proj->destroyLater();
     return;
   }
 }

--- a/src/qmapshack/device/IDevice.cpp
+++ b/src/qmapshack/device/IDevice.cpp
@@ -250,7 +250,7 @@ void IDevice::insertCopyOfProject(IGisProject* project, int& lastResult) {
     }
 
     if (project2->remove()) {
-      delete project2;
+      project2->destroyLater();
     } else {
       return;
     }
@@ -263,7 +263,7 @@ void IDevice::updateProject(IGisProject* project) {
   IGisProject* project2 = getProjectByKey(project->getKey());
   if (project2) {
     if (project2->remove()) {
-      delete project2;
+      project2->destroyLater();
     } else {
       return;
     }

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -834,125 +834,107 @@ void CGisListWks::slotLoadWorkspace() {
 
   QUERY_RUN("SELECT type, keyqms, name, changed, visible, data FROM workspace", return)
 
-  {  // open context for progress dialog
-    // Refer to https://stackoverflow.com/questions/26495049/qsqlquery-size-always-returns-1
-    qreal total = 0;
-    if (db.driver()->hasFeature(QSqlDriver::QuerySize)) {
-      total = query.size();
-    } else {
-      if (query.last()) {
-        total = query.at() + 1;
-        query.first();
-        query.previous();
+  while (query.next()) {
+    int type = query.value(0).toInt();
+    QString name = query.value(2).toString();
+    bool changed = query.value(3).toBool();
+    bool visible = query.value(4).toBool();
+    QByteArray data = query.value(5).toByteArray();
+
+    QDataStream stream(&data, QIODevice::ReadOnly);
+    stream.setVersion(QDataStream::Qt_5_2);
+    stream.setByteOrder(QDataStream::LittleEndian);
+
+    IGisProject* project = nullptr;
+    switch (type) {
+      case IGisProject::eTypeQms: {
+        project = new CQmsProject(name, this);
+        project->setVisibility(visible);
+        *project << stream;
+        break;
+      }
+
+      case IGisProject::eTypeQlb: {
+        project = new CQlbProject(name, this);
+        project->setVisibility(visible);
+        *project << stream;
+        break;
+      }
+
+      case IGisProject::eTypeGpx: {
+        project = new CGpxProject(name, this);
+        project->setVisibility(visible);
+        *project << stream;
+        break;
+      }
+
+      case IGisProject::eTypeDb: {
+        CDBProject* dbProject;
+        project = dbProject = new CDBProject(IGisProject::eTypeDb, this);
+        project->setVisibility(visible);
+
+        project->IGisProject::operator<<(stream);
+        dbProject->restoreDBLink();
+
+        if (!project->isValid()) {
+          project->destroyLater();
+          project = nullptr;
+        } else {
+          dbProject->postStatus(false);
+        }
+        break;
+      }
+
+      case IGisProject::eTypeSlf: {
+        project = new CSlfProject(name, false);
+        project->setVisibility(visible);
+        *project << stream;
+
+        // the CSlfProject does not - as the other C*Project - register itself in the list
+        // of currently opened projects. This is done manually here.
+        addProject(project);
+        break;
+      }
+
+      case IGisProject::eTypeFit: {
+        project = new CFit2Project(name, this);
+        project->setVisibility(visible);
+        *project << stream;
+        break;
+      }
+
+      case IGisProject::eTypeTcx: {
+        project = new CTcxProject(name, this);
+        project->setVisibility(visible);
+        *project << stream;
+        break;
+      }
+
+      case IGisProject::eTypeSml: {
+        project = new CSmlProject(name, this);
+        project->setVisibility(visible);
+        *project << stream;
+        break;
+      }
+
+      case IGisProject::eTypeLog: {
+        project = new CSmlProject(name, this);
+        project->setVisibility(visible);
+        *project << stream;
+        break;
       }
     }
-    PROGRESS_SETUP(tr("Loading workspace. Please wait."), 0, total, this);
-    quint32 progCnt = 0;
 
-    while (query.next()) {
-      PROGRESS(progCnt++, return);
-
-      int type = query.value(0).toInt();
-      QString name = query.value(2).toString();
-      bool changed = query.value(3).toBool();
-      bool visible = query.value(4).toBool();
-      QByteArray data = query.value(5).toByteArray();
-
-      QDataStream stream(&data, QIODevice::ReadOnly);
-      stream.setVersion(QDataStream::Qt_5_2);
-      stream.setByteOrder(QDataStream::LittleEndian);
-
-      IGisProject* project = nullptr;
-      switch (type) {
-        case IGisProject::eTypeQms: {
-          project = new CQmsProject(name, this);
-          project->setVisibility(visible);
-          *project << stream;
-          break;
-        }
-
-        case IGisProject::eTypeQlb: {
-          project = new CQlbProject(name, this);
-          project->setVisibility(visible);
-          *project << stream;
-          break;
-        }
-
-        case IGisProject::eTypeGpx: {
-          project = new CGpxProject(name, this);
-          project->setVisibility(visible);
-          *project << stream;
-          break;
-        }
-
-        case IGisProject::eTypeDb: {
-          CDBProject* dbProject;
-          project = dbProject = new CDBProject(IGisProject::eTypeDb, this);
-          project->setVisibility(visible);
-
-          project->IGisProject::operator<<(stream);
-          dbProject->restoreDBLink();
-
-          if (!project->isValid()) {
-            delete project;
-            project = nullptr;
-          } else {
-            dbProject->postStatus(false);
-          }
-          break;
-        }
-
-        case IGisProject::eTypeSlf: {
-          project = new CSlfProject(name, false);
-          project->setVisibility(visible);
-          *project << stream;
-
-          // the CSlfProject does not - as the other C*Project - register itself in the list
-          // of currently opened projects. This is done manually here.
-          addProject(project);
-          break;
-        }
-
-        case IGisProject::eTypeFit: {
-          project = new CFit2Project(name, this);
-          project->setVisibility(visible);
-          *project << stream;
-          break;
-        }
-
-        case IGisProject::eTypeTcx: {
-          project = new CTcxProject(name, this);
-          project->setVisibility(visible);
-          *project << stream;
-          break;
-        }
-
-        case IGisProject::eTypeSml: {
-          project = new CSmlProject(name, this);
-          project->setVisibility(visible);
-          *project << stream;
-          break;
-        }
-
-        case IGisProject::eTypeLog: {
-          project = new CSmlProject(name, this);
-          project->setVisibility(visible);
-          *project << stream;
-          break;
-        }
-      }
-
-      if (nullptr != project) {
-        // Hiding the individual projects from the map (1a, 1b, 1c) could be done here within a single statement,
-        // but this results in a visible `the checkbox is being unchecked`, especially in case the project
-        // is large and takes some time to load.
-        // When done directly after construction there is no `blinking` of the check mark
-        if (changed) {
-          project->setChanged();
-        }
+    if (nullptr != project) {
+      // Hiding the individual projects from the map (1a, 1b, 1c) could be done here within a single statement,
+      // but this results in a visible `the checkbox is being unchecked`, especially in case the project
+      // is large and takes some time to load.
+      // When done directly after construction there is no `blinking` of the check mark
+      if (changed) {
+        project->setChanged();
       }
     }
-  }  // close context for progress dialog
+  }
 
   slotGeoSearch(static_cast<QAction*>(CMainWindow::self().findChild<QAction*>("actionGeoSearch"))->isChecked());
 
@@ -1383,7 +1365,7 @@ static void closeProjects(const QList<QTreeWidgetItem*>& items) {
       if (IGisProject::eTypeGeoSearch == project->getType()) {
         CMainWindow::self().findChild<QAction*>("actionGeoSearch")->setChecked(false);
       }
-      delete project;
+      project->destroyLater();
     }
   }
 }
@@ -1430,7 +1412,7 @@ void CGisListWks::slotDeleteProject() {
       }
 
       if (project->remove()) {
-        delete project;
+        project->destroyLater();
       }
     }
   }
@@ -1552,7 +1534,21 @@ void CGisListWks::slotItemDoubleClicked(QTreeWidgetItem* item, int) {
   }
 }
 
-void CGisListWks::slotItemChanged(QTreeWidgetItem* /*item*/, int /*column*/) {
+void CGisListWks::slotItemChanged(QTreeWidgetItem* item, int /*column*/) {
+  // Check if the project or the item's project is flagged for no update.
+  // First try to derive the pointer to the project
+  IGisProject* itemPrj = dynamic_cast<IGisProject*>(item);
+  if (itemPrj == nullptr) {
+    IGisItem* itemGis = dynamic_cast<IGisItem*>(item);
+    if (itemGis != nullptr) {
+      itemPrj = dynamic_cast<IGisProject*>(itemGis->parent());
+    }
+  }
+  // If successfull check for the no update flag.
+  if (itemPrj != nullptr && (itemPrj->isNoUpdate() || !itemPrj->isVisible())) {
+    return;
+  }
+
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
   CGisWorkspace::self().slotWksItemSelectionReset();
   emit sigChanged();
@@ -2018,7 +2014,7 @@ bool CGisListWks::event(QEvent* e) {
             project = new CDBProject(evt->db, evt->id, this);
           }
           if (!project->isValid()) {
-            delete project;
+            project->destroyLater();
             break;
           }
           project->setWorkspaceFilter(CGisWorkspace::self().getCurrentSearch());
@@ -2031,7 +2027,10 @@ bool CGisListWks::event(QEvent* e) {
       case eEvtD2WHideFolder: {
         CEvtD2WHideFolder* evt = (CEvtD2WHideFolder*)e;
         CDBProject* project = getProjectById(evt->id, evt->db);
-        if (project && project->askBeforClose()) {
+        if (project == nullptr) {
+          break;
+        }
+        if (project->askBeforClose()) {
           /*
               Tell the DB view that we aborted to hide the folder by posting it's
               current status.
@@ -2039,7 +2038,7 @@ bool CGisListWks::event(QEvent* e) {
           project->postStatus(false);
           return false;
         }
-        delete project;
+        project->destroyLater();
 
         e->accept();
         emit sigChanged();

--- a/src/qmapshack/gis/CGisWorkspace.cpp
+++ b/src/qmapshack/gis/CGisWorkspace.cpp
@@ -111,7 +111,7 @@ void CGisWorkspace::loadGisProject(const QString& filename) {
                                tr("The project \"%1\" is already in the workspace.").arg(item->getName()),
                                QMessageBox::Abort);
 
-      delete item;
+      item->destroyLater();
       item = nullptr;
     }
 

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -38,7 +38,7 @@ constexpr int kFontSizeDiffProject = 2;
 constexpr int kFontSizeDiffItem = 3;
 constexpr int kFontSizeInvalid = -1;
 constexpr int kProgressBarHeight = 5;
-constexpr int kProgressBarHeightHalf = 3;
+constexpr int kProgressBarHeightHalf = 1;
 
 CWksItemDelegate::CWksItemDelegate(CGisListWks* parent) : QStyledItemDelegate(parent), treeWidget(parent) {
   SETTINGS;
@@ -128,7 +128,7 @@ QSize CWksItemDelegate::sizeHint(const QStyleOptionViewItem& opt, const QModelIn
   }
 }
 
-std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect, QRect, QRect> CWksItemDelegate::getRectanglesProject(
+std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect, QRect, QRect, QRect> CWksItemDelegate::getRectanglesProject(
     const QStyleOptionViewItem& opt, IWksItem& item) const {
   const QFont fontName = opt.font;
   const QFontMetrics fmName(fontName);
@@ -200,8 +200,11 @@ std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect, QRect, QRect> CWksIt
                        r.width() - rectIcon.width() - 2 * kMargin, fmStatus.height());
   }
 
-  return {fontName,    fontStatus, rectIcon,          rectName,       rectStatus,
-          rectVisible, rectSave,   rectActiveProject, rectAutoSyncDev};
+  const QRect rectProgress(rectIcon.right() + 4 * kMargin, r.bottom() - kProgressBarHeight,
+                           r.width() - rectIcon.width() - 8 * kMargin, kProgressBarHeight);
+
+  return {fontName,     fontStatus,  rectIcon, rectName,          rectStatus,
+          rectProgress, rectVisible, rectSave, rectActiveProject, rectAutoSyncDev};
 }
 
 std::tuple<QFont, QFont, QRect, QRect, QRect, QRect> CWksItemDelegate::getRectanglesItem(
@@ -403,7 +406,7 @@ void CWksItemDelegate::paintProject(QPainter* p, const QStyleOptionViewItem& opt
     return;
   }
 
-  auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectVisible, rectSave, rectActiveProject,
+  auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectProgress, rectVisible, rectSave, rectActiveProject,
         rectAutoSyncDev] = getRectanglesProject(opt, *project);
 
   const bool isOnDevice = item.isOnDevice() != IWksItem::eTypeNone;
@@ -477,7 +480,10 @@ void CWksItemDelegate::paintProject(QPainter* p, const QStyleOptionViewItem& opt
               isOnDevice ? project->getName() : project->getNameEx());
 
   // -- start ------------ status line ---------------------------------------
-  if (rectStatus.isValid()) {
+  auto [hasProgress, progress] = item.getProgress();
+  if (hasProgress) {
+    drawProgressBar(p, rectProgress, progress);
+  } else if (rectStatus.isValid()) {
     QString status;
     const QString& keywords = project->getKeywords();
     if (!keywords.isEmpty() && itemStatusControl.prj.keywords) {
@@ -557,7 +563,7 @@ void CWksItemDelegate::paintDevice(QPainter* p, const QStyleOptionViewItem& opt,
   // draw progress bar
   auto [hasProgress, progress] = item.getProgress();
   if (hasProgress) {
-    drawProgressBar(p, rectStatus, progress);
+    drawProgressBar(p, rectProgress, progress);
   } else {
     // draw status
     p->setPen(colorName);
@@ -764,7 +770,7 @@ bool CWksItemDelegate::editorEvent(QEvent* event, QAbstractItemModel* model, con
 
 bool CWksItemDelegate::mousePressProject(QMouseEvent* me, const QStyleOptionViewItem& opt, const QModelIndex& index,
                                          IWksItem& item) {
-  auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectVisible, rectSave, rectActiveProject,
+  auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectProgress, rectVisible, rectSave, rectActiveProject,
         rectAutoSyncDev] = getRectanglesProject(opt, item);
   if (rectVisible.contains(me->pos())) {
     item.setVisibility(!item.isVisible());
@@ -884,7 +890,7 @@ bool CWksItemDelegate::helpEvent(QHelpEvent* event, QAbstractItemView* view, con
 
 bool CWksItemDelegate::helpEventProject(const QPoint& pos, const QPoint& posGlobal, QAbstractItemView* view,
                                         const QStyleOptionViewItem& opt, IWksItem& item) {
-  auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectVisible, rectSave, rectActiveProject,
+  auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectProgress, rectVisible, rectSave, rectActiveProject,
         rectAutoSyncDev] = getRectanglesProject(opt, item);
   if (rectVisible.contains(pos)) {
     if (item.isVisible()) {

--- a/src/qmapshack/gis/CWksItemDelegate.h
+++ b/src/qmapshack/gis/CWksItemDelegate.h
@@ -147,7 +147,7 @@ class CWksItemDelegate : public QStyledItemDelegate {
  private:
   IWksItem* indexToItem(const QModelIndex& index) const;
 
-  std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect, QRect, QRect> getRectanglesProject(
+  std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect, QRect, QRect, QRect> getRectanglesProject(
       const QStyleOptionViewItem& opt, IWksItem& item) const;
   std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect> getRectanglesDevice(const QStyleOptionViewItem& opt,
                                                                                   const IWksItem& item) const;

--- a/src/qmapshack/gis/gpx/CGpxProject.cpp
+++ b/src/qmapshack/gis/gpx/CGpxProject.cpp
@@ -60,7 +60,7 @@ CGpxProject::CGpxProject(const QString& filename, const IGisProject* project, ID
     : IGisProject(eTypeGpx, filename, parent) {
   icon = QPixmap("://icons/32x32/GpxProject.png");
   *(IGisProject*)this = *project;
-  blockUpdateItems(project->blockUpdateItems());
+  blockUpdateItems(project->isNoUpdate());
 
   CSelectCopyAction::result_e res = CSelectCopyAction::eResultNone;
   const int N = project->childCount();

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -1070,7 +1070,7 @@ void CDetailsPrj::slotSortMode(int idx) {
 }
 
 void CDetailsPrj::updateData() {
-  if (!prj.blockUpdateItems()) {
+  if (!prj.isNoUpdate()) {
     slotSetupGui();
   }
 }

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -45,6 +45,7 @@
 #include "gis/wpt/CGisItemWpt.h"
 #include "helpers/CSelectCopyAction.h"
 #include "helpers/CSettings.h"
+#include "helpers/CThread.h"
 #include "misc.h"
 
 const QString IGisProject::filedialogAllSupported =
@@ -97,10 +98,28 @@ IGisProject::IGisProject(type_e type, const QString& filename, IDevice* parent)
 }
 
 IGisProject::~IGisProject() {
+  if (threadLoadPoject != nullptr) {
+    qWarning() << getName() << "threadLoadPoject is still active!";
+    threadLoadPoject->requestInterruption();
+  }
   delete dlgDetails;
   if (key == keyUserFocus && isOnDevice() == IDevice::eTypeNone) {
     keyUserFocus.clear();
   }
+}
+
+void IGisProject::destroyLater() {
+  QMutexLocker lock(&IGisItem::mutexItems);
+  if (threadLoadPoject != nullptr) {
+    threadLoadPoject->requestInterruption();
+  }
+  QMetaObject::invokeMethod(
+      &CGisWorkspace::self(),
+      [this]() {
+        QMutexLocker lock(&IGisItem::mutexItems);
+        delete this;
+      },
+      Qt::QueuedConnection);
 }
 
 IGisProject* IGisProject::create(const QString filename, CGisListWks* parent) {
@@ -284,7 +303,7 @@ void IGisProject::switchOnCorrelation() {
 }
 
 void IGisProject::updateItems() {
-  if (noUpdate) {
+  if (isNoUpdate()) {
     return;
   }
 
@@ -689,7 +708,7 @@ void IGisProject::insertCopyOfItem(IGisItem* item, int off, CSelectCopyAction::r
 }
 
 void IGisProject::drawItem(QPainter& p, const QPolygonF& viewport, QList<QRectF>& blockedAreas, CGisDraw* gis) {
-  if (!isVisible()) {
+  if (!isVisible() || isNoUpdate()) {
     return;
   }
 
@@ -708,7 +727,7 @@ void IGisProject::drawItem(QPainter& p, const QPolygonF& viewport, QList<QRectF>
 }
 
 void IGisProject::drawItem(QPainter& p, const QRectF& viewport, CGisDraw* gis) {
-  if (!isVisible()) {
+  if (!isVisible() || isNoUpdate()) {
     return;
   }
 

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -36,6 +36,7 @@ class CGisItemWpt;
 class QDataStream;
 class CDetailsPrj;
 class IDevice;
+class CThread;
 
 class IGisProject : public IWksItem {
   Q_DECLARE_TR_FUNCTIONS(IGisProject)
@@ -93,9 +94,15 @@ class IGisProject : public IWksItem {
 
   IGisProject(type_e type, const QString& filename, CGisListWks* parent);
   IGisProject(type_e type, const QString& filename, IDevice* parent);
-  virtual ~IGisProject();
 
   static IGisProject* create(const QString filename, CGisListWks* parent);
+
+  /**
+   * @brief Delayed delete to abort any threaded operations.
+   *
+   * This is the preferred way to destroy a IGisProject instance.
+   */
+  void destroyLater();
 
   /**
      @brief Ask to save the project before it is closed.
@@ -389,12 +396,6 @@ class IGisProject : public IWksItem {
    */
   void blockUpdateItems(bool yes);
 
-  /**
-     @brief  Return state of current update block
-     @return True if updates are blocked.
-   */
-  bool blockUpdateItems() const { return noUpdate; }
-
   void setProjectFilter(const CSearch& search);
   void setWorkspaceFilter(const CSearch& search);
   void applyFilters();
@@ -413,7 +414,17 @@ class IGisProject : public IWksItem {
   void filterProject(bool filter);
   CProjectFilterItem* getProjectFilterItem() { return projectFilter; }
 
+  /**
+     @brief  Return state of current update block
+     @return True if updates are blocked.
+   */
+  bool isNoUpdate() const { return noUpdate; }
+
  protected:
+  /**
+   * @brief Do not use delete directly. Use destroyLater() instead.
+   */
+  virtual ~IGisProject();
   using IWksItem::updateDecoration;
   void genKey() const;
   virtual void setupName(const QString& defaultName);
@@ -457,7 +468,6 @@ class IGisProject : public IWksItem {
   mutable QString key;
   QString filename;
   bool valid = false;
-  bool noUpdate = false;
   bool noCorrelation = false;
   bool changedRoadbookMode = false;
 
@@ -488,6 +498,10 @@ class IGisProject : public IWksItem {
   CSearch workspaceSearch = CSearch("");
 
   QPointer<CProjectFilterItem> projectFilter;
+  QPointer<CThread> threadLoadPoject;
+
+ private:
+  bool noUpdate = false;
 };
 Q_DECLARE_METATYPE(IGisProject*)
 

--- a/src/qmapshack/gis/qms/serialization.cpp
+++ b/src/qmapshack/gis/qms/serialization.cpp
@@ -26,6 +26,7 @@
 #include "gis/trk/CGisItemTrk.h"
 #include "gis/wpt/CGisItemWpt.h"
 #include "helpers/CLimit.h"
+#include "helpers/CThread.h"
 #include "helpers/CValue.h"
 
 #define VER_TRK quint8(7)
@@ -860,6 +861,14 @@ QDataStream& CGisItemOvlArea::operator>>(QDataStream& stream) const {
 }
 
 QDataStream& IGisProject::operator<<(QDataStream& stream) {
+  struct temp_item_data_t {
+    QString lastDatabaseHash;
+    IGisItem::history_t history;
+    quint8 changed;
+    quint8 version;
+    quint8 type;
+  };
+
   quint8 version;
   QIODevice* dev = stream.device();
   qint64 pos = dev->pos();
@@ -871,8 +880,6 @@ QDataStream& IGisProject::operator<<(QDataStream& stream) {
     dev->seek(pos);
     return stream;
   }
-
-  blockUpdateItems(true);
 
   stream >> version;
   if (filename.isEmpty()) {
@@ -913,56 +920,107 @@ QDataStream& IGisProject::operator<<(QDataStream& stream) {
     sortingFolder = (sorting_folder_e)tmp;
   }
 
+  QList<temp_item_data_t> items;
   while (!stream.atEnd()) {
-    QString lastDatabaseHash;
-    IGisItem::history_t history;
-    quint8 changed = 0;
-    quint8 version, type;
-    stream >> version;
-    stream >> type;
-    stream >> history;
+    temp_item_data_t item;
+
+    stream >> item.version;
+    stream >> item.type;
+    stream >> item.history;
     if (version > 1) {
-      stream >> changed;
+      stream >> item.changed;
     }
 
     if (version > 2) {
-      stream >> lastDatabaseHash;
+      stream >> item.lastDatabaseHash;
     }
-
-    IGisItem* item = nullptr;
-    switch (type) {
-      case IGisItem::eTypeWpt:
-        item = new CGisItemWpt(history, lastDatabaseHash, this);
-        break;
-
-      case IGisItem::eTypeTrk:
-        item = new CGisItemTrk(history, lastDatabaseHash, this);
-        break;
-
-      case IGisItem::eTypeRte:
-        item = new CGisItemRte(history, lastDatabaseHash, this);
-        break;
-
-      case IGisItem::eTypeOvl:
-        item = new CGisItemOvlArea(history, lastDatabaseHash, this);
-        break;
-
-      default:;
-    }
-
-    // Update decoration always, to set possible rating and tag markers
-    if (item) {
-      if (changed) {
-        item->updateDecoration(IWksItem::eMarkChanged, IWksItem::eMarkNone);
-      } else {
-        item->updateDecoration(IWksItem::eMarkNone, IWksItem::eMarkNone);
-      }
-    }
+    items << item;
   }
 
-  sortItems();
+  // Let the chaos start!
+  // To keep the UI responsive and to update the progress bars the load process has to be
+  // orchestrated in a thread. However all the UI dependent stuff has to be done in the main UI
+  // thread, making things very complicated. The strategy:
+  //  * Place all UI dependent stuff in a QMetaObject::invokeMethod() call
+  //  * The first thing to do when scheduled is to check for the thread has been requested to
+  //    finish. In this case return immediately.
+  //  * Wait in the thread for all QMetaObject::invokeMethod() to finish (Qt::BlockingQueuedConnection)
+  //  * After a wait (Qt::BlockingQueuedConnection) check if the thread has been requested to finish
+  //    In this case return immediately.
+  threadLoadPoject = new CThread([this, items]() {
+    const quint32 total = items.count();
+    quint32 count = 0;
 
-  blockUpdateItems(false);
+    QMetaObject::invokeMethod(
+        treeWidget(),
+        [this]() {
+          if (threadLoadPoject == nullptr || threadLoadPoject->isInterruptionRequested()) {
+            return;
+          }
+          blockUpdateItems(true);
+        },
+        Qt::BlockingQueuedConnection);
+
+    for (const temp_item_data_t& itemData : items) {
+      if (threadLoadPoject == nullptr || threadLoadPoject->isInterruptionRequested()) {
+        break;
+      }
+      setProgress(++count, total);
+      QMetaObject::invokeMethod(
+          treeWidget(),
+          [this, itemData]() {
+            if (threadLoadPoject == nullptr || threadLoadPoject->isInterruptionRequested()) {
+              return;
+            }
+            QMutexLocker lock(&IGisItem::mutexItems);
+            IGisItem* item = nullptr;
+            switch (itemData.type) {
+              case IGisItem::eTypeWpt:
+                item = new CGisItemWpt(itemData.history, itemData.lastDatabaseHash, this);
+                break;
+
+              case IGisItem::eTypeTrk:
+                item = new CGisItemTrk(itemData.history, itemData.lastDatabaseHash, this);
+                break;
+
+              case IGisItem::eTypeRte:
+                item = new CGisItemRte(itemData.history, itemData.lastDatabaseHash, this);
+                break;
+
+              case IGisItem::eTypeOvl:
+                item = new CGisItemOvlArea(itemData.history, itemData.lastDatabaseHash, this);
+                break;
+
+              default:;
+            }
+
+            // Update decoration always, to set possible rating and tag markers
+            if (item) {
+              if (itemData.changed) {
+                item->updateDecoration(IWksItem::eMarkChanged, IWksItem::eMarkNone);
+              } else {
+                item->updateDecoration(IWksItem::eMarkNone, IWksItem::eMarkNone);
+              }
+            }
+          },
+          Qt::BlockingQueuedConnection);
+    }  // end for loop
+
+    QMetaObject::invokeMethod(
+        treeWidget(),
+        [this]() {
+          if (threadLoadPoject == nullptr || threadLoadPoject->isInterruptionRequested()) {
+            return;
+          }
+          blockUpdateItems(false);
+        },
+        Qt::BlockingQueuedConnection);
+    if (threadLoadPoject == nullptr || threadLoadPoject->isInterruptionRequested()) {
+      return;
+    }
+    setProgress(total, total);
+  });
+  threadLoadPoject->start();
   return stream;
 }
 

--- a/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
+++ b/src/qmapshack/gis/summary/CGisSummaryDropZone.cpp
@@ -103,6 +103,6 @@ void CGisSummaryDropZone::dropEvent(QDropEvent* e) {
     }
 
     project->save(saveActionForAll);
-    delete project;
+    project->destroyLater();
   }
 }

--- a/src/qmapshack/gis/tcx/CTcxProject.cpp
+++ b/src/qmapshack/gis/tcx/CTcxProject.cpp
@@ -42,7 +42,7 @@ CTcxProject::CTcxProject(const QString& filename, const IGisProject* project, ID
     : IGisProject(eTypeGpx, filename, parent) {
   icon = QPixmap("://icons/32x32/TcxProject.png");
   *(IGisProject*)this = *project;
-  blockUpdateItems(project->blockUpdateItems());
+  blockUpdateItems(project->isNoUpdate());
 
   CSelectCopyAction::result_e res = CSelectCopyAction::eResultNone;
   const int N = project->childCount();

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -2571,7 +2571,7 @@ void CGisItemTrk::updateHistory(quint32 visuals) {
 }
 
 void CGisItemTrk::updateVisuals(quint32 visuals, const QString& who) {
-  qDebug() << "CGisItemTrk::updateVisuals()" << getName() << who;
+  // qDebug() << "CGisItemTrk::updateVisuals()" << getName() << who << Qt::hex << visuals;
 
   if (!dlgDetails.isNull() && (visuals & eVisualDetails)) {
     dlgDetails->updateData();


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1004

### What you have done:
[comment]: # (Describe roughly.)

I broke up the operator<<() method of IGisProject into a part done when called and a thread loading the GIS items of a project. As everything UI related has to be done in the main UI thread, the thread main duty is to queue chunks of code to be executed in the main thread. This is a quite awkward way to do it but with the current data/view model of QMapShack the only way to do it.

It has some caveats: 
* performance is a bit less than before. This is the trade off to have a responsive UI, switching back and forth between threads.
* It's not 100% crash safe. See testing section for details

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Load a few chunky projects into the workspace, 
2. Restart QMapShack
3. Projects should be restored displaying a progress bar
4. Moving the map while loading should be ok
5. Removing all projects (F8) while loading should be ok
6. Expanding a project while loading should be ok
7. !!! Closing QMS while loading will result into a segfault. This is known. I see no way to fix that.!!!

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
