### PR TITLE
[QMS-1027] Fix: Maps: Copyright notice is missing in tool tips

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@ V1.XX.X
 [QMS-1018] Fix: Warnings in CMapItemDelegate
 [QMS-1021] Dev: Add unique key to views for better identification
 [QMS-1024] Fix: Accessibility issue : font is too small (macOS)
-
+[QMS-1027] Fix: Maps: Copyright notice is missing in tool tips
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -232,7 +232,7 @@ bool CMapItem::activate() {
     return false;
   }
 
-  setToolTip(0, mapfile->getCopyright());
+  IMapItem::toolTip = mapfile->getCopyright();
 
   // setup map with settings stored in
   // the shadow config

--- a/src/qmapshack/map/CMapItemDelegate.cpp
+++ b/src/qmapshack/map/CMapItemDelegate.cpp
@@ -361,8 +361,15 @@ bool CMapItemDelegate::helpEvent(QHelpEvent* event, QAbstractItemView* view, con
   } else if (rectName.contains(event->pos())) {
     const QFontMetrics fm(fontName);
     const QRect& boundingRectName = fm.boundingRect(item->getName());
+    QString toolTip;
     if (boundingRectName.width() > rectName.width()) {
-      QToolTip::showText(event->globalPos(), item->getName(), view, {}, 3000);
+      toolTip = QString("<p>%1</p>").arg(item->getName());
+    }
+    if (!item->getToolTip().isEmpty()) {
+      toolTip += QString("<p>%1</p>").arg(item->getToolTip());
+    }
+    if (!toolTip.isEmpty()) {
+      QToolTip::showText(event->globalPos(), toolTip, view, {}, 5000);
     }
   }
 

--- a/src/qmapshack/map/IMapItem.h
+++ b/src/qmapshack/map/IMapItem.h
@@ -41,7 +41,14 @@ class IMapItem {
    * @brief Get the map's name as displayed
    * @return
    */
-  QString getName() const { return name; };
+  const QString& getName() const { return name; };
+
+  /**
+   * @brief Get a tool tip text for the map
+   *
+   * @return Some string or empty string
+   */
+  const QString& getToolTip() const { return toolTip; }
 
   /**
    * @brief Activate or deactivate map
@@ -78,6 +85,11 @@ class IMapItem {
    * @brief Name as displayed in the tree widget
    */
   QString name;
+
+  /**
+   * @brief Tool tip to be displayed in the tree widget
+   */
+  QString toolTip;
 
   static constexpr Qt::GlobalColor kColorOut = Qt::lightGray;
   static constexpr Qt::GlobalColor kColorIn = Qt::darkGreen;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1027

### What you have done:
[comment]: # (Describe roughly.)

* Store copyright info in IMapItem
* Use info when assembling the tool tip string

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
