### PR TITLE
[QMS-1059] Fix: F1 help browser does not open external links

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-1059] Fix: F1 help browser does not open external links
+
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small
 [QMS-678] Fix: Database dropdown in Routing dock prevents narrowing of docks

--- a/src/common/help/CHelpBrowser.cpp
+++ b/src/common/help/CHelpBrowser.cpp
@@ -34,6 +34,7 @@ void CHelpBrowser::setSource(const QUrl& url) {
     return;
   }
   QTextBrowser::setSource(url);
+  QTextBrowser::setOpenExternalLinks(true);
 }
 
 QVariant CHelpBrowser::loadResource(int type, const QUrl& name) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1059

### What you have done:
[comment]: # (Describe roughly.)

Added statement `QTextBrowser::setOpenExternalLinks(true);` in file `src/common/help/CHelpBrowser.cpp`.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. In QMS, hit F1 key to open help browser
2. Open tab _Content -> QMapShack manual -> Basic usage -> Installing QMapShack -> Install QMapShack_
   -> help page _Install QMapShack_ opens in help browser
3. Hit text [in the download section](https://github.com/Maproom/qmapshack/releases) in section Install QMapShack -> Windows of help page
4. See that external link is opened in standard browser

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
