### PR TITLE
[QMS-1067] Fix: Wrong encoding still appears in logfile

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-1059] Fix: F1 help browser does not open external links
 [QMS-1061] Fix: File not found error with non-ASCII characters in path (Umlauts)
 [QMS-1064] Fix: Crash in progress dialog while optimizing a route
+[QMS-1067] Fix: Wrong encoding still appears in logfile
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -707,10 +707,9 @@ QWidget* CMainWindow::getBestWidgetForParent() {
 }
 
 QString CMainWindow::getUser() {
-  QString user = getenv("USER");
+  QString user = qEnvironmentVariable("USER");
   if (user.isEmpty()) {
-    user = getenv("USERNAME");  // for windows
-
+    user = qEnvironmentVariable("USERNAME");  // for windows
     if (user.isEmpty()) {
       user = "QMapShack";
     }

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     qDebug().nospace() << "Qt versions: " << "build=" << QT_VERSION_STR << ", runtime=" << qVersion();
     QString argList("");
     for (int i = 1; i < argCnt; i++) {
-      argList += " \"" + QString(argVal[i]) + "\"";
+      argList += " \"" % QString::fromLocal8Bit(argVal[i]) % "\"";
     }
     qDebug() << "Executable path:" << QFileInfo(argVal[0]).absoluteFilePath();
     qDebug().noquote().nospace() << "Argument list:" << argList;

--- a/src/qmaptool/CMainWindow.cpp
+++ b/src/qmaptool/CMainWindow.cpp
@@ -114,10 +114,9 @@ CMainWindow::~CMainWindow() {
 }
 
 QString CMainWindow::getUser() {
-  QString user = getenv("USER");
+  QString user = qEnvironmentVariable("USER");
   if (user.isEmpty()) {
-    user = getenv("USERNAME");  // for windows
-
+    user = qEnvironmentVariable("USERNAME");  // for windows
     if (user.isEmpty()) {
       user = "QMapTool";
     }

--- a/src/qmaptool/main.cpp
+++ b/src/qmaptool/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv) {
     qDebug().nospace() << "Qt versions: " << "build=" << QT_VERSION_STR << ", runtime=" << qVersion();
     QString argList("");
     for (int i = 1; i < argCnt; i++) {
-      argList += " \"" + QString(argVal[i]) + "\"";
+      argList += " \"" % QString::fromLocal8Bit(argVal[i]) % "\"";
     }
     qDebug() << "Executable path:" << QFileInfo(argVal[0]).absoluteFilePath();
     qDebug().noquote().nospace() << "Argument list:" << argList;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1067

### What you have done:
[comment]: # (Describe roughly.)

1. Replaced `getenv` by `qEnvironmentVariable` in function `CMainWindow::getUser`.
2. Replacing `QString(argVal[i])` by `QString::fromLocal8Bit(argVal[i])` in file `main.cpp`.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. **On platform Windows**, create a user whose user name contains non-ASCII characters, e.g. German umlauts
    and/or append `-c <configfile>` to command line parameters, where \<configfile> contains non-ASCII characters.
2. Run QMS with  command line parameters `-d` or `-f <logfile>` and write debug output to \<logfile>.
3. Verify that debug output does not contain replacement character(s) _diamond with question mark_ � indicating character(s) not recognized as valid UTF-8.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
