### PR TITLE
[QMS-1034] Fix replace DEM dialog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ V1.XX.X
 [QMS-1024] Fix: Accessibility issue : font is too small (macOS)
 [QMS-1027] Fix: Maps: Copyright notice is missing in tool tips
 [QMS-1031] Fix: Fatal error exporting database project
+[QMS-1034] Fix: Show view names instead of keys in Replace DEM dialog
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons
@@ -75,7 +76,7 @@ V1.18.2
 [QMS-855] Code cleanup: Convert waypoint icon map into a list
 [QMS-857] Fix crash in track profile using QT >6.10
 [QMS-859] Add waypoint icons
-[QMS-861] Add action to clear the waypoint icon history 
+[QMS-861] Add action to clear the waypoint icon history
 [QMS-863] Fixing QFILE_MAYBE_NODISCARD warnings for Qt 6.10 and more recent
 [QMS-866] Add waypoint icons
 [QMS-867] Add etrex tag to icons supported on that device

--- a/src/qmapshack/canvas/CCanvasSelect.cpp
+++ b/src/qmapshack/canvas/CCanvasSelect.cpp
@@ -26,7 +26,7 @@ CCanvasSelect::CCanvasSelect(CCanvas*& canvas, QWidget* parent) : QDialog(parent
 
   const QList<CCanvas*>& allCanvas = CMainWindow::self().getCanvas();
   for (CCanvas* c : allCanvas) {
-    comboCanvas->addItem(c->objectName(), QVariant::fromValue<CCanvas*>(c));
+    comboCanvas->addItem(c->getName(), QVariant::fromValue<CCanvas*>(c));
   }
 }
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1034

### What you have done:
[comment]: # (Describe roughly.)

Instead of `get_objectName()` use of `getName()` to retrieve the contents of the dropdown.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Click on "Replace Elevation by DEM" in workplace or context menu of a track

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
