### PR TITLE
[QMS-1040] Fix: Issue sending relative filenames from secondary to primary instance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ V1.XX.X
 [QMS-1034] Fix: Show view names instead of keys in Replace DEM dialog
 [QMS-1036] Fix: Prevent QMS from opening twice & corrupting sqlite db
 [QMS-1037] Fix: Buggy handling of multiple times cloned view(s)
+[QMS-1040] Fix: Issue sending relative filenames from secondary to primary instance
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/CSingleInstanceProxy.cpp
+++ b/src/qmapshack/CSingleInstanceProxy.cpp
@@ -38,9 +38,18 @@ CSingleInstanceProxy::CSingleInstanceProxy(const QStringList filenames) {
       // Another instance is already running. In that case
       // the list of files to open is sent to the primary instance.
       // And this secondary instance will be closed imediately.
+
+      // send full path names 
+      QStringList paths;
+      for (const QString& filename : filenames) {
+        const QString& path = QFileInfo(filename).absoluteFilePath();
+        if (QFile(path).exists()) {
+          paths << path;
+        }
+      }
       QByteArray sendData;
       QDataStream sendDataStream(&sendData, QIODevice::WriteOnly);
-      sendDataStream << filenames;
+      sendDataStream << paths;
       socket.write(sendData);
       socket.waitForBytesWritten(3000);
 

--- a/src/qmaptool/CSingleInstanceProxy.cpp
+++ b/src/qmaptool/CSingleInstanceProxy.cpp
@@ -38,9 +38,18 @@ CSingleInstanceProxy::CSingleInstanceProxy(const QStringList filenames) {
       // Another instance is already running. In that case
       // the list of files to open is sent to the primary instance.
       // And this secondary instance will be closed imediately.
+
+      // send full path names 
+      QStringList paths;
+      for (const QString& filename : filenames) {
+        const QString& path = QFileInfo(filename).absoluteFilePath();
+        if (QFile(path).exists()) {
+          paths << path;
+        }
+      }
       QByteArray sendData;
       QDataStream sendDataStream(&sendData, QIODevice::WriteOnly);
-      sendDataStream << filenames;
+      sendDataStream << paths;
       socket.write(sendData);
       socket.waitForBytesWritten(3000);
 


### PR DESCRIPTION


<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1040

### What you have done:
[comment]: # (Describe roughly.)

Convert relative file paths to absolute file paths and send list of absolute filenames from secondary to primary QMS instance.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run primary QMS instance from working directory A.
2. Working directory B contains valid and non empty GIS files _Project1.gpx_ and _Project2.gpx_.
   Run secondary QMS instance from working directory B twice or more times by command line
   `qmapshack -d -c new.ini Project1.gpx Project2.gpx`
3. See that primary instance either adds projects _Project1_ and _Project2_ to workspace
   or rejects if already existing in wokspace.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
