### PR TITLE
[QMS-1047] Fix: GDAL >= 3.13.x: compile error, macOS: PROJ 9.8.0 issue

### DIFF
--- a/MacOSX/build-gdal.sh
+++ b/MacOSX/build-gdal.sh
@@ -6,69 +6,68 @@ echo "${ATTN}-----------------${NC}"
 
 ######################################################################## 
 # build GDAL (using cmake)
-    echo "${ATTN}Building GDAL ...${NC}"
-    cd $QMSDEVDIR
+echo "${ATTN}Building GDAL ...${NC}"
+cd $QMSDEVDIR
 
-    # Check for local GDAL repo
-    if [ -d gdal ] && [ -e gdal/gdal-$GDAL_RELEASE.txt ]
-    then
-      # Update existing repo
-      cd $QMSDEVDIR/gdal
-      git fetch
-      git merge
-    else
-      # Create new repo
-      rm -rf gdal 2>/dev/null
-      git clone -b "release/$GDAL_RELEASE" https://github.com/OSGeo/gdal.git
-# --> folder $QMSVERDIR/gdal created
-      cd $QMSDEVDIR/gdal
-      touch gdal-$GDAL_RELEASE.txt
-    fi
+# Check for local GDAL repo
+if [ -d gdal ] && [ -e gdal/gdal-$GDAL_RELEASE.txt ]
+then
+  # Update existing repo
+  cd $QMSDEVDIR/gdal
+  git fetch
+  git merge
+else
+  # Create new repo
+  rm -rf gdal 2>/dev/null
+  git clone -b "release/$GDAL_RELEASE" https://github.com/OSGeo/gdal.git
+  # --> folder $QMSVERDIR/gdal created
+  cd $QMSDEVDIR/gdal
+  touch gdal-$GDAL_RELEASE.txt
+fi
 
-    mkdir build
-    cd build
-    
-    # Ensure local PROJ is used
-    export PKG_CONFIG_PATH="$LOCAL_ENV/lib/pkgconfig"
-    export CMAKE_PREFIX_PATH="$LOCAL_ENV:$CMAKE_PREFIX_PATH"
-    export PROJ_INCLUDE="$LOCAL_ENV/include"
+mkdir build
+cd build
 
-    # Boost headers need to be in the include path
-    export CPATH="$LOCAL_ENV/include:$PACKAGES_PATH/include:${CPATH}"
-    export LIBRARY_PATH="$LOCAL_ENV/lib:$PACKAGES_PATH/lib"
-    export LD_LIBRARY_PATH="$LOCAL_ENV/lib:$PACKAGES_PATH/lib"
+# Ensure local PROJ is used
+export PKG_CONFIG_PATH="$LOCAL_ENV/lib/pkgconfig"
+export CMAKE_PREFIX_PATH="$LOCAL_ENV:$CMAKE_PREFIX_PATH"
+export PROJ_INCLUDE="$LOCAL_ENV/include"
 
-    GDAL=$LOCAL_ENV
+# Boost headers need to be in the include path
+export CPATH="$LOCAL_ENV/include:$PACKAGES_PATH/include:${CPATH}"
+export LIBRARY_PATH="$LOCAL_ENV/lib:$PACKAGES_PATH/lib"
+export LD_LIBRARY_PATH="$LOCAL_ENV/lib:$PACKAGES_PATH/lib"
 
-    $PACKAGES_PATH/bin/cmake .. -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
-                                -DCMAKE_BUILD_TYPE=Release \
-                                -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV \
-                                -DGDAL_SET_INSTALL_RELATIVE_RPATH=ON \
-                                -DGDAL_USE_INTERNAL_LIBS=ON \
-                                -DGDAL_USE_EXTERNAL_LIBS=OFF \
-                                -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON \
-                                -DGDAL_USE_CURL=ON \
-                                -DGDAL_ENABLE_DRIVER_WMS:BOOL=ON \
-                                -DGDAL_ENABLE_DRIVER_WCS:BOOL=ON \
-                                -DGDAL_USE_TIFF=ON \
-                                -DGDAL_USE_GEOTIFF=ON \
-                                -DGDAL_USE_GEOS=ON \
-                                -DGDAL_USE_PNG=ON \
-                                -DGDAL_USE_GIF=ON \
-                                -DGDAL_USE_ODBC=ON \
-                                -DGDAL_USE_PCRE2=ON \
-                                -DGDAL_USE_ICONV=ON \
-                                -DGDAL_USE_LIBXML2=ON \
-                                -DGDAL_USE_EXPAT=ON \
-                                -DGDAL_USE_HEIF=ON \
-                                -DGDAL_USE_WEBP=OFF \
-                                -DGDAL_ENABLE_PYTHON=OFF \
-                                -DGDAL_USE_SWIG=OFF \
-                                -DGDAL_USE_POPPLER=ON \
-                                -DBUILD_PYTHON_BINDINGS=OFF
-                            
-                                                                
-                             
-    $PACKAGES_PATH/bin/cmake --build . -j"$(sysctl -n hw.ncpu)"
-    $PACKAGES_PATH/bin/cmake --build . --target install
-    cd $QMSDEVDIR
+GDAL=$LOCAL_ENV
+
+$PACKAGES_PATH/bin/cmake .. -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+                            -DCMAKE_BUILD_TYPE=Release \
+                            -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV \
+                            -DGDAL_SET_INSTALL_RELATIVE_RPATH=ON \
+                            -DGDAL_USE_INTERNAL_LIBS=ON \
+                            -DGDAL_USE_EXTERNAL_LIBS=OFF \
+                            -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON \
+                            -DGDAL_USE_CURL=ON \
+                            -DGDAL_ENABLE_DRIVER_WMS:BOOL=ON \
+                            -DGDAL_ENABLE_DRIVER_WCS:BOOL=ON \
+                            -DGDAL_USE_TIFF=ON \
+                            -DGDAL_USE_GEOTIFF=ON \
+                            -DGDAL_USE_GEOS=ON \
+                            -DGDAL_USE_PNG=ON \
+                            -DGDAL_USE_GIF=ON \
+                            -DGDAL_USE_ODBC=ON \
+                            -DGDAL_USE_PCRE2=ON \
+                            -DGDAL_USE_ICONV=ON \
+                            -DGDAL_USE_LIBXML2=ON \
+                            -DGDAL_USE_EXPAT=ON \
+                            -DGDAL_USE_HEIF=ON \
+                            -DGDAL_USE_WEBP=OFF \
+                            -DGDAL_ENABLE_PYTHON=OFF \
+                            -DGDAL_USE_SWIG=OFF \
+                            -DGDAL_USE_POPPLER=ON \
+                            -DBUILD_PYTHON_BINDINGS=OFF
+
+$PACKAGES_PATH/bin/cmake --build . -j"$(sysctl -n hw.ncpu)"
+$PACKAGES_PATH/bin/cmake --build . --target install
+
+cd $QMSDEVDIR

--- a/MacOSX/build-proj.sh
+++ b/MacOSX/build-proj.sh
@@ -5,21 +5,31 @@ echo "${ATTN}Building PROJ ...${NC}"
 echo "${ATTN}-----------------${NC}"
 
 ######################################################################## 
-# build Proj
-
-PROJ_PKG=proj-$PROJ_RELEASE
-
-cd $QMSDEVDIR
+# build PROJ
 echo "${ATTN}Building Proj ...${NC}"
-if [ ! -d $PROJ_PKG ]
-then 
-  curl https://download.osgeo.org/proj/$PROJ_PKG.tar.gz  | tar xzf -
+cd $QMSDEVDIR
+
+# Check for local PROJ repo
+if [ -d proj ] && [ -e proj/proj-$PROJ_RELEASE.txt ]
+then
+  # Update existing repo
+  cd $QMSDEVDIR/proj
+  git fetch
+  git merge
+else
+  # Create new repo
+  rm -rf proj 2>/dev/null
+  git clone -b "$PROJ_RELEASE" https://github.com/OSGeo/proj.git
+  # --> folder $QMSVERDIR/proj created
+  cd $QMSDEVDIR/proj
+  touch proj-$PROJ_RELEASE.txt
 fi
 
-# --> folder $QMSVERDIR/$PROJ_PKG/ created
-cd $QMSDEVDIR/$PROJ_PKG
 mkdir build
 cd build
+
+PROJ=$LOCAL_ENV
+
 $PACKAGES_PATH/bin/cmake .. -DCMAKE_INSTALL_PREFIX=$LOCAL_ENV
 $PACKAGES_PATH/bin/cmake --build . -j4
 $PACKAGES_PATH/bin/cmake --build . --target install
@@ -33,4 +43,5 @@ then
   curl https://download.osgeo.org/proj/$PROJ_DATA.tar.gz | tar xzf -
   touch $PROJ_DATA.txt
 fi
+
 cd $QMSDEVDIR

--- a/MacOSX/config.sh
+++ b/MacOSX/config.sh
@@ -175,7 +175,7 @@ else
         export GDAL=$PACKAGES_PATH
     fi
     if [ "$BUILD_PROJ" = "x" ]; then
-        export PROJ_RELEASE="9.8.0"
+        export PROJ_RELEASE="9.8"
         export PROJ_DATA_RELEASE="1.24"
         export PROJ_DEV_PATH=$LOCAL_ENV
     else

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ V1.XX.X
 [QMS-1037] Fix: Buggy handling of multiple times cloned view(s)
 [QMS-1040] Fix: Issue sending relative filenames from secondary to primary instance
 [QMS-1043] Fix: Inconsistent tab ordering
+[QMS-1047] Fix: GDAL >= 3.13.x: compile error, macOS: PROJ 9.8.0 issue
 
 V1.20.1
 [QMS-945] Redesign icons for focus, autosave, sync, and DB buttons

--- a/src/qmt_map2jnx/main.cpp
+++ b/src/qmt_map2jnx/main.cpp
@@ -430,7 +430,8 @@ static void printProgress(int current, int total) {
   static int nLastTick = -1;
   int nThisTick = (int)(dfComplete * 40.0);
 
-  nThisTick = MIN(40, MAX(0, nThisTick));
+  // gdal >= 3.13 issue: MIN -> std::min, MAX -> std::max
+  nThisTick = std::min(40, std::max(0, nThisTick));
 
   // Have we started a new progress run?
   if (nThisTick < nLastTick && nLastTick >= 39) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1047

### What you have done:
[comment]: # (Describe roughly.)

1. File `src/qmt_map2jnx/main.cpp`:
   Replaced macro `MIN` by `std::min` and macro `MAX` by `std::max`.

2. Modified macOS build scripts no longer to use fixed PROD version 9.8.0
    but to use latest PROD version 9.8.x

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. See that `qmt_map2jnx` compiles and links successfully.
2. See that build on macOS successfully uses latest PROD version, as of today version 9.8.1.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
