### PR TITLE
[QMS-1017] Fix: Map view jumping after editing track

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-1009] Fix: Workspace icon size does not follow font size
 [QMS-1012] Fix: Delegate entries possibly hardly readable
 [QMS-1013] Fix: Icons do not fit into on screen multiple selection circles
+[QMS-1017] Fix: Map view jumping after editing track
 [QMS-1018] Fix: Warnings in CMapItemDelegate
 [QMS-1021] Dev: Add unique key to views for better identification
 [QMS-1022] Fix: Wrong view active after restart

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -984,6 +984,25 @@ void CMainWindow::testForNoView() {
 void CMainWindow::slotTabCloseRequest(int i) {
   QMutexLocker lock(&CMapItem::mutexActiveMaps);
 
+  int current = tabWidget->currentIndex();
+  // current tab is closing
+  if (i == current) {
+    if ((current + 1) == tabWidget->count()) {
+      current--;
+    } else {
+      current++;
+    }
+    // would next current tab be any canvas?
+    CCanvas* canvas = dynamic_cast<CCanvas*>(tabWidget->widget(current));
+    if (canvas != nullptr) {
+      // yes -> force "visible" canvas as current
+      canvas = getVisibleCanvas();
+      if (canvas != nullptr) {
+        tabWidget->setCurrentIndex(tabWidget->indexOf(canvas));
+      }
+    }
+  }
+
   delete tabWidget->widget(i);
 
   testForNoView();


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1017

### What you have done:
[comment]: # (Describe roughly.)

I have implemented following algorithm:

- If a tab other than "current tabWidget" tab is about to close, QTabWidget's rules apply. "current tabWidget" remains.
  If tab to close is no map view tab or is not "current tabMaps" map view, current map view remains.
  If tab to close is "current tabMaps" map view, current map view changes but according to QTabWidget's rules.
- If "current tabWidget" tab is about to close, algorithm tests kind of next tab to normally become "current tabWidget" tab
   if QTabWidget's rules would be applied.
  - If next tab to become "current tabWidget" tab is no map view tab, QTabWidget's rules apply.
  - But if next tab to become "current tabWidget" tab is a map view tab, QTabWidget's rules do not apply.
     Instead, "current tabWidget" tab is forced to show map view matching "current tabMaps" tab's map view.

This algorithm preserves QTabWidget's behavior as much as possible.
With one exception: "current" map view is preserved when closing a project editor, track editor, diary and/or similar tab.

QTabWidget's internal rule when closing other than "current" tab is as follows:
The "current" tab remains.
QTabWidget's internal rules when closing "current" tab are as follows:
If "current" tab is not the last tab, the tab on the right becomes next "current" tab.
If "current" is the last tab, the tab on the left becomes next "current" tab.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Create several map view tabs
2. Select a map view as current
3. Add project editor, track editor, diary and/or similar tabs
4. Rearrange tabs
5. Close any or all project editor, track editor, diary and/or similar tabs
6. See that selected map view has not changed

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
