### PR TITLE
[QMS-1061] Fix: File not found error with non-ASCII characters in path (Umlauts)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-1059] Fix: F1 help browser does not open external links
+[QMS-1061] Fix: File not found error with non-ASCII characters in path (Umlauts)
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -39,22 +39,34 @@ CDemVRT::CDemVRT(const QString& filename, CDemDraw* parent) : IDem(parent), file
     return;
   }
 
+  QString fileItem;
   char** fileList = dataset->GetFileList();
   int n = 0;
   while (fileList[n] != nullptr) {
-    QString fileItem = QString::fromUtf8(fileList[n]);
-    if (!QFileInfo(fileItem).exists()) {
-      CSLDestroy(fileList);
-      GDALClose(dataset);
-      dataset = nullptr;
-      QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
-                           tr("File does not exist:") % '\n' % fileItem % '\n' %
-                           tr("referenced by file:") % '\n' % filename);
-      return;
+#if defined(Q_OS_WIN32)
+    fileItem = QString::fromLocal8Bit(fileList[n]);
+    if (QFileInfo(fileItem).exists()) {
+      n++;
+      continue;
     }
-    n++;
+#endif // defined(Q_OS_WIN32)
+    fileItem = QString::fromUtf8(fileList[n]);
+    if (QFileInfo(fileItem).exists()) {
+      n++;
+      continue;
+    }
+    n = -1;
+    break;
   }
   CSLDestroy(fileList);
+  if (n < 0) {
+    GDALClose(dataset);
+    dataset = nullptr;
+    QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
+                           tr("File does not exist:") % '\n' % fileItem % '\n' %
+                           tr("referenced by file:") % '\n' % filename);
+    return;
+  }
 
   if (dataset->GetRasterCount() != 1) {
     GDALClose(dataset);

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -43,22 +43,34 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibili
     return;
   }
 
+  QString fileItem;
   char** fileList = dataset->GetFileList();
   int n = 0;
   while (fileList[n] != nullptr) {
-    QString fileItem = QString::fromUtf8(fileList[n]);
-    if (!QFileInfo(fileItem).exists()) {
-      CSLDestroy(fileList);
-      GDALClose(dataset);
-      dataset = nullptr;
-      QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
-                           tr("File does not exist:") % '\n' % fileItem % '\n' %
-                           tr("referenced by file:") % '\n' % filename);
-      return;
+#if defined(Q_OS_WIN32)
+    fileItem = QString::fromLocal8Bit(fileList[n]);
+    if (QFileInfo(fileItem).exists()) {
+      n++;
+      continue;
     }
-    n++;
+#endif // defined(Q_OS_WIN32)
+    fileItem = QString::fromUtf8(fileList[n]);
+    if (QFileInfo(fileItem).exists()) {
+      n++;
+      continue;
+    }
+    n = -1;
+    break;
   }
   CSLDestroy(fileList);
+  if (n < 0) {
+    GDALClose(dataset);
+    dataset = nullptr;
+    QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
+                           tr("File does not exist:") % '\n' % fileItem % '\n' %
+                           tr("referenced by file:") % '\n' % filename);
+    return;
+  }
 
   // ------- setup color table ---------
   rasterBandCount = dataset->GetRasterCount();


### PR DESCRIPTION

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1061

### What you have done:
[comment]: # (Describe roughly.)

In addition to to check file existence for returned filename referenced by a VRT file
by `QFileInfo(QString::fromUtf8(filename)).exists()`, on platform Windows existence is now checked
by `QFileInfo(QString::fromLocal8Bit(filename)).exists()` too.
In an ANSI encoded VRT file, this will allow valid ANSI characters for filenames depending on current Windows codepage,
e.g. German umlauts for codepage 1252.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

On platform Windows:
1. Create an ANSI encoded VRT file referencing files with filenames containing non-ASCII characters valid for current codepage
2. Try to activate VRT file, DEM or map file
3. Do not see _File not found error_  

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
