### PR TITLE
[QMS-1012] Fix: Delegate entries possibly hardly readable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,8 @@ V1.XX.X
 [QMS-998] Add progress bar to GPS devices while loading records
 [QMS-1004] Add progress bar in projects while restoring the workspace
 [QMS-1009] Fix: Workspace icon size does not follow font size
+[QMS-1012] Fix: Delegate entries possibly hardly readable
+[QMS-1013] Fix: Icons do not fit into on screen multiple selection circles
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/gis/CDBItemDelegate.cpp
+++ b/src/qmapshack/gis/CDBItemDelegate.cpp
@@ -124,22 +124,23 @@ void CDBItemDelegate::paint(QPainter* p, const QStyleOptionViewItem& opt, const 
     }
   }
 
-  QColor color = opt.palette.color(QPalette::Active,
-                                   opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
+  QColor color = opt.palette.color(colorGroup,
+                                   opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
 
   IDBItem* parent = dynamic_cast<IDBItem*>(item->parent());
   if (item->type() == IDBItem::eTypeItem) {
     if (parent && parent->type() == IDBItem::eTypeLostFound) {
-      color = opt.palette.color(parent->getCheckState() != Qt::Unchecked ? QPalette::Active : QPalette::Disabled,
-                                opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+      color = opt.palette.color(parent->getCheckState() != Qt::Unchecked ? colorGroup : QPalette::Disabled,
+                                opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
     } else {
-      color = opt.palette.color(item->getCheckState() != Qt::Unchecked ? QPalette::Active : QPalette::Disabled,
-                                opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+      color = opt.palette.color(item->getCheckState() != Qt::Unchecked ? colorGroup : QPalette::Disabled,
+                                opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
     }
   } else if (item->type() > IDBItem::eTypeGroup) {
     fontName.setBold(item->getCheckState() != Qt::Unchecked);
-    color = opt.palette.color(item->getCheckState() != Qt::PartiallyChecked ? QPalette::Active : QPalette::Disabled,
-                              opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+    color = opt.palette.color(item->getCheckState() != Qt::PartiallyChecked ? colorGroup : QPalette::Disabled,
+                              opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
   }
 
   p->setPen(color);

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -411,9 +411,10 @@ void CWksItemDelegate::paintProject(QPainter* p, const QStyleOptionViewItem& opt
 
   const bool isOnDevice = item.isOnDevice() != IWksItem::eTypeNone;
   const bool isVisible = item.isVisible();
+  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
   const QColor& colorName =
-      opt.palette.color(isVisible ? QPalette::Active : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+      opt.palette.color(isVisible ? colorGroup : QPalette::Disabled,
+                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
 
   // draw icon
   const QPixmap& icon = item.getIcon().scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
@@ -544,9 +545,10 @@ void CWksItemDelegate::paintDevice(QPainter* p, const QStyleOptionViewItem& opt,
       getRectanglesDevice(opt, item);
 
   const bool isVisible = item.isVisible();
+  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
   const QColor& colorName =
-      opt.palette.color(isVisible ? QPalette::Active : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+      opt.palette.color(isVisible ? colorGroup : QPalette::Disabled,
+                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
 
   // draw name
   fontName.setBold(item.hasUserFocus());
@@ -581,9 +583,10 @@ void CWksItemDelegate::paintItem(QPainter* p, const QStyleOptionViewItem& opt, c
 
   const bool isVisible = item.isVisible();
   const QIcon::Mode iconMode = isVisible ? QIcon::Normal : QIcon::Disabled;
+  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
   const QColor& colorName =
-      opt.palette.color(isVisible ? QPalette::Active : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+      opt.palette.color(isVisible ? colorGroup : QPalette::Disabled,
+                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
 
   // draw name
   fontName.setBold(item.hasUserFocus());

--- a/src/qmapshack/map/CMapItemDelegate.cpp
+++ b/src/qmapshack/map/CMapItemDelegate.cpp
@@ -236,9 +236,10 @@ void CMapItemDelegate::paint(QPainter* p, const QStyleOptionViewItem& opt, const
   const bool isActive = item->getStatus() == IMapItem::eStatus::Active;
 
   // derive strings colors
+  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
   QColor colorName =
-      opt.palette.color(isActive ? QPalette::Active : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::BrightText : QPalette::WindowText);
+      opt.palette.color(isActive ? colorGroup : QPalette::Disabled,
+                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
 
   QColor colorStatus = colorName;
   QString status;

--- a/src/qmapshack/mouse/CScrOptUnclutter.cpp
+++ b/src/qmapshack/mouse/CScrOptUnclutter.cpp
@@ -84,7 +84,7 @@ void CScrOptUnclutter::addItem(IGisItem* gisItem) {
   item.hasUserFocus = gisItem->hasUserFocus();
   item.name = gisItem->getNameEx();
   item.key = gisItem->getKey();
-  item.icon = gisItem->getDisplayIcon().scaled(22,22,Qt::KeepAspectRatio,Qt::SmoothTransformation);
+  item.icon = gisItem->getDisplayIcon().scaled(22, 22, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   item.area = item.icon.rect();
   item.active = item.area.adjusted(-10, -10, 10, 10);
 }

--- a/src/qmapshack/mouse/CScrOptUnclutter.cpp
+++ b/src/qmapshack/mouse/CScrOptUnclutter.cpp
@@ -84,7 +84,7 @@ void CScrOptUnclutter::addItem(IGisItem* gisItem) {
   item.hasUserFocus = gisItem->hasUserFocus();
   item.name = gisItem->getNameEx();
   item.key = gisItem->getKey();
-  item.icon = gisItem->getDisplayIcon();
+  item.icon = gisItem->getDisplayIcon().scaled(22,22,Qt::KeepAspectRatio,Qt::SmoothTransformation);
   item.area = item.icon.rect();
   item.active = item.area.adjusted(-10, -10, 10, 10);
 }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1012

### What you have done:
[comment]: # (Describe roughly.)

Set text highlight color for delegate entries according to state either from QPalette::Active or from QPalette::Inactive.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Select delegate entry project, project item, map item, dem item or database item
2. See that entry has easily readable highlighted text on highlighted background
3. Click anywhere in QMS main window -> entry loses input focus -> highlighted background color changes 
4. See that entry has still easily readable highlighted text on highlighted background

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
