### PR TITLE
[QMS-678] Fix: Database dropdown in Routing dock prevents narrowing of docks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-670] Fix: Accessibility issue : font is too small
+[QMS-678] Fix: Database dropdown in Routing dock prevents narrowing of docks
 [QMS-990] Fix: Toolbar menu item(s) too small, "View" menu item missing (macOS)
 [QMS-992] Fix: Changing items does not update the map view
 [QMS-994] Fix: QMapTool not callable from QMapShack (macOS)

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -56,6 +56,10 @@ CRouterRoutino::CRouterRoutino(QWidget* parent) : IRouter(true, parent) {
   pSelf = this;
   setupUi(this);
 
+  const QFontMetrics& fm(comboDatabase->fontMetrics());
+  int minWidth = fm.boundingRect(QString("A").repeated(16)).width();
+  comboDatabase->setMinimumWidth(minWidth);
+
   connect(labelHelp, &QLabel::linkActivated, &CMainWindow::self(),
           static_cast<void (CMainWindow::*)(const QString&)>(&CMainWindow::slotLinkActivated));
 

--- a/src/qmapshack/gis/rte/router/IRouterRoutino.ui
+++ b/src/qmapshack/gis/rte/router/IRouterRoutino.ui
@@ -30,7 +30,10 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMinimumSize</enum>
+     </property>
      <item row="3" column="1">
       <widget class="QComboBox" name="comboDatabase"/>
      </item>


### PR DESCRIPTION


<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#678

### What you have done:
[comment]: # (Describe roughly.)

Changed grid layout's size constraint to `SetMinimumSize` and set database combobox minimum size to width of a 16 characters "A" string. Thus allows narrowing down dock, even for long database names.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Create and add a Routino database with a very long database name
2. See that long database name does not prevent from shrinking Routino dock.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
