### PR TITLE
[QMS-1031] Fix: Fatal error exporting database project

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ V1.XX.X
 [QMS-1021] Dev: Add unique key to views for better identification
 [QMS-1024] Fix: Accessibility issue : font is too small (macOS)
 [QMS-1027] Fix: Maps: Copyright notice is missing in tool tips
+[QMS-1031] Fix: Fatal error exporting database project
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/gis/IWksItem.cpp
+++ b/src/qmapshack/gis/IWksItem.cpp
@@ -23,12 +23,6 @@
 
 #include "gis/IGisItem.h"
 
-void checkForThread() {
-  if (!QThread::isMainThread()) {
-    qFatal() << "Called from a thread other than the maiUI thread! This will not work!";
-  }
-}
-
 IWksItem::IWksItem(QTreeWidgetItem* parent, int type) : QTreeWidgetItem(parent, type) { setupAnimations(); }
 IWksItem::IWksItem(QTreeWidget* parent, int type) : QTreeWidgetItem(parent, type) { setupAnimations(); }
 
@@ -60,14 +54,14 @@ IWksItem::eBaseType IWksItem::getBaseType() const {
 }
 
 void IWksItem::updateDecoration(quint32 enable, quint32 disable) {
-  checkForThread();
+  if (!QThread::isMainThread()) return;
   flagsDecoration |= enable;
   flagsDecoration &= ~disable;
   updateItem();
 }
 
 void IWksItem::updateItem() {
-  checkForThread();
+  if (!QThread::isMainThread()) return;
   QPointer<QTreeWidget> tree = treeWidget();
   if (tree == nullptr) {
     return;
@@ -85,7 +79,7 @@ void IWksItem::updateItem() {
 }
 
 bool IWksItem::holdUiFocus(const QStyleOptionViewItem& opt) {
-  checkForThread();
+  if (!QThread::isMainThread()) return false;
   bool hasFocus = (opt.state & QStyle::State_HasFocus) != 0;
   if (hasFocus != lastFocusState) {
     float opacity = hasFocus ? 1.0 : 0.0;
@@ -101,19 +95,19 @@ bool IWksItem::holdUiFocus(const QStyleOptionViewItem& opt) {
 }
 
 void IWksItem::setVisibility(bool visible) {
-  checkForThread();
+  if (!QThread::isMainThread()) return;
   this->visible = visible;
   updateItem();
 }
 
 void IWksItem::setAutoSave(bool on) {
-  checkForThread();
+  if (!QThread::isMainThread()) return;
   autoSave = on;
   updateItem();
 }
 
 void IWksItem::setAutoSyncToDev(bool on) {
-  checkForThread();
+  if (!QThread::isMainThread()) return;
   autoSyncToDev = on;
   updateItem();
 }
@@ -127,7 +121,7 @@ void IWksItem::setProgress(quint32 count, quint32 total) {
 }
 
 std::tuple<bool, qreal> IWksItem::getProgress() const {
-  checkForThread();
+  if (!QThread::isMainThread()) return {false, 0};
   QMutexLocker lock(&IGisItem::mutexItems);
   const qreal progress = (100.0 * countProgress) / totalProgress;
   return {countProgress != totalProgress, progress};


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1031

### What you have done:
[comment]: # (Describe roughly.)

IWksItem: Do not use qFatal in the thread check. Simply return.

That's ok because if you use a GIS item object in a thread you just want to load it, hardly displaying anything.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Export should work again.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
