### PR TITLE
[QMS-1064] Fix: Crash in progress dialog while optimizing a route

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-1059] Fix: F1 help browser does not open external links
 [QMS-1061] Fix: File not found error with non-ASCII characters in path (Umlauts)
+[QMS-1064] Fix: Crash in progress dialog while optimizing a route
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/helpers/CProgressDialog.cpp
+++ b/src/qmapshack/helpers/CProgressDialog.cpp
@@ -24,7 +24,7 @@
 #include "canvas/CCanvas.h"
 #include "units/IUnit.h"
 
-QStack<CProgressDialog*> CProgressDialog::stackSelf;
+QStack<QPointer<CProgressDialog>> CProgressDialog::stackSelf;
 
 #define DELAY 500
 
@@ -55,7 +55,7 @@ CProgressDialog::CProgressDialog(const QString text, int min, int max, QWidget* 
   timer = new QTimer(this);
   timer->setSingleShot(true);
   connect(timer, &QTimer::timeout, this, [this, oldTopIndex] {
-    if (oldTopIndex > 0) {
+    if (oldTopIndex > 0 && !stackSelf[oldTopIndex].isNull()) {
       stackSelf[oldTopIndex]->pause();
     }
     show();
@@ -73,7 +73,7 @@ CProgressDialog* CProgressDialog::self() {
 
 CProgressDialog::~CProgressDialog() {
   stackSelf.pop();
-  if (!stackSelf.isEmpty()) {
+  if (!stackSelf.isEmpty() && !stackSelf.top().isNull()) {
     stackSelf.top()->goOn();
   }
   CCanvas::restoreOverrideCursor("~CProgressDialog");
@@ -97,7 +97,7 @@ void CProgressDialog::goOn() {
 }
 
 void CProgressDialog::setAllVisible(bool yes) {
-  if (stackSelf.isEmpty()) {
+  if (stackSelf.isEmpty() || stackSelf.top().isNull()) {
     return;
   }
 

--- a/src/qmapshack/helpers/CProgressDialog.h
+++ b/src/qmapshack/helpers/CProgressDialog.h
@@ -61,7 +61,7 @@ class CProgressDialog : public QDialog, private Ui::IProgressDialog {
   void pause();
   void goOn();
 
-  static QStack<CProgressDialog*> stackSelf;
+  static QStack<QPointer<CProgressDialog>> stackSelf;
   QElapsedTimer time;
   QTimer* timer;
   qint32 timeElapsed = 0;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1064

### What you have done:
[comment]: # (Describe roughly.)

Do not store raw pointers in CProgressDialog::stackSelf. Use QPointer and check for nullptr.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
