### PR TITLE
[QMS-1013] Fix: Icons do not fit into on screen multiple selection circles

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-998] Add progress bar to GPS devices while loading records
 [QMS-1004] Add progress bar in projects while restoring the workspace
 [QMS-1009] Fix: Workspace icon size does not follow font size
+[QMS-1013] Fix: Icons do not fit into on screen multiple selection circles
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/mouse/CScrOptUnclutter.cpp
+++ b/src/qmapshack/mouse/CScrOptUnclutter.cpp
@@ -84,7 +84,7 @@ void CScrOptUnclutter::addItem(IGisItem* gisItem) {
   item.hasUserFocus = gisItem->hasUserFocus();
   item.name = gisItem->getNameEx();
   item.key = gisItem->getKey();
-  item.icon = gisItem->getDisplayIcon();
+  item.icon = gisItem->getDisplayIcon().scaled(22,22,Qt::KeepAspectRatio,Qt::SmoothTransformation);
   item.area = item.icon.rect();
   item.active = item.area.adjusted(-10, -10, 10, 10);
 }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1013

### What you have done:
[comment]: # (Describe roughly.)

Downscale icons in function `CScrOptUnclutter::addItem` to 22 pixels:
<img width="1003" height="255" alt="grafik" src="https://github.com/user-attachments/assets/ef48157c-d9d2-4f4b-9671-7c420e8d5317" />


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Click track/route intersection and/or matching waypoint/track/route
2. See that track/route/waypoint icons fit into circles

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
