### PR TITLE
[QMS-1036] Fix: Prevent QMS from opening twice & corrupting sqlite db

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ V1.XX.X
 [QMS-1027] Fix: Maps: Copyright notice is missing in tool tips
 [QMS-1031] Fix: Fatal error exporting database project
 [QMS-1034] Fix: Show view names instead of keys in Replace DEM dialog
+[QMS-1036] Fix: Prevent QMS from opening twice & corrupting sqlite db
 [QMS-1037] Fix: Buggy handling of multiple times cloned view(s)
 
 V1.20.1

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -45,6 +45,7 @@ class CMainWindow : public QMainWindow, private Ui::IMainWindow {
   Q_OBJECT
  public:
   static CMainWindow& self() { return *pSelf; }
+  static bool isNull() { return pSelf == nullptr; }
 
   static QWidget* getBestWidgetForParent();
 

--- a/src/qmapshack/CSingleInstanceProxy.cpp
+++ b/src/qmapshack/CSingleInstanceProxy.cpp
@@ -21,28 +21,37 @@
 #include <QtNetwork>
 
 #include "CMainWindow.h"
+#include "setup/IAppSetup.h"
 
 CSingleInstanceProxy::CSingleInstanceProxy(const QStringList filenames) {
-  serverName = CMainWindow::self().getUser();
+  serverName = CMainWindow::getUser();
   if (serverName != "QMapShack") {
     serverName = "QMapShack-" + serverName;
   }
 
-  QLocalSocket socket;
-  socket.connectToServer(serverName);
-  if (socket.waitForConnected(1000)) {
-    // if the connection is successful another instance
-    // is already running. In that case the list of files to
-    // open is sent to the primary instance. And this instance
-    // will be closed imediately.
-    QDataStream stream(&socket);
-    stream << filenames;
-    socket.waitForBytesWritten(3000);
+  // setting lock failed -> secondary instance
+  if (!IAppSetup::getPlatformInstance()->setLock()) {
+    bool ok = false;
+    QLocalSocket socket;
+    socket.connectToServer(serverName);
+    if (socket.waitForConnected(1000)) {
+      // Another instance is already running. In that case
+      // the list of files to open is sent to the primary instance.
+      // And this secondary instance will be closed imediately.
+      QByteArray sendData;
+      QDataStream sendDataStream(&sendData, QIODevice::WriteOnly);
+      sendDataStream << filenames;
+      socket.write(sendData);
+      socket.waitForBytesWritten(3000);
 
-    // wait for confirmation
-    socket.waitForReadyRead(3000);
-    bool ok;
-    stream >> ok;
+      // wait for confirmation
+      socket.waitForReadyRead(3000);
+      QByteArray recvData = socket.readAll();
+      QDataStream recvDataStream(recvData);
+      recvDataStream >> ok;
+    }
+    socket.close();
+
     qDebug() << "Sent parameters to primary instance. Result" << ok;
     qDebug() << "There can only be one. Exit.";
     exit(0);
@@ -51,8 +60,8 @@ CSingleInstanceProxy::CSingleInstanceProxy(const QStringList filenames) {
   // Looks like we are the first instance.
   // Create a server socket and wait for other instances to connect.
   server = new QLocalServer(this);
-  connect(server, &QLocalServer::newConnection, this, &CSingleInstanceProxy::slotNewConnection);
   server->removeServer(serverName);
+  connect(server, &QLocalServer::newConnection, this, &CSingleInstanceProxy::slotNewConnection);
   if (!server->listen(serverName)) {
     qDebug() << "CSingleInstanceProxy: Failed to start single instance server socket.";
   } else {
@@ -71,20 +80,28 @@ void CSingleInstanceProxy::slotNewConnection() {
   // Each secondary instance will send a QStringList with files to open
   // The list can be empty.
   if (socket->waitForReadyRead(3000)) {
-    QStringList filenames;
-    QDataStream stream(socket);
-    stream >> filenames;
+    // main window might not yet exist
+    bool ok = !CMainWindow::isNull();
 
-    CMainWindow& w = CMainWindow::self();
-    w.loadGISData(filenames);
+    QByteArray recvData = socket->readAll();
+    QDataStream recvDataStream(recvData);
+    QStringList filenames;
+    recvDataStream >> filenames;
 
     // confirm that files are loaded
-    stream << true;
+    QByteArray sendData;
+    QDataStream sendDataStream(&sendData, QIODevice::WriteOnly);
+    sendDataStream << ok;
+    socket->write(sendData);
     socket->waitForBytesWritten(3000);
 
-    // raise the application window to top of desktop
-    w.raise();
-    w.activateWindow();
+    if (ok) {
+      CMainWindow& w = CMainWindow::self();
+      w.loadGISData(filenames);
+      // raise the application window to top of desktop
+      w.raise();
+      w.activateWindow();
+    }
   }
 
   socket->close();

--- a/src/qmapshack/locale/qmapshack.ts
+++ b/src/qmapshack/locale/qmapshack.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_ca.ts
+++ b/src/qmapshack/locale/qmapshack_ca.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_cs.ts
+++ b/src/qmapshack/locale/qmapshack_cs.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Kritické...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Kritické...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Kritické...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_de.ts
+++ b/src/qmapshack/locale/qmapshack_de.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation>Schwerer Fehler...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation>Datei konnte nicht gesperrt werden&lt;br&gt;%1&lt;br&gt;%2</translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation>Schwerer Fehler...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation>Datei konnte nicht gesperrt werden&lt;br&gt;%1&lt;br&gt;%2</translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation>Schwerer Fehler...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation>Datei konnte nicht gesperrt werden&lt;br&gt;%1&lt;br&gt;%2</translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_es.ts
+++ b/src/qmapshack/locale/qmapshack_es.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_fr.ts
+++ b/src/qmapshack/locale/qmapshack_fr.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatal...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_it.ts
+++ b/src/qmapshack/locale/qmapshack_it.ts
@@ -129,6 +129,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatale...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatale...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Fatale...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_nl.ts
+++ b/src/qmapshack/locale/qmapshack_nl.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/locale/qmapshack_ru.ts
+++ b/src/qmapshack/locale/qmapshack_ru.ts
@@ -128,6 +128,45 @@
     </message>
 </context>
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="113"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Неустранимая ошибка...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="114"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="194"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Неустранимая ошибка...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="195"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="128"/>
+        <source>Fatal...</source>
+        <translation type="unfinished">Неустранимая ошибка...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="129"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="102"/>

--- a/src/qmapshack/setup/CAppSetupLinux.cpp
+++ b/src/qmapshack/setup/CAppSetupLinux.cpp
@@ -21,10 +21,15 @@
 
 #include "setup/CAppSetupLinux.h"
 
+#include <QMessageBox>
 #include <QWindow>
 
-#include "signal.h"
-#include "unistd.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "config.h"
 #include "version.h"
@@ -85,6 +90,29 @@ void CAppSetupLinux::closeOnSIGTERM() {
   };
 
   signal(SIGTERM, handler);
+}
+
+bool CAppSetupLinux::setLock() {
+  const QString& fileName = userDataPath() % "/." % qApp->applicationName() % ".lock";
+  qDebug() << "Try to lock file" << fileName << "...";
+  int fd = open(QFile::encodeName(fileName).data(), O_CREAT|O_RDWR, S_IRWXU);
+  if (fd != -1) {
+    struct flock lock;
+    memset(&lock, 0, sizeof(struct flock));
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    if (fcntl(fd, F_SETLK, &lock) == 0) {
+      qDebug() << "... Success";
+      return true;
+    } else if (errno == EACCES || errno == EAGAIN) {
+      qDebug().noquote() << "..." << strerror(errno);
+      close(fd);
+      return false;
+    }
+  }
+  QMessageBox::critical(nullptr, tr("Fatal..."), 
+     tr("Failed to lock file<br>%1<br>%2").arg(fileName, strerror(errno)));
+  exit(-1);
 }
 
 #endif // defined(Q_OS_LINUX)

--- a/src/qmapshack/setup/CAppSetupLinux.h
+++ b/src/qmapshack/setup/CAppSetupLinux.h
@@ -24,6 +24,7 @@
 #include "setup/IAppSetup.h"
 
 class CAppSetupLinux : public IAppSetup {
+  Q_DECLARE_TR_FUNCTIONS(CAppSetupLinux)
  public:
   void initQMapShack() override;
   QString routinoPath(QString xmlFile) override;
@@ -32,6 +33,7 @@ class CAppSetupLinux : public IAppSetup {
   QString logDir() override;
   QString findExecutable(const QString& name) override { return QStandardPaths::findExecutable(name); }
   QString helpFile() override;
+  bool setLock() override;
 
  private:
   static void closeOnSIGTERM();

--- a/src/qmapshack/setup/CAppSetupMac.cpp
+++ b/src/qmapshack/setup/CAppSetupMac.cpp
@@ -22,10 +22,15 @@
 #include "setup/CAppSetupMac.h"
 
 #include <QFont>
+#include <QMessageBox>
 #include <QWindow>
 
-#include "signal.h"
-#include "unistd.h"
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/errno.h>
+#include <unistd.h>
 
 #include "misc.h"
 
@@ -166,6 +171,29 @@ void CAppSetupMac::closeOnSIGTERM() {
   };
 
   signal(SIGTERM, handler);
+}
+
+bool CAppSetupMac::setLock() {
+  const QString& fileName = userDataPath() % "/.lock";
+  qDebug() << "Try to lock file" << fileName << "...";
+  int fd = open(QFile::encodeName(fileName).data(), O_CREAT|O_RDWR, S_IRWXU);
+  if (fd != -1) {
+    struct flock lock;
+    memset(&lock, 0, sizeof(struct flock));
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    if (fcntl(fd, F_SETLK, &lock) == 0) {
+      qDebug() << "... Success";
+      return true;
+    } else if (errno == EACCES || errno == EAGAIN) {
+      qDebug().noquote() << "..." << strerror(errno);
+      close(fd);
+      return false;
+    }
+  }
+  QMessageBox::critical(nullptr, tr("Fatal..."),
+     tr("Failed to lock file<br>%1<br>%2").arg(fileName, strerror(errno)));
+  exit(-1);
 }
 
 #endif // defined(Q_OS_MAC)

--- a/src/qmapshack/setup/CAppSetupMac.h
+++ b/src/qmapshack/setup/CAppSetupMac.h
@@ -24,6 +24,7 @@
 #include "setup/IAppSetup.h"
 
 class CAppSetupMac : public IAppSetup {
+  Q_DECLARE_TR_FUNCTIONS(CAppSetupMac)
  public:
   void initQMapShack() override;
   QString routinoPath(QString xmlFile) override;
@@ -32,6 +33,7 @@ class CAppSetupMac : public IAppSetup {
   QString logDir() override;
   QString findExecutable(const QString& name) override { return QStandardPaths::findExecutable(name); }
   QString helpFile() override;
+  bool setLock() override;
 
  private:
   QDir getApplicationDir(QString subdir);

--- a/src/qmapshack/setup/CAppSetupWin.cpp
+++ b/src/qmapshack/setup/CAppSetupWin.cpp
@@ -22,9 +22,13 @@
 #include "setup/CAppSetupWin.h"
 
 #include <QAbstractNativeEventFilter>
+#include <QMessageBox>
 #include <QWindow>
 
-#include "windows.h"
+#include <windows.h>
+#include <winbase.h>
+#include <errhandlingapi.h>
+#include <fileapi.h>
 
 #include "config.h"
 #include "version.h"
@@ -100,6 +104,30 @@ QString CAppSetupWin::helpFile() {
   QDir dirApp(QCoreApplication::applicationDirPath());
   QDir dirHelp(dirApp.absoluteFilePath(_MKSTR(HELPPATH)));
   return dirHelp.absoluteFilePath("QMSHelp.qhc");
+}
+
+bool CAppSetupWin::setLock() {
+  const QString& fileName = userDataPath() % "/." % qApp->applicationName() % ".lock";
+  qDebug() << "Try to lock file" << fileName << "...";
+  HANDLE hd = CreateFileW((const wchar_t*)fileName.utf16(),
+              GENERIC_READ|GENERIC_WRITE, 0,
+              NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+  if (hd != INVALID_HANDLE_VALUE) {
+    qDebug() << "... Success";
+    return true;
+  }
+  DWORD errorId = GetLastError();
+  wchar_t errorMsg[256];
+  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_IGNORE_INSERTS|FORMAT_MESSAGE_MAX_WIDTH_MASK,
+               NULL, errorId, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
+               errorMsg, (sizeof(errorMsg) / sizeof(wchar_t)), NULL);
+  if (errorId == ERROR_SHARING_VIOLATION) {
+    qDebug().noquote() << "..." << QString::fromUtf16((const char16_t*)errorMsg);
+    return false;
+  }
+  QMessageBox::critical(nullptr, tr("Fatal..."),
+     tr("Failed to lock file<br>%1<br>%2").arg(fileName, QString::fromUtf16((const char16_t*)errorMsg)));
+  exit(-1);
 }
 
 #endif // defined(Q_OS_WIN32)

--- a/src/qmapshack/setup/CAppSetupWin.h
+++ b/src/qmapshack/setup/CAppSetupWin.h
@@ -24,6 +24,7 @@
 #include "setup/IAppSetup.h"
 
 class CAppSetupWin : public IAppSetup {
+  Q_DECLARE_TR_FUNCTIONS(CAppSetupWin)
  public:
   void initQMapShack() override;
   QString routinoPath(QString xmlFile) override;
@@ -32,6 +33,7 @@ class CAppSetupWin : public IAppSetup {
   QString logDir() override;
   QString findExecutable(const QString& name) override;
   QString helpFile() override;
+  bool setLock() override;
 
   QByteArray path;
 };

--- a/src/qmapshack/setup/IAppSetup.h
+++ b/src/qmapshack/setup/IAppSetup.h
@@ -36,6 +36,7 @@ class IAppSetup {
   virtual QString logDir() = 0;
   virtual QString findExecutable(const QString& name) = 0;
   virtual QString helpFile() = 0;
+  virtual bool setLock() = 0;
 
  protected:
   void prepareGdal(QString gdalDataDir, QString gdalPluginsDir, QString projDataDir);

--- a/src/qmaptool/CMainWindow.h
+++ b/src/qmaptool/CMainWindow.h
@@ -38,6 +38,7 @@ class CMainWindow : public QMainWindow, private Ui::IMainWindow {
   Q_OBJECT
  public:
   static CMainWindow& self() { return *pSelf; }
+  static bool isNull() { return pSelf == nullptr; }
 
   virtual ~CMainWindow();
 

--- a/src/qmaptool/CSingleInstanceProxy.cpp
+++ b/src/qmaptool/CSingleInstanceProxy.cpp
@@ -21,28 +21,37 @@
 #include <QtNetwork>
 
 #include "CMainWindow.h"
+#include "setup/IAppSetup.h"
 
 CSingleInstanceProxy::CSingleInstanceProxy(const QStringList filenames) {
-  serverName = CMainWindow::self().getUser();
+  serverName = CMainWindow::getUser();
   if (serverName != "QMapTool") {
     serverName = "QMapTool-" + serverName;
   }
 
-  QLocalSocket socket;
-  socket.connectToServer(serverName);
-  if (socket.waitForConnected(1000)) {
-    // if the connection is successful another instance
-    // is already running. In that case the list of files to
-    // open is sent to the primary instance. And this instance
-    // will be closed imediately.
-    QDataStream stream(&socket);
-    stream << filenames;
-    socket.waitForBytesWritten(3000);
+  // setting lock failed -> secondary instance
+  if (!IAppSetup::IAppSetup::self().setLock()) {
+    bool ok = false;
+    QLocalSocket socket;
+    socket.connectToServer(serverName);
+    if (socket.waitForConnected(1000)) {
+      // Another instance is already running. In that case
+      // the list of files to open is sent to the primary instance.
+      // And this secondary instance will be closed imediately.
+      QByteArray sendData;
+      QDataStream sendDataStream(&sendData, QIODevice::WriteOnly);
+      sendDataStream << filenames;
+      socket.write(sendData);
+      socket.waitForBytesWritten(3000);
 
-    // wait for confirmation
-    socket.waitForReadyRead(3000);
-    bool ok;
-    stream >> ok;
+      // wait for confirmation
+      socket.waitForReadyRead(3000);
+      QByteArray recvData = socket.readAll();
+      QDataStream recvDataStream(recvData);
+      recvDataStream >> ok;
+    }
+    socket.close();
+
     qDebug() << "Sent parameters to primary instance. Result" << ok;
     qDebug() << "There can only be one. Exit.";
     exit(0);
@@ -51,8 +60,8 @@ CSingleInstanceProxy::CSingleInstanceProxy(const QStringList filenames) {
   // Looks like we are the first instance.
   // Create a server socket and wait for other instances to connect.
   server = new QLocalServer(this);
-  connect(server, &QLocalServer::newConnection, this, &CSingleInstanceProxy::slotNewConnection);
   server->removeServer(serverName);
+  connect(server, &QLocalServer::newConnection, this, &CSingleInstanceProxy::slotNewConnection);
   if (!server->listen(serverName)) {
     qDebug() << "CSingleInstanceProxy: Failed to start single instance server socket.";
   } else {
@@ -71,20 +80,28 @@ void CSingleInstanceProxy::slotNewConnection() {
   // Each secondary instance will send a QStringList with files to open
   // The list can be empty.
   if (socket->waitForReadyRead(3000)) {
-    QStringList filenames;
-    QDataStream stream(socket);
-    stream >> filenames;
+    // main window might not yet exist
+    bool ok = !CMainWindow::isNull();
 
-    CMainWindow& w = CMainWindow::self();
-    // w.loadGISData(filenames);
+    QByteArray recvData = socket->readAll();
+    QDataStream recvDataStream(recvData);
+    QStringList filenames;
+    recvDataStream >> filenames;
 
     // confirm that files are loaded
-    stream << true;
+    QByteArray sendData;
+    QDataStream sendDataStream(&sendData, QIODevice::WriteOnly);
+    sendDataStream << ok;
+    socket->write(sendData);
     socket->waitForBytesWritten(3000);
 
-    // raise the application window to top of desktop
-    w.raise();
-    w.activateWindow();
+    if (ok) {
+      CMainWindow& w = CMainWindow::self();
+      // w.loadGISData(filenames);
+      // raise the application window to top of desktop
+      w.raise();
+      w.activateWindow();
+    }
   }
 
   socket->close();

--- a/src/qmaptool/locale/qmaptool.ts
+++ b/src/qmaptool/locale/qmaptool.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="108"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="109"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="171"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="172"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="120"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="121"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="80"/>

--- a/src/qmaptool/locale/qmaptool_de.ts
+++ b/src/qmaptool/locale/qmaptool_de.ts
@@ -2,6 +2,46 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="de_DE">
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="108"/>
+        <source>Fatal...</source>
+        <translation>Schwerer Fehler...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="109"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translatorcomment>Datei konnte nicht gesperrt werden&lt;br&gt;%1&lt;br&gt;%2</translatorcomment>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="171"/>
+        <source>Fatal...</source>
+        <translation>Schwerer Fehler...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="172"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation>Datei konnte nicht gesperrt werden&lt;br&gt;%1&lt;br&gt;%2</translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="120"/>
+        <source>Fatal...</source>
+        <translation>Schwerer Fehler...</translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="121"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation>Datei konnte nicht gesperrt werden&lt;br&gt;%1&lt;br&gt;%2</translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="80"/>

--- a/src/qmaptool/locale/qmaptool_es.ts
+++ b/src/qmaptool/locale/qmaptool_es.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="es_ES">
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="108"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="109"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="171"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="172"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="120"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="121"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="80"/>

--- a/src/qmaptool/locale/qmaptool_it.ts
+++ b/src/qmaptool/locale/qmaptool_it.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="it_IT">
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="108"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="109"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="171"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="172"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="120"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="121"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="80"/>

--- a/src/qmaptool/locale/qmaptool_ru.ts
+++ b/src/qmaptool/locale/qmaptool_ru.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
+    <name>CAppSetupLinux</name>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="108"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupLinux.cpp" line="109"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupMac</name>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="171"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupMac.cpp" line="172"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CAppSetupWin</name>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="120"/>
+        <source>Fatal...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../setup/CAppSetupWin.cpp" line="121"/>
+        <source>Failed to lock file&lt;br&gt;%1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CCanvas</name>
     <message>
         <location filename="../canvas/CCanvas.cpp" line="80"/>

--- a/src/qmaptool/setup/CAppSetupLinux.cpp
+++ b/src/qmaptool/setup/CAppSetupLinux.cpp
@@ -21,10 +21,15 @@
 
 #include "setup/CAppSetupLinux.h"
 
+#include <QMessageBox>
 #include <QWindow>
 
-#include "signal.h"
-#include "unistd.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "config.h"
 #include "version.h"
@@ -80,6 +85,29 @@ void CAppSetupLinux::closeOnSIGTERM() {
   };
 
   signal(SIGTERM, handler);
+}
+
+bool CAppSetupLinux::setLock() {
+  const QString& fileName = userDataPath() % "/." % qApp->applicationName() % ".lock";
+  qDebug() << "Try to lock file" << fileName << "...";
+  int fd = open(QFile::encodeName(fileName).data(), O_CREAT|O_RDWR, S_IRWXU);
+  if (fd != -1) {
+    struct flock lock;
+    memset(&lock, 0, sizeof(struct flock));
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    if (fcntl(fd, F_SETLK, &lock) == 0) {
+      qDebug() << "... Success";
+      return true;
+    } else if (errno == EACCES || errno == EAGAIN) {
+      qDebug().noquote() << "..." << strerror(errno);
+      close(fd);
+      return false;
+    }
+  }
+  QMessageBox::critical(nullptr, tr("Fatal..."),
+     tr("Failed to lock file<br>%1<br>%2").arg(fileName, strerror(errno)));
+  exit(-1);
 }
 
 #endif // defined(Q_OS_LINUX)

--- a/src/qmaptool/setup/CAppSetupLinux.h
+++ b/src/qmaptool/setup/CAppSetupLinux.h
@@ -24,6 +24,7 @@
 #include "setup/IAppSetup.h"
 
 class CAppSetupLinux : public IAppSetup {
+  Q_DECLARE_TR_FUNCTIONS(CAppSetupLinux)
  public:
   CAppSetupLinux(QObject* parent) : IAppSetup(parent) {}
 
@@ -35,6 +36,7 @@ class CAppSetupLinux : public IAppSetup {
   QString logDir() override;
   QString findExecutable(const QString& name) override { return QStandardPaths::findExecutable(name); }
   QString helpFile() override;
+  bool setLock() override;
 
  private:
   static void closeOnSIGTERM();

--- a/src/qmaptool/setup/CAppSetupMac.cpp
+++ b/src/qmaptool/setup/CAppSetupMac.cpp
@@ -21,10 +21,15 @@
 
 #include "setup/CAppSetupMac.h"
 
+#include <QMessageBox>
 #include <QWindow>
 
-#include "signal.h"
-#include "unistd.h"
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/errno.h>
+#include <unistd.h>
 
 #include "misc.h"
 
@@ -143,6 +148,29 @@ void CAppSetupMac::closeOnSIGTERM() {
   };
 
   signal(SIGTERM, handler);
+}
+
+bool CAppSetupMac::setLock() {
+  const QString& fileName = userDataPath() % "/.lock";
+  qDebug() << "Try to lock file" << fileName << "...";
+  int fd = open(QFile::encodeName(fileName).data(), O_CREAT|O_RDWR, S_IRWXU);
+  if (fd != -1) {
+    struct flock lock;
+    memset(&lock, 0, sizeof(struct flock));
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    if (fcntl(fd, F_SETLK, &lock) == 0) {
+      qDebug() << "... Success";
+      return true;
+    } else if (errno == EACCES || errno == EAGAIN) {
+      qDebug().noquote() << "..." << strerror(errno);
+      close(fd);
+      return false;
+    }
+  }
+  QMessageBox::critical(nullptr, tr("Fatal..."),
+     tr("Failed to lock file<br>%1<br>%2").arg(fileName, strerror(errno)));
+  exit(-1);
 }
 
 #endif // defined(Q_OS_MAC)

--- a/src/qmaptool/setup/CAppSetupMac.h
+++ b/src/qmaptool/setup/CAppSetupMac.h
@@ -24,6 +24,7 @@
 #include "setup/IAppSetup.h"
 
 class CAppSetupMac : public IAppSetup {
+  Q_DECLARE_TR_FUNCTIONS(CAppSetupMac)
  public:
   CAppSetupMac(QObject *parent) : IAppSetup(parent) {}
 
@@ -35,6 +36,7 @@ class CAppSetupMac : public IAppSetup {
   QString logDir() override;
   QString findExecutable(const QString &name) override;
   QString helpFile() override;
+  bool setLock() override;
 
  private:
   QDir getApplicationDir(QString subdir);

--- a/src/qmaptool/setup/CAppSetupWin.cpp
+++ b/src/qmaptool/setup/CAppSetupWin.cpp
@@ -22,9 +22,13 @@
 #include "setup/CAppSetupWin.h"
 
 #include <QAbstractNativeEventFilter>
+#include <QMessageBox>
 #include <QWindow>
 
-#include "windows.h"
+#include <windows.h>
+#include <winbase.h>
+#include <errhandlingapi.h>
+#include <fileapi.h>
 
 #include "config.h"
 #include "version.h"
@@ -92,6 +96,30 @@ QString CAppSetupWin::helpFile() {
   QDir dirApp = QDir(QCoreApplication::applicationDirPath());
   QDir dirHelp = QDir(dirApp.absoluteFilePath(_MKSTR(HELPPATH)));
   return dirHelp.absoluteFilePath("QMTHelp.qhc");
+}
+
+bool CAppSetupWin::setLock() {
+  const QString& fileName = userDataPath() % "/." % qApp->applicationName() % ".lock";
+  qDebug() << "Try to lock file" << fileName << "...";
+  HANDLE hd = CreateFileW((const wchar_t*)fileName.utf16(),
+              GENERIC_READ|GENERIC_WRITE, 0,
+              NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+  if (hd != INVALID_HANDLE_VALUE) {
+    qDebug() << "... Success";
+    return true;
+  }
+  DWORD errorId = GetLastError();
+  wchar_t errorMsg[256];
+  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_IGNORE_INSERTS|FORMAT_MESSAGE_MAX_WIDTH_MASK,
+               NULL, errorId, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+               errorMsg, (sizeof(errorMsg) / sizeof(wchar_t)), NULL);
+  if (errorId == ERROR_SHARING_VIOLATION) {
+    qDebug().noquote() << "..." << QString::fromUtf16((const char16_t*)errorMsg);
+    return false;
+  }
+  QMessageBox::critical(nullptr, tr("Fatal..."),
+     tr("Failed to lock file<br>%1<br>%2").arg(fileName, QString::fromUtf16((const char16_t*)errorMsg)));
+  exit(-1);
 }
 
 #endif // defined(Q_OS_WIN32)

--- a/src/qmaptool/setup/CAppSetupWin.h
+++ b/src/qmaptool/setup/CAppSetupWin.h
@@ -24,6 +24,7 @@
 #include "setup/IAppSetup.h"
 
 class CAppSetupWin : public IAppSetup {
+  Q_DECLARE_TR_FUNCTIONS(CAppSetupWin)
  public:
   CAppSetupWin(QObject* parent) : IAppSetup(parent) {}
 
@@ -35,6 +36,7 @@ class CAppSetupWin : public IAppSetup {
   QString logDir() override;
   QString findExecutable(const QString& name) override;
   QString helpFile() override;
+  bool setLock() override;
 
   QByteArray path;
 };

--- a/src/qmaptool/setup/IAppSetup.h
+++ b/src/qmaptool/setup/IAppSetup.h
@@ -40,6 +40,8 @@ class IAppSetup : public QObject {
   virtual QString userDataPath(QString subdir = 0) = 0;
   virtual QString logDir() = 0;
   virtual QString findExecutable(const QString& name) = 0;
+  virtual QString helpFile() = 0;
+  virtual bool setLock() = 0;
 
   QString getGdaladdo() const {
     return QFile::exists(pathGdaladdoOverride) ? pathGdaladdoOverride : QFile::exists(pathGdaladdo) ? pathGdaladdo : "";
@@ -145,7 +147,6 @@ class IAppSetup : public QObject {
 
   bool isQmtmap2jnxOverride() const { return !pathQmtmap2jnxOverride.isEmpty(); }
 
-  virtual QString helpFile() = 0;
  signals:
   void sigSetupChanged();
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1036

### What you have done:
[comment]: # (Describe roughly.)

Main issue - QMS opening twice:
Additionally use operating system's native file locking methods to distinguish between primary and secondary QMS instance.

Sub-issue 1 - transferring optional GIS filenames from secondary to primary QMS instance:
Slightly modified data exchange between secondary and primary QMS instance making it reliable.

Sub-issue 2 - primary QMS instance crashing at start due receiving list of GIS filenames from secondary instance:
Now checking if `&CMainWindow::self()` still points to NULL before calling any CMainWindow class function.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Verify that it is no longer possible to run more than 1 primary instance of QMS per user. In other words, QMS no longer opens twice. If desired, use debug switch _-d_ to watch output.
2. Run secondary QMS instance supplying additional GIS files on command line. See that GIS files are processed by primary QMS instance.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
