### PR TITLE
[QMS-1022] Fix: Wrong view active after restart

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-1013] Fix: Icons do not fit into on screen multiple selection circles
 [QMS-1018] Fix: Warnings in CMapItemDelegate
 [QMS-1021] Dev: Add unique key to views for better identification
+[QMS-1022] Fix: Wrong view active after restart
 [QMS-1024] Fix: Accessibility issue : font is too small (macOS)
 [QMS-1027] Fix: Maps: Copyright notice is missing in tool tips
 [QMS-1031] Fix: Fatal error exporting database project

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -295,7 +295,7 @@ CMainWindow::CMainWindow() : id(QRandomGenerator::global()->generate()) {
   actionProfileIsWindow->setChecked(cfg.value("profileIsWindow", false).toBool());
   actionLinkMapViews->setChecked(cfg.value("linkMapViews", false).toBool());
   mapFont = cfg.value("mapFont", font()).value<QFont>();
-  tabWidget->setCurrentIndex(cfg.value("visibleCanvas", 0).toInt());
+  tabWidget->setCurrentIndex(getTabIndexForCanvasKey(cfg.value("visibleCanvas", "").toString()));
   cfg.endGroup();  // Canvas
 
   QStatusBar* status = statusBar();
@@ -563,7 +563,8 @@ CMainWindow::~CMainWindow() {
 
   cfg.setValue("canvasOrder", allViewKeys);
   cfg.setValue("gisLayerOpacity", CCanvas::gisLayerOpacity);
-  cfg.setValue("visibleCanvas", tabWidget->currentIndex());
+  const CCanvas* canvas = getVisibleCanvas();
+  cfg.setValue("visibleCanvas", canvas != nullptr ? canvas->getKey() : "");
   cfg.setValue("isGeosearchVisible", actionGeoSearch->isChecked());
   cfg.setValue("isScaleVisible", actionShowScale->isChecked());
   cfg.setValue("isGridVisible", actionShowGrid->isChecked());
@@ -750,7 +751,12 @@ void CMainWindow::addWidgetToTab(QWidget* w) {
   }
 }
 
-CCanvas* CMainWindow::getVisibleCanvas() const { return dynamic_cast<CCanvas*>(tabWidget->currentWidget()); }
+CCanvas* CMainWindow::getVisibleCanvas() const { 
+  int n = tabMaps->currentIndex();
+  CMapList* mapList = dynamic_cast<CMapList*>(tabMaps->widget(n));
+  n = mapList != nullptr ? getTabIndexForCanvasKey(mapList->getCanvasKey()) : -1;
+  return dynamic_cast<CCanvas*>(tabWidget->widget(n));
+}
 
 QList<CCanvas*> CMainWindow::getCanvas() const {
   QList<CCanvas*> result;
@@ -763,6 +769,16 @@ QList<CCanvas*> CMainWindow::getCanvas() const {
   }
 
   return result;
+}
+
+int CMainWindow::getTabIndexForCanvasKey(const QString& key) const {
+  for (int i = 0; i < tabWidget->count(); i++) {
+    CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->widget(i));
+    if (canvas != nullptr && canvas->getKey() == key) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 void CMainWindow::zoomCanvasTo(const QRectF rect) {

--- a/src/qmapshack/CMainWindow.h
+++ b/src/qmapshack/CMainWindow.h
@@ -117,6 +117,8 @@ class CMainWindow : public QMainWindow, private Ui::IMainWindow {
   CCanvas* getVisibleCanvas() const;
   QList<CCanvas*> getCanvas() const;
 
+  int getTabIndexForCanvasKey(const QString& key) const;
+
   QAction* getMapSetupAction() { return actionSetupMapPaths; }
 
   QAction* getDemSetupAction() { return actionSetupDEMPaths; }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1022

### What you have done:
[comment]: # (Describe roughly.)

Save current active map view's unique key to config instead of current tab index.
When closing QMS, current active map view is now taken from current map list tab.
Current map list tab always corresponds to active map view,
whether map view or diary or project editor or ... tab is visible when closing QMS.

Compatibility to previously saved tab index is preserved.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Create several map views
2. Set one of these map view as current
3. Create diary and/or project editor and/or ... tabs
4. Arrange these tabs in any arbitrary order
5. Close and re-open QMS, regardless of whether last open tab was a map view or diary or project editor tab
6. See that previous current map view becomes current map view again

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
