### PR TITLE
[QMS-1029] Fix: Unable to significantly change window size while editing project (Windows)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ V1.XX.X
 [QMS-1022] Fix: Wrong view active after restart
 [QMS-1024] Fix: Accessibility issue : font is too small (macOS)
 [QMS-1027] Fix: Maps: Copyright notice is missing in tool tips
+[QMS-1029] Fix: Unable to significantly change window size while editing project (Windows)
 [QMS-1031] Fix: Fatal error exporting database project
 [QMS-1034] Fix: Show view names instead of keys in Replace DEM dialog
 [QMS-1036] Fix: Prevent QMS from opening twice & corrupting sqlite db

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -63,7 +63,7 @@ CDetailsPrj::CDetailsPrj(IGisProject& prj, QWidget* parent)
 
   timerUpdateTime = new QTimer(this);
   timerUpdateTime->setSingleShot(true);
-  timerUpdateTime->setInterval(20);
+  timerUpdateTime->setInterval(500);
   connect(timerUpdateTime, &QTimer::timeout, this, &CDetailsPrj::slotSetupGui);
 
   timerUpdateTime->start();


### PR DESCRIPTION


<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1029

### What you have done:
[comment]: # (Describe roughly.)

For issue to happen the following requirements must be met
1. Issue only happens on Windows
2. Issue only happens if button _Show window contents while dragging_  in _Performance Options_ is checked
   which however is checked by default.
3. Issue only happens when editing project to draw is taking time enough to progress dialog being shown for some seconds
   which is likely to happen with large projects on low-end computers.

State **before** applying this fix:
When dragging main window's resize corner, Windows fires WM_SIZE events at shorter intervals than the time required to draw diary. Thus while dragging, diary is nearly permanently triggered to be redrawn before main window could be significantly resized. While dragging, processing time to elapse before starting to redraw is currently 20 ms.

State **after** applying this fix:
While dragging, processing time to elapse before starting to redraw is increased to 500 ms, giving a real chance to significantly change window size.

Side-effect on Windows which is only now becoming visible:
When dragging window size to smallest possible width and/or height, window size jumps back to previous size after progress dialog disappears. Thus, it is not possible to shrink main window to exactly minimum width and/or height when drawing diary had triggered progress dialog. But that's a lesser evil than not being able to resize at all.

Circle down side-effect:
Progress dialog is a modal dialog. After progress dialog is closed, something triggers a main window WM_SIZE event with prevouis main window size. Unfortunately I could not find out the culprit nor found out how to prevent. Maybe someone else? Making progress dialog non-modal prevents from main window WM_SIZE event getting triggered. But that wasn't intentional.

Fix has no negative impact nor side-effect on Linux and macOS.
 
### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS on computer meeting above requirements
2. Open diary of a large project taking some seconds to be drawn
3. After diary has been drawn, see that main window can be resized for at least 500 ms before diary gets redrawn.
4. On Windows, see known side-effec: shrinking to exactly minimum width and/or height fails. 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
