### PR TITLE
[QMS-1009] Fix: Workspace icon size does not follow font size

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-996] Fix: POIs not displayed (macOS)
 [QMS-998] Add progress bar to GPS devices while loading records
 [QMS-1004] Add progress bar in projects while restoring the workspace
+[QMS-1009] Fix: Workspace icon size does not follow font size
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/gis/CDBItemDelegate.cpp
+++ b/src/qmapshack/gis/CDBItemDelegate.cpp
@@ -107,7 +107,8 @@ void CDBItemDelegate::paint(QPainter* p, const QStyleOptionViewItem& opt, const 
 
   auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectButton] = getRectangles(opt, *item);
 
-  QIcon(item->getIcon()).paint(p, rectIcon, Qt::AlignCenter);
+  const QPixmap& icon = item->getIcon().scaled(rectIcon.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  QIcon(icon).paint(p, rectIcon, Qt::AlignCenter);
 
   if (rectButton.isValid()) {
     switch (item->getCheckState()) {

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -416,7 +416,8 @@ void CWksItemDelegate::paintProject(QPainter* p, const QStyleOptionViewItem& opt
                         opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
 
   // draw icon
-  QIcon(item.getIcon()).paint(p, rectIcon, Qt::AlignCenter, item.isVisible() ? QIcon::Normal : QIcon::Disabled);
+  const QPixmap& icon = item.getIcon().scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+  QIcon(icon).paint(p, rectIcon, Qt::AlignCenter, item.isVisible() ? QIcon::Normal : QIcon::Disabled);
 
   // draw tool button to toggle visibility
   drawToolButton(p, opt, rectVisible,
@@ -554,7 +555,8 @@ void CWksItemDelegate::paintDevice(QPainter* p, const QStyleOptionViewItem& opt,
   p->drawText(rectName.adjusted(0, -1, 0, 1), Qt::AlignLeft | Qt::AlignTop, item.getName());
 
   // draw icon
-  QIcon(item.getIcon()).paint(p, rectIcon, Qt::AlignCenter, isVisible ? QIcon::Normal : QIcon::Disabled);
+  const QPixmap& icon = item.getIcon().scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+  QIcon(icon).paint(p, rectIcon, Qt::AlignCenter, isVisible ? QIcon::Normal : QIcon::Disabled);
 
   // draw tool button to activate
   drawToolButton(p, opt, rectVisible,
@@ -686,7 +688,8 @@ void CWksItemDelegate::paintItem(QPainter* p, const QStyleOptionViewItem& opt, c
   // -- stop ------------ status line ---------------------------------------
 
   // draw icon
-  QIcon(item.getIcon()).paint(p, rectIcon, Qt::AlignCenter, iconMode);
+  const QPixmap& icon = item.getIcon().scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+  QIcon(icon).paint(p, rectIcon, Qt::AlignCenter, iconMode);
 
   // draw save/changed icon
   if (rectChanged.isValid()) {
@@ -706,7 +709,8 @@ void CWksItemDelegate::paintGeoSearch(QPainter* p, const QStyleOptionViewItem& o
       getRectanglesGeoSearch(opt);
   const bool isVisible = item.isVisible();
 
-  QIcon(item.getIcon()).paint(p, rectIcon, Qt::AlignCenter, isVisible ? QIcon::Normal : QIcon::Disabled);
+  const QPixmap& icon = item.getIcon().scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+  QIcon(icon).paint(p, rectIcon, Qt::AlignCenter, isVisible ? QIcon::Normal : QIcon::Disabled);
   QIcon(":/icons/32x32/Apply.png").paint(p, rectSetup, Qt::AlignCenter, QIcon::Normal);
   QIcon(search->getWptIcon()).paint(p, rectWptIcon, Qt::AlignCenter, QIcon::Normal);
 
@@ -737,7 +741,8 @@ void CWksItemDelegate::paintGeoSearchError(QPainter* p, const QStyleOptionViewIt
   auto [font, rectIcon, rectName] = getRectanglesGeoSearchError(opt);
   const bool isVisible = item.isVisible();
 
-  QIcon(item.getIcon()).paint(p, rectIcon, Qt::AlignCenter, isVisible ? QIcon::Normal : QIcon::Disabled);
+  const QPixmap& icon = item.getIcon().scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+  QIcon(icon).paint(p, rectIcon, Qt::AlignCenter, isVisible ? QIcon::Normal : QIcon::Disabled);
   const QColor& color = opt.palette.color(isVisible ? QPalette::Active : QPalette::Disabled, QPalette::WindowText);
 
   p->setPen(color);

--- a/src/qmapshack/helpers/CWptIconManager.cpp
+++ b/src/qmapshack/helpers/CWptIconManager.cpp
@@ -2027,11 +2027,11 @@ void CWptIconManager::init() {
     setWptIconByName(name, path, categories, tags, vendors);
   }
 
-  for (const CWptIconManager::icon_t &icon : wptIcons) {
-    for (const QString &vendor : icon.vendors) {
-      for (const QString &category : icon.categories) {
+  for (const CWptIconManager::icon_t& icon : wptIcons) {
+    for (const QString& vendor : icon.vendors) {
+      for (const QString& category : icon.categories) {
         if (!vendorCategories.contains(vendor)) {
-          vendorCategories[vendor] = { category };
+          vendorCategories[vendor] = {category};
         } else if (!vendorCategories[vendor].contains(category)) {
           vendorCategories[vendor].append(category);
         }
@@ -2095,14 +2095,6 @@ QPixmap CWptIconManager::getWptIconByName(const QString& name, QPointF& focus, Q
   }
 
   QPixmap icon = loadIcon(iconRef.path);
-
-  // Limit icon size to "DEFAULTICONSIZE" pixel max.
-  int maxValue = qMax(icon.width(), icon.height());
-  if (maxValue > DEFAULTICONSIZE) {
-    qreal scale = qreal(DEFAULTICONSIZE) / maxValue;
-    focus = focus * scale;
-    icon = icon.scaled(icon.size() * scale, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-  }
 
   return icon;
 }

--- a/src/qmapshack/map/CMapItemDelegate.cpp
+++ b/src/qmapshack/map/CMapItemDelegate.cpp
@@ -189,7 +189,7 @@ void CMapItemDelegate::initStyleOption(QStyleOptionViewItem* option, const QMode
   if (!data.contains(key)) {
     data.insert(key, {});
   }
-  data[key].icon = option->icon;
+  data[key].icon = option->icon.pixmap({48, 48});
   option->features &= ~QStyleOptionViewItem::HasDecoration;
 }
 
@@ -273,7 +273,9 @@ void CMapItemDelegate::paint(QPainter* p, const QStyleOptionViewItem& opt, const
   p->drawText(rectStatus.adjusted(0, -1, 0, 1), Qt::AlignLeft | Qt::AlignVCenter, status);
 
   // draw icon
-  data[keyFromIndex(index)].icon.paint(p, rectIcon);
+  const QPixmap& icon =
+      data[keyFromIndex(index)].icon.scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+  QIcon(icon).paint(p, rectIcon);
 
   // draw tool button to activate
   QStyleOptionToolButton btnOpt;

--- a/src/qmapshack/map/CMapItemDelegate.h
+++ b/src/qmapshack/map/CMapItemDelegate.h
@@ -86,7 +86,7 @@ class CMapItemDelegate : public QStyledItemDelegate {
   };
 
   struct item_data_t {
-    QIcon icon;
+    QPixmap icon;
     animations_t animations;
   };
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1009

### What you have done:
[comment]: # (Describe roughly.)

Scale all icons to rectIcon before painting them

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
