### PR TITLE
[QMS-1043] Fix: Inconsistent tab ordering

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ V1.XX.X
 [QMS-1036] Fix: Prevent QMS from opening twice & corrupting sqlite db
 [QMS-1037] Fix: Buggy handling of multiple times cloned view(s)
 [QMS-1040] Fix: Issue sending relative filenames from secondary to primary instance
+[QMS-1043] Fix: Inconsistent tab ordering
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -236,6 +236,22 @@ CMainWindow::CMainWindow() : id(QRandomGenerator::global()->generate()) {
   connect(tabPoi, &QTabWidget::currentChanged, this, &CMainWindow::slotCurrentTabPoi);
 
   connect(tabWidget->tabBar(), &QTabBar::tabMoved, this, [this](int from, int to) {
+    CCanvas* canvasFrom = dynamic_cast<CCanvas*>(tabWidget->widget(from));
+    if (canvasFrom == nullptr) return;
+    CCanvas* canvasTo = dynamic_cast<CCanvas*>(tabWidget->widget(to));
+    if (canvasTo == nullptr) return;
+    const QString& keyFrom = canvasFrom->getKey();
+    const QString& keyTo = canvasTo->getKey();
+    for (int i = 0; i < tabMaps->count(); i++) {
+      CMapList* mapList = dynamic_cast<CMapList*>(tabMaps->widget(i));
+      if (mapList == nullptr) {
+        continue;
+      } else if (mapList->getCanvasKey() == keyFrom) {
+        from = i;
+      } else if (mapList->getCanvasKey() == keyTo) {
+        to = i;
+      }
+    }
     tabMaps->tabBar()->moveTab(from, to);
     tabDem->tabBar()->moveTab(from, to);
     tabPoi->tabBar()->moveTab(from, to);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1043

### What you have done:
[comment]: # (Describe roughly.)

Swapping "tabWidget" tabs now checks kind of tab to swap, either canvas tab or some else tab.
It does no longer swap "tabMaps" tabs when swapping non-canvas kind "tabWidget" tabs.
It does no longer map unmodified "tabWidget" tab indexes to "tabMaps" tab indexes but recalculates "tabMaps" tab indexes.
When swapping, non-canvas kind "tabWidget" tabs existing between canvas tab leaded to unpredicatable "tabMaps" tabs ordering.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Create some map view tabs
2. Create some other tabs: diary tabs, track editor tabs, ...
3. Rearrange tabs as desired, shifting them left or right
4. See that sorting of map view tabs keeps the same in all windows having tabs: map area window, map list, DEM list, POI list

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
