### PR TITLE
Fix build failure with GDAL 3.13.0.

### DIFF
--- a/src/qmt_map2jnx/main.cpp
+++ b/src/qmt_map2jnx/main.cpp
@@ -430,7 +430,11 @@ static void printProgress(int current, int total) {
   static int nLastTick = -1;
   int nThisTick = (int)(dfComplete * 40.0);
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 13, 0)
+  nThisTick = CPL_MIN(40, CPL_MAX(0, nThisTick));
+#else
   nThisTick = MIN(40, MAX(0, nThisTick));
+#endif
 
   // Have we started a new progress run?
   if (nThisTick < nLastTick && nLastTick >= 39) {


### PR DESCRIPTION
1.20.1 fails to build with GDAL 3.13.0 due to API changes:
```
error: 'MIN' was not declared in this scope
error: 'MAX' was not declared in this scope
```
See: https://github.com/OSGeo/gdal/commit/1f41ebcb4eaaad8ad5d81a789bf03ce9c20b3beb#diff-5e4656f11ffb922553c3e06f51ce9666886da91cfbc868ba4eac4c7515013c21