### PR TITLE
[QMS-1018] Fix: Warnings in CMapItemDelegate

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-1009] Fix: Workspace icon size does not follow font size
 [QMS-1012] Fix: Delegate entries possibly hardly readable
 [QMS-1013] Fix: Icons do not fit into on screen multiple selection circles
+[QMS-1018] Fix: Warnings in CMapItemDelegate
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/map/CMapItemDelegate.cpp
+++ b/src/qmapshack/map/CMapItemDelegate.cpp
@@ -190,7 +190,8 @@ void CMapItemDelegate::initStyleOption(QStyleOptionViewItem* option, const QMode
     data.insert(key, {});
   }
   data[key].icon = option->icon.pixmap({48, 48});
-  option->features &= ~QStyleOptionViewItem::HasDecoration;
+  option->icon = QIcon();
+  option->decorationSize = QSize(0, 0);
 }
 
 std::tuple<QFont, QFont, QRect, QRect, QRect, QRect, QRect> CMapItemDelegate::getRectangles(


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1018

### What you have done:
[comment]: # (Describe roughly.)

Remove the decoration from the QStyleOptionViewItem was done wrong

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Start QMapShack
* Select a map item 

Without the patch warnings are seen
With the patch no warnings are seen.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
