### PR TITLE
[QMS-1021] Dev: Add unique key to views for better identification

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,9 @@ V1.XX.X
 [QMS-1012] Fix: Delegate entries possibly hardly readable
 [QMS-1013] Fix: Icons do not fit into on screen multiple selection circles
 [QMS-1018] Fix: Warnings in CMapItemDelegate
+[QMS-1021] Dev: Add unique key to views for better identification
 [QMS-1024] Fix: Accessibility issue : font is too small (macOS)
+
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -71,6 +71,7 @@
 #include "version.h"
 
 #ifdef Q_OS_WIN64
+// clang-format off
 #include <windows.h>
 #include <dbt.h>
 #include <guiddef.h>
@@ -78,6 +79,7 @@
 #include <usbiodef.h>
 
 #include "device/CDeviceWatcherWindows.h"
+// clang-format on
 #endif  // Q_OS_WIN64
 
 CMainWindow* CMainWindow::pSelf = nullptr;
@@ -226,15 +228,13 @@ CMainWindow::CMainWindow() : id(QRandomGenerator::global()->generate()) {
   connect(actionRenameView, &QAction::triggered, this, &CMainWindow::slotRenameView);
   connect(tabWidget, &QTabWidget::tabCloseRequested, this, &CMainWindow::slotTabCloseRequest);
   connect(tabWidget, &QTabWidget::tabBarDoubleClicked, this, &CMainWindow::slotRenameView);
-  connect(tabWidget, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabCanvas);
-  connect(tabMaps, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabMaps);
-  connect(tabDem, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabDem);
-  connect(tabWidget, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabCanvas);
 
   // to keep tab order in sync with map, dem and poi tab widgets
+  connect(tabWidget, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabCanvas);
   connect(tabMaps, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabMaps);
   connect(tabDem, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabDem);
   connect(tabPoi, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabPoi);
+
   connect(tabWidget->tabBar(), &QTabBar::tabMoved, this, [this](int from, int to) {
     tabMaps->tabBar()->moveTab(from, to);
     tabDem->tabBar()->moveTab(from, to);
@@ -250,23 +250,22 @@ CMainWindow::CMainWindow() : id(QRandomGenerator::global()->generate()) {
   CDemDraw::loadDemPath(cfg);
   CPoiDraw::loadPoiPath(cfg);
 
-  QStringList names = cfg.value("canvasOrder").toStringList();
+  QStringList keys = cfg.value("canvasOrder").toStringList();
 
   cfg.beginGroup("Views");
-  if (names.isEmpty()) {
-    names = cfg.childGroups();
+  if (keys.isEmpty()) {
+    keys = cfg.childGroups();
   }
 
-  for (const QString& name : names) {
-    CCanvas* view = createCanvas(name);
-
-    cfg.beginGroup(name);
+  for (const QString& key : keys) {
+    CCanvas* view = createCanvas(key);
+    cfg.beginGroup(key);
     view->loadConfig(cfg);
-    cfg.endGroup();  // name
+    cfg.endGroup();  // key
   }
-  if (names.isEmpty()) {
+  if (keys.isEmpty()) {
     // keep for new installations without config
-    CCanvas* view = createCanvas(QString());
+    CCanvas* view = createCanvas("");
     // call just to setup default values
     cfg.beginGroup(view->objectName());
     view->loadConfig(cfg);
@@ -536,7 +535,7 @@ CMainWindow::~CMainWindow() {
   cfg.beginGroup("Canvas");
   QList<CCanvas*> allViews;
   QList<QWidget*> allOtherTabs;
-  QStringList allViewNames;
+  QStringList allViewKeys;
 
   // save setup of all views
   cfg.beginGroup("Views");
@@ -553,8 +552,8 @@ CMainWindow::~CMainWindow() {
     }
 
     // save views
-    allViewNames << view->objectName();
-    cfg.beginGroup(view->objectName());
+    allViewKeys << view->getKey();
+    cfg.beginGroup(view->getKey());
     view->saveConfig(cfg);
     cfg.endGroup();
 
@@ -562,7 +561,7 @@ CMainWindow::~CMainWindow() {
   }
   cfg.endGroup();  // Views
 
-  cfg.setValue("canvasOrder", allViewNames);
+  cfg.setValue("canvasOrder", allViewKeys);
   cfg.setValue("gisLayerOpacity", CCanvas::gisLayerOpacity);
   cfg.setValue("visibleCanvas", tabWidget->currentIndex());
   cfg.setValue("isGeosearchVisible", actionGeoSearch->isChecked());
@@ -651,9 +650,9 @@ void CMainWindow::setupHomePath() {
   cfg.setValue("Paths/homePath", homeDir.absolutePath());
 }
 
-CCanvas* CMainWindow::createCanvas(const QString& name) {
-  CCanvas* view = new CCanvas(tabWidget, name);
-  tabWidget->addTab(view, view->objectName());
+CCanvas* CMainWindow::createCanvas(const QString& key) {
+  CCanvas* view = new CCanvas(tabWidget, key);
+  tabWidget->addTab(view, view->getName());
   connect(view, &CCanvas::sigMousePosition, this, &CMainWindow::slotMousePosition);
   connect(view, &CCanvas::sigMoveAndZoom, this, &CMainWindow::slotMapMoveAndZoom);
   connect(actionShowTrackHighlight, &QAction::changed, view, [view] { view->slotUpdateTrackInfo(false); });
@@ -662,6 +661,11 @@ CCanvas* CMainWindow::createCanvas(const QString& name) {
   connect(actionShowTrackInfoPoints, &QAction::changed, view, [view] { view->slotUpdateTrackInfo(true); });
   connect(actionShowTrackSummary, &QAction::changed, view, [view] { view->slotUpdateTrackInfo(false); });
   connect(actionShowTrackProfile, &QAction::changed, view, [view] { view->slotUpdateTrackInfo(false); });
+
+  connect(view, &CCanvas::sigNameChanged, this, [this](const CCanvas& canvas) {
+    int idx = tabWidget->indexOf(&canvas);
+    tabWidget->setTabText(idx, canvas.getName());
+  });
 
   return view;
 }
@@ -728,11 +732,11 @@ bool CMainWindow::flipMouseWheel() const { return actionFlipMouseWheel->isChecke
 
 bool CMainWindow::profileIsWindow() const { return actionProfileIsWindow->isChecked(); }
 
-void CMainWindow::addMapList(CMapList* list, const QString& name) { tabMaps->addTab(list, name); }
+void CMainWindow::addMapList(CMapList* list) { list->addToTabWidget(tabMaps); }
 
-void CMainWindow::addDemList(CDemList* list, const QString& name) { tabDem->addTab(list, name); }
+void CMainWindow::addDemList(CDemList* list) { list->addToTabWidget(tabDem); }
 
-void CMainWindow::addPoiList(CPoiList* list, const QString& name) { tabPoi->addTab(list, name); }
+void CMainWindow::addPoiList(CPoiList* list) { list->addToTabWidget(tabPoi); }
 
 void CMainWindow::addWidgetToTab(QWidget* w) {
   if (tabWidget->indexOf(w) == NOIDX) {
@@ -882,8 +886,8 @@ void CMainWindow::slotQuickstart() {
   }
 }
 
-CCanvas* CMainWindow::addCanvas(const QString& name) {
-  CCanvas* canvas = createCanvas(name);
+CCanvas* CMainWindow::addCanvas(const QString& key) {
+  CCanvas* canvas = createCanvas(key);
   tabWidget->setCurrentWidget(canvas);
   testForNoView();
   emit sigCanvasChange();
@@ -954,33 +958,23 @@ void CMainWindow::slotTabCloseRequest(int i) {
   emit sigCanvasChange();
 }
 
-static inline bool compareNames(QString s1, QString s2) { return s1.replace("&", "") == s2.replace("&", ""); }
-
 void CMainWindow::slotCurrentTabCanvas(int i) {
-  QString name = tabWidget->tabText(i);
-  for (int n = 0; n < tabMaps->count(); n++) {
-    bool isMapView = compareNames(name, tabMaps->tabText(n));
+  CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->widget(i));
+  if (canvas == nullptr) {
+    return;
+  }
+  emit canvas->sigCanvasIsCurrent();
 
+  for (int n = 0; n < tabMaps->count(); n++) {
+    CMapList* mapList = dynamic_cast<CMapList*>(tabMaps->widget(n));
+    if (mapList == nullptr) {
+      continue;
+    }
+    bool isMapView = canvas->getKey() == mapList->getCanvasKey();
     actionSetupGrid->setEnabled(isMapView);
     actionSetupMapBackground->setEnabled(isMapView);
     actionSetupMapView->setEnabled(isMapView);
-
     if (isMapView) {
-      tabMaps->setCurrentIndex(n);
-      break;
-    }
-  }
-
-  for (int n = 0; n < tabDem->count(); n++) {
-    if (compareNames(name, tabDem->tabText(n))) {
-      tabDem->setCurrentIndex(n);
-      break;
-    }
-  }
-
-  for (int n = 0; n < tabPoi->count(); n++) {
-    if (compareNames(name, tabPoi->tabText(n))) {
-      tabPoi->setCurrentIndex(n);
       break;
     }
   }
@@ -999,51 +993,54 @@ void CMainWindow::slotCurrentTabCanvas(int i) {
 }
 
 void CMainWindow::slotCurrentTabMaps(int i) {
-  QString name = tabMaps->tabText(i);
-  for (int n = 0; n < tabWidget->count(); n++) {
-    if (compareNames(name, tabWidget->tabText(n))) {
-      tabWidget->setCurrentIndex(n);
-      break;
-    }
+  CMapList* list = dynamic_cast<CMapList*>(tabMaps->widget(i));
+  if (list == nullptr) {
+    return;
   }
 
-  for (int n = 0; n < tabDem->count(); n++) {
-    if (compareNames(name, tabDem->tabText(n))) {
-      tabDem->setCurrentIndex(n);
+  for (int n = 0; n < tabWidget->count(); n++) {
+    CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->widget(n));
+    if (canvas == nullptr) {
+      continue;
+    }
+    if (list->getCanvasKey() == canvas->getKey()) {
+      tabWidget->setCurrentIndex(n);
       break;
     }
   }
 }
 
 void CMainWindow::slotCurrentTabDem(int i) {
-  QString name = tabMaps->tabText(i);
-  for (int n = 0; n < tabWidget->count(); n++) {
-    if (compareNames(name, tabWidget->tabText(n))) {
-      tabWidget->setCurrentIndex(n);
-      break;
-    }
+  CDemList* list = dynamic_cast<CDemList*>(tabDem->widget(i));
+  if (list == nullptr) {
+    return;
   }
 
-  for (int n = 0; n < tabMaps->count(); n++) {
-    if (compareNames(name, tabMaps->tabText(n))) {
-      tabMaps->setCurrentIndex(n);
+  for (int n = 0; n < tabWidget->count(); n++) {
+    CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->widget(n));
+    if (canvas == nullptr) {
+      continue;
+    }
+    if (list->getCanvasKey() == canvas->getKey()) {
+      tabWidget->setCurrentIndex(n);
       break;
     }
   }
 }
 
 void CMainWindow::slotCurrentTabPoi(int i) {
-  QString name = tabPoi->tabText(i);
-  for (int n = 0; n < tabWidget->count(); n++) {
-    if (compareNames(name, tabWidget->tabText(n))) {
-      tabWidget->setCurrentIndex(n);
-      break;
-    }
+  CPoiList* list = dynamic_cast<CPoiList*>(tabPoi->widget(i));
+  if (list == nullptr) {
+    return;
   }
 
-  for (int n = 0; n < tabPoi->count(); n++) {
-    if (compareNames(name, tabPoi->tabText(n))) {
-      tabMaps->setCurrentIndex(n);
+  for (int n = 0; n < tabWidget->count(); n++) {
+    CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->widget(n));
+    if (canvas == nullptr) {
+      continue;
+    }
+    if (list->getCanvasKey() == canvas->getKey()) {
+      tabWidget->setCurrentIndex(n);
       break;
     }
   }
@@ -1252,7 +1249,7 @@ void CMainWindow::slotStoreView() {
   view.clear();
 
   canvas->saveConfig(view);
-  view.setValue("name", canvas->objectName());
+  view.setValue("key", canvas->objectName());
 
   path = fi.absolutePath();
   cfg.setValue("Paths/lastViewPath", path);
@@ -1266,16 +1263,30 @@ void CMainWindow::slotLoadView() {
   if (filename.isEmpty()) {
     return;
   }
-  QSettings view(filename, QSettings::IniFormat);
 
-  const QString& name = view.value("name", QString()).toString();
-  CCanvas* canvas = addCanvas(name);
+  QSettings view(filename, QSettings::IniFormat);
+  const QString& key = view.value("key", QString()).toString();
+
+  // check of view is already loaded.
+  for (int i = 0; i < tabWidget->count(); i++) {
+    CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->widget(i));
+    if (canvas && canvas->getKey() == key) {
+      QMessageBox::information(
+          this, tr("Can not add view..."),
+          tr("The view is already loaded as '%1'. You have to close it befor loading it again.").arg(canvas->getName()),
+          QMessageBox::Abort);
+      return;
+    }
+  }
+
+  // view is unique, add it
+  CCanvas* canvas = addCanvas(key);
   if (nullptr == canvas) {
     return;
   }
-
   canvas->loadConfig(view);
 
+  // save new view in main config.
   cfg.beginGroup("Canvas");
   cfg.beginGroup("Views");
   cfg.beginGroup(canvas->objectName());
@@ -1284,6 +1295,7 @@ void CMainWindow::slotLoadView() {
   cfg.endGroup();  // "Views"
   cfg.endGroup();  // "Canvas"
 
+  // remember path of loaded view as last view's path
   QFileInfo fi(filename);
   path = fi.absolutePath();
   cfg.setValue("Paths/lastViewPath", path);
@@ -1457,17 +1469,16 @@ void CMainWindow::slotStartQMapTool() { QProcess::startDetached("qmaptool", {});
 void CMainWindow::slotGeoSearchConfigChanged() { actionGeoSearch->setIcon(geoSearchConfig->getCurrentIcon()); }
 
 void CMainWindow::slotRenameView() {
-  int idx = tabWidget->currentIndex();
-  QString name = tabWidget->tabText(idx);
+  CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->currentWidget());
+  if (canvas == nullptr) {
+    return;
+  }
+  QString name = canvas->getName();
   name = QInputDialog::getText(this, tr("Rename View..."), tr("Enter new name for view"), QLineEdit::Normal, name);
   if (name.isEmpty()) {
     return;
   }
-  tabWidget->widget(idx)->setObjectName(name);
-  tabWidget->setTabText(idx, name);
-  tabMaps->setTabText(idx, name);
-  tabDem->setTabText(idx, name);
-  tabPoi->setTabText(idx, name);
+  canvas->setName(name);
 }
 
 void CMainWindow::displayRegular() {

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -73,9 +73,9 @@ class CMainWindow : public QMainWindow, private Ui::IMainWindow {
 
   virtual ~CMainWindow();
 
-  void addMapList(CMapList* list, const QString& name);
-  void addDemList(CDemList* list, const QString& name);
-  void addPoiList(CPoiList* list, const QString& name);
+  void addMapList(CMapList* list);
+  void addDemList(CDemList* list);
+  void addPoiList(CPoiList* list);
   void addWidgetToTab(QWidget* w);
 
   bool isScaleVisible() const;
@@ -201,7 +201,7 @@ class CMainWindow : public QMainWindow, private Ui::IMainWindow {
   void displayFullscreen();
   CCanvas* createCanvas(const QString& name);
   void setupHomePath();
-  CCanvas* addCanvas(const QString& name);
+  CCanvas* addCanvas(const QString& key);
 
   static CMainWindow* pSelf;
   static QDir homeDir;

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -69,23 +69,58 @@ inline QSize getTrackProfileSize(int height) {
                       : QSize(WIDTH_PROFILE_SMALL, HEIGHT_PROFILE_SMALL);
 }
 
-CCanvas::CCanvas(QWidget* parent, const QString& name) : QWidget(parent) {
-  setFocusPolicy(Qt::WheelFocus);
+QString CCanvas::generateKey(int count) {
+  uint64_t microseconds =
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
+          .count();
+  const QString& tmp = QString("%1_%2").arg(count).arg(microseconds);
+  QCryptographicHash md5(QCryptographicHash::Md5);
+  md5.addData(tmp.toLatin1());
+  return "key_" + md5.result().toHex();
+}
 
-  if (name.isEmpty()) {
-    for (int count = 1;; ++count) {
-      QString name = tr("View %1").arg(count);
-      if (nullptr == CMainWindow::self().findChild<CCanvas*>(name)) {
-        setObjectName(name);
+bool checkOtherCanvasForName(const QString& name) {
+  const auto& children = CMainWindow::self().findChildren<CCanvas*>();
+  bool found = false;
+  for (const auto& child : children) {
+    if (child->getName() == name) {
+      found = true;
+      break;
+    }
+  }
+  return found;
+}
+
+CCanvas::CCanvas(QWidget* parent, const QString& storedKey) : QWidget(parent) {
+  static int count = 0;
+  count++;
+
+  if (storedKey.isEmpty()) {
+    // new canvas
+    // generate unique default name
+    for (int n = 1;; ++n) {
+      const QString& name = tr("View %1").arg(n);
+      if (checkOtherCanvasForName(name) == false) {
+        setName(name);
         break;
       }
     }
+    // generate unique key
+    _key = generateKey(count);
+  } else if (!storedKey.startsWith("key_")) {
+    // backward compatibility, the storedKey is the name
+    setName(storedKey);
+    // generate unique key
+    _key = generateKey(count);
   } else {
-    setObjectName(name);
+    // stored canvas with a valid key
+    _key = storedKey;
+    // name will be updated by config file
   }
+  setObjectName(_key);
 
+  setFocusPolicy(Qt::WheelFocus);
   setMouseTracking(true);
-
   grabGesture(Qt::PinchGesture);
 
   map = new CMapDraw(this);
@@ -392,6 +427,7 @@ void CCanvas::saveConfig(QSettings& cfg) {
   cfg.setValue("proj", map->getProjection());
   cfg.setValue("scales", map->getScalesType());
   cfg.setValue("backColor", backColor.name());
+  cfg.setValue("name", getName());
 }
 
 void CCanvas::loadConfig(QSettings& cfg) {
@@ -401,6 +437,7 @@ void CCanvas::loadConfig(QSettings& cfg) {
 
   const QString& backColorStr = cfg.value("backColor", "#FFFFBF").toString();
   backColor = QColor(backColorStr);
+  setName(cfg.value("name", getName()).toString());
 
   map->loadConfig(cfg);
   poi->loadConfig(cfg);
@@ -411,6 +448,11 @@ void CCanvas::loadConfig(QSettings& cfg) {
   for (IDrawContext* context : allContext) {
     context->zoom(map->zoom());
   }
+}
+
+void CCanvas::setName(const QString& newName) {
+  _name = newName;
+  emit sigNameChanged(*this);
 }
 
 void CCanvas::setMap(const QString& filename) { map->buildMapList(filename); }

--- a/src/qmapshack/canvas/CCanvas.h
+++ b/src/qmapshack/canvas/CCanvas.h
@@ -56,7 +56,7 @@ class CTableTrkInfo;
 class CCanvas : public QWidget {
   Q_OBJECT
  public:
-  CCanvas(QWidget* parent, const QString& name);
+  CCanvas(QWidget* parent, const QString& storedKey);
   virtual ~CCanvas();
 
   static void setOverrideCursor(const QCursor& cursor, const QString& src);
@@ -81,6 +81,10 @@ class CCanvas : public QWidget {
 
   void setScales(const scales_type_e type);
   scales_type_e getScalesType();
+
+  const QString& getKey() const { return _key; }
+  const QString& getName() const { return _name; }
+  void setName(const QString& newName);
 
   qreal getElevationAt(const QPointF& pos, bool checkScale) const;
   void getElevationAt(const QPolygonF& pos, QPolygonF& ele) const;
@@ -190,6 +194,8 @@ class CCanvas : public QWidget {
   void sigZoom();
   void sigMove();
   void sigResize(const QSize& size);
+  void sigNameChanged(const CCanvas& self);
+  void sigCanvasIsCurrent();
 
  public slots:
   void slotTriggerCompleteUpdate(CCanvas::redraw_e flags);
@@ -214,6 +220,7 @@ class CCanvas : public QWidget {
   void slotToolTip();
 
  private:
+  static QString generateKey(int count);
   void drawStatusMessages(QPainter& p);
   void drawTrackStatistic(QPainter& p);
   void drawScale(QPainter& p, QRectF drawRect);
@@ -239,6 +246,11 @@ class CCanvas : public QWidget {
   bool isShowTrackInfoPoints() const;
   bool isShowTrackProfile() const;
   bool isShowTrackHighlight() const;
+
+  // only change in ctor
+  QString _key;
+  // only change via setName()
+  QString _name;
 
   bool showTrackOverlays = true;
 

--- a/src/qmapshack/dem/CDemDraw.cpp
+++ b/src/qmapshack/dem/CDemDraw.cpp
@@ -37,7 +37,7 @@ QStringList CDemDraw::supportedFormats = QString("*.vrt|*.wcs").split('|');
 
 CDemDraw::CDemDraw(CCanvas* canvas) : IDrawContext("dem", CCanvas::eRedrawDem, canvas) {
   demList = new CDemList(canvas);
-  CMainWindow::self().addDemList(demList, canvas->objectName());
+  CMainWindow::self().addDemList(demList);
   connect(canvas, &CCanvas::destroyed, demList, &CDemList::deleteLater);
   connect(demList, &CDemList::sigChanged, this, &CDemDraw::slotChanged);
   dems << this;
@@ -207,7 +207,7 @@ void CDemDraw::loadDemList(QSettings& cfg) {
   // dem items.
   QList<CDemItem*> demsUnknown = demsFound.values();
   std::sort(demsUnknown.begin(), demsUnknown.end(), &sortByName<CDemItem>);
-  for (CDemItem* dem : demsUnknown) {    
+  for (CDemItem* dem : demsUnknown) {
     demList->addDem(dem);
     dem->setStatus(IMapItem::eStatus::Unused);
   }

--- a/src/qmapshack/dem/CDemList.cpp
+++ b/src/qmapshack/dem/CDemList.cpp
@@ -51,6 +51,7 @@ void CDemTreeWidget::dragEnterEvent(QDragEnterEvent* e) {
   }
   QTreeWidget::dragEnterEvent(e);
 }
+
 void CDemTreeWidget::dragLeaveEvent(QDragLeaveEvent* e) {
   CDemItem* item = dynamic_cast<CDemItem*>(currentItem());
   if (item) {
@@ -81,7 +82,7 @@ void CDemTreeWidget::dropEvent(QDropEvent* e) {
   emit sigChanged();
 }
 
-CDemList::CDemList(QWidget* parent) : QWidget(parent) {
+CDemList::CDemList(CCanvas* parent) : QWidget(parent), canvas(parent) {
   setupUi(this);
   lineFilter->addAction(actionClearFilter, QLineEdit::TrailingPosition);
 
@@ -106,6 +107,29 @@ CDemList::CDemList(QWidget* parent) : QWidget(parent) {
 }
 
 CDemList::~CDemList() {}
+
+QString CDemList::getCanvasKey() const {
+  if (canvas) {
+    return canvas->getKey();
+  }
+  return "";
+}
+
+void CDemList::addToTabWidget(QTabWidget* widget) {
+  if (canvas == nullptr) {
+    return;
+  }
+  tabWidget = widget;
+  tabWidget->addTab(this, canvas->getName());
+
+  // Those two connection only live as long as tabWidget or canvas.
+  // Therefore we do not need to check for valid pointers inside the lambdas
+  connect(canvas, &CCanvas::sigCanvasIsCurrent, tabWidget, [this]() { tabWidget->setCurrentWidget(this); });
+  connect(canvas, &CCanvas::sigNameChanged, tabWidget, [this](const CCanvas& c) {
+    const int idx = tabWidget->indexOf(this);
+    tabWidget->setTabText(idx, c.getName());
+  });
+}
 
 void CDemList::addDem(CDemItem* dem) {
   treeWidget->addTopLevelItem(dem);

--- a/src/qmapshack/dem/CDemList.h
+++ b/src/qmapshack/dem/CDemList.h
@@ -19,11 +19,14 @@
 #ifndef CDEMLIST_H
 #define CDEMLIST_H
 
+#include <QPointer>
 #include <QTreeWidget>
 #include <QWidget>
 
 class CDemItem;
 class QMenu;
+class CCanvas;
+class QTabWidget;
 
 class CDemTreeWidget : public QTreeWidget {
   Q_OBJECT
@@ -47,8 +50,20 @@ class CDemTreeWidget : public QTreeWidget {
 class CDemList : public QWidget, private Ui::IDemsList {
   Q_OBJECT
  public:
-  CDemList(QWidget* parent);
+  CDemList(CCanvas* parent);
   virtual ~CDemList();
+
+  /**
+   * @brief Get the key of the canvas this list is attached to
+   * @return The key as string if a canvas is attached. If not, an empty string.
+   */
+  QString getCanvasKey() const;
+
+  /**
+   * @brief Add this dem list to the given tab widget
+   * @param widget  add list to this tab widget
+   */
+  void addToTabWidget(QTabWidget* widget);
 
   void clear();
   int count();
@@ -89,6 +104,8 @@ class CDemList : public QWidget, private Ui::IDemsList {
 
  private:
   QMenu* menu;
+  QPointer<CCanvas> canvas;
+  QPointer<QTabWidget> tabWidget;
 };
 
 #endif  // CDEMLIST_H

--- a/src/qmapshack/gis/trk/filter/CFilterReplaceElevation.cpp
+++ b/src/qmapshack/gis/trk/filter/CFilterReplaceElevation.cpp
@@ -47,7 +47,7 @@ void CFilterReplaceElevation::updateUi() {
 
   const QList<CCanvas*>& list = CMainWindow::self().getCanvas();
   for (CCanvas* canvas : list) {
-    comboView->addItem(canvas->objectName(), QVariant::fromValue<CCanvas*>(canvas));
+    comboView->addItem(canvas->getName(), QVariant::fromValue<CCanvas*>(canvas));
   }
 
   if (!current.isEmpty()) {

--- a/src/qmapshack/map/CMapDraw.cpp
+++ b/src/qmapshack/map/CMapDraw.cpp
@@ -40,7 +40,7 @@ QStringList CMapDraw::supportedFormats = QString("*.vrt|*.jnx|*.img|*.rmap|*.wmt
 
 CMapDraw::CMapDraw(CCanvas* parent) : IDrawContext("map", CCanvas::eRedrawMap, parent) {
   mapList = new CMapList(canvas);
-  CMainWindow::self().addMapList(mapList, canvas->objectName());
+  CMainWindow::self().addMapList(mapList);
   connect(canvas, &CCanvas::destroyed, mapList, &CMapList::deleteLater);
   connect(mapList, &CMapList::sigChanged, this, &CMapDraw::slotChanged);
   maps << this;

--- a/src/qmapshack/map/CMapList.cpp
+++ b/src/qmapshack/map/CMapList.cpp
@@ -82,7 +82,7 @@ void CMapTreeWidget::dropEvent(QDropEvent* e) {
   emit sigChanged();
 }
 
-CMapList::CMapList(QWidget* parent) : QWidget(parent) {
+CMapList::CMapList(CCanvas* parent) : QWidget(parent), canvas(parent) {
   setupUi(this);
   lineFilter->addAction(actionClearFilter, QLineEdit::TrailingPosition);
 
@@ -107,6 +107,29 @@ CMapList::CMapList(QWidget* parent) : QWidget(parent) {
 }
 
 CMapList::~CMapList() {}
+
+QString CMapList::getCanvasKey() const {
+  if (canvas) {
+    return canvas->getKey();
+  }
+  return "";
+}
+
+void CMapList::addToTabWidget(QTabWidget* widget) {
+  if (canvas == nullptr) {
+    return;
+  }
+  tabWidget = widget;
+  tabWidget->addTab(this, canvas->getName());
+
+  // Those two connection only live as long as tabWidget or canvas.
+  // Therefore we do not need to check for valid pointers inside the lambdas
+  connect(canvas, &CCanvas::sigCanvasIsCurrent, tabWidget, [this]() { tabWidget->setCurrentWidget(this); });
+  connect(canvas, &CCanvas::sigNameChanged, tabWidget, [this](const CCanvas& c) {
+    const int idx = tabWidget->indexOf(this);
+    tabWidget->setTabText(idx, c.getName());
+  });
+}
 
 void CMapList::addMap(CMapItem* map) {
   treeWidget->addTopLevelItem(map);

--- a/src/qmapshack/map/CMapList.h
+++ b/src/qmapshack/map/CMapList.h
@@ -19,11 +19,14 @@
 #ifndef CMAPLIST_H
 #define CMAPLIST_H
 
+#include <QPointer>
 #include <QTreeWidget>
 #include <QWidget>
 
 class CMapItem;
 class QMenu;
+class CCanvas;
+class QTabWidget;
 
 class CMapTreeWidget : public QTreeWidget {
   Q_OBJECT
@@ -46,12 +49,40 @@ class CMapTreeWidget : public QTreeWidget {
 class CMapList : public QWidget, private Ui::IMapList {
   Q_OBJECT
  public:
-  CMapList(QWidget* parent);
+  CMapList(CCanvas* parent);
   virtual ~CMapList();
 
+  /**
+   * @brief Get the key of the canvas this list is attached to
+   * @return The key as string if a canvas is attached. If not, an empty string.
+   */
+  QString getCanvasKey() const;
+
+  /**
+   * @brief Add this map list to the given tab widget
+   * @param widget  add list to this tab widget
+   */
+  void addToTabWidget(QTabWidget* widget);
+
+  /**
+   * @brief Remove all maps from the list
+   */
   void clear();
+  /**
+   * @brief Number of maps in the list
+   * @return
+   */
   int count();
+  /**
+   * @brief Get map item at index
+   * @param i
+   * @return A pointer to the map item or nullptr if index is out of bound
+   */
   CMapItem* item(int i);
+
+  /**
+   * @brief Cast operator to get the tree widget
+   */
   operator QTreeWidget*() { return treeWidget; }
 
   /**
@@ -91,6 +122,8 @@ class CMapList : public QWidget, private Ui::IMapList {
 
  private:
   QMenu* menu;
+  QPointer<CCanvas> canvas;
+  QPointer<QTabWidget> tabWidget;
 };
 
 #endif  // CMAPLIST_H

--- a/src/qmapshack/poi/CPoiDraw.cpp
+++ b/src/qmapshack/poi/CPoiDraw.cpp
@@ -34,7 +34,7 @@ QStringList CPoiDraw::supportedFormats = QString("*.poi").split('|');
 
 CPoiDraw::CPoiDraw(CCanvas* canvas) : IDrawContext("poi", CCanvas::eRedrawPoi, canvas) {
   poiList = new CPoiList(canvas);
-  CMainWindow::self().addPoiList(poiList, canvas->objectName());
+  CMainWindow::self().addPoiList(poiList);
   connect(canvas, &CCanvas::destroyed, poiList, &CPoiList::deleteLater);
   connect(poiList, &CPoiList::sigChanged, this, &CPoiDraw::emitSigCanvasUpdate);
 

--- a/src/qmapshack/poi/CPoiList.cpp
+++ b/src/qmapshack/poi/CPoiList.cpp
@@ -23,7 +23,7 @@
 #include "poi/CPoiDraw.h"
 #include "poi/CPoiFileItem.h"
 
-CPoiList::CPoiList(QWidget* parent) : QWidget(parent) {
+CPoiList::CPoiList(CCanvas* parent) : QWidget(parent), canvas(parent) {
   setupUi(this);
 
   connect(treeWidget, &CPoiTreeWidget::customContextMenuRequested, this, &CPoiList::slotContextMenu);
@@ -38,6 +38,29 @@ CPoiList::CPoiList(QWidget* parent) : QWidget(parent) {
   menu->addSeparator();
   menu->addAction(actionReloadPoi);
   menu->addAction(CMainWindow::self().getPoiSetupAction());
+}
+
+QString CPoiList::getCanvasKey() const {
+  if (canvas) {
+    return canvas->getKey();
+  }
+  return "";
+}
+
+void CPoiList::addToTabWidget(QTabWidget* widget) {
+  if (canvas == nullptr) {
+    return;
+  }
+  tabWidget = widget;
+  tabWidget->addTab(this, canvas->getName());
+
+  // Those two connection only live as long as tabWidget or canvas.
+  // Therefore we do not need to check for valid pointers inside the lambdas
+  connect(canvas, &CCanvas::sigCanvasIsCurrent, tabWidget, [this]() { tabWidget->setCurrentWidget(this); });
+  connect(canvas, &CCanvas::sigNameChanged, tabWidget, [this](const CCanvas& c) {
+    const int idx = tabWidget->indexOf(this);
+    tabWidget->setTabText(idx, c.getName());
+  });
 }
 
 void CPoiList::clear() { treeWidget->clear(); }

--- a/src/qmapshack/poi/CPoiList.h
+++ b/src/qmapshack/poi/CPoiList.h
@@ -19,9 +19,12 @@
 #ifndef CPOILIST_H
 #define CPOILIST_H
 
+#include <QPointer>
 #include <QTreeWidget>
 
 class CPoiFileItem;
+class CCanvas;
+class QTabWidget;
 
 class CPoiTreeWidget : public QTreeWidget {
   Q_OBJECT
@@ -37,8 +40,20 @@ class CPoiTreeWidget : public QTreeWidget {
 class CPoiList : public QWidget, private Ui::IPoiList {
   Q_OBJECT
  public:
-  CPoiList(QWidget* parent);
+  CPoiList(CCanvas* parent);
   virtual ~CPoiList() = default;
+
+  /**
+   * @brief Get the key of the canvas this list is attached to
+   * @return The key as string if a canvas is attached. If not, an empty string.
+   */
+  QString getCanvasKey() const;
+
+  /**
+   * @brief Add this map list to the given tab widget
+   * @param widget  add list to this tab widget
+   */
+  void addToTabWidget(QTabWidget* widget);
 
   void clear();
   int count();
@@ -58,6 +73,8 @@ class CPoiList : public QWidget, private Ui::IPoiList {
 
  private:
   QMenu* menu;
+  QPointer<CCanvas> canvas;
+  QPointer<QTabWidget> tabWidget;
 };
 
 #endif  // CPOILIST_H


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1021

### What you have done:
[comment]: # (Describe roughly.)

* Add API for unique key to CCanvas
* Add API to get and set name to CCanvas
* Fix the code to use the key instead of the name to identify a canvas (view) object

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Should work as before. However view tabs can have the same name, now.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
