### PR TITLE
[QMS-1069] Fix: Crash when aborting a route calculation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-1061] Fix: File not found error with non-ASCII characters in path (Umlauts)
 [QMS-1064] Fix: Crash in progress dialog while optimizing a route
 [QMS-1067] Fix: Wrong encoding still appears in logfile
+[QMS-1069] Fix: Crash when aborting a route calculation
 [QMS-1071] Fix: Valid DEM file may not be loaded
 
 V1.20.2

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -19,6 +19,7 @@
 
 #include "gis/rte/router/CRouterBRouter.h"
 
+#include <QMutex>
 #include <QtNetwork>
 #include <QtWidgets>
 
@@ -64,6 +65,7 @@ CRouterBRouter::CRouterBRouter(QWidget* parent) : IRouter(false, parent) {
   connect(timerCloseStatusMsg, &QTimer::timeout, this, &CRouterBRouter::slotCloseStatusMsg);
 
   routerSetup = dynamic_cast<CRouterSetup*>(parent);
+  Q_ASSERT(routerSetup != nullptr);
 
   connect(toolConsole, &QToolButton::clicked, this, &CRouterBRouter::slotToggleConsole);
   connect(toolToggleBRouter, &QToolButton::clicked, this, &CRouterBRouter::slotToggleBRouter);
@@ -161,11 +163,10 @@ void CRouterBRouter::updateDialog() const {
     labelCopyrightBRouterWeb->setVisible(true);
   }
   comboProfile->clear();
-  bool hasItems = false;
   const QStringList& profiles = setup->getProfiles();
+  const bool hasItems = !profiles.isEmpty();
   for (const QString& profile : profiles) {
     comboProfile->addItem(profile, profile);
-    hasItems = true;
   }
   comboProfile->setEnabled(hasItems);
   toolProfileInfo->setEnabled(hasItems);
@@ -183,9 +184,8 @@ void CRouterBRouter::slotCloseStatusMsg() const {
 }
 
 QString CRouterBRouter::getOptions() {
-  return QString(tr("profile: %1, alternative: %2")
-                     .arg(comboProfile->currentText())
-                     .arg(comboAlternative->currentData().toInt()));
+  return QString(
+      tr("profile: %1, alternative: %2").arg(comboProfile->currentText()).arg(comboAlternative->currentData().toInt()));
 }
 
 void CRouterBRouter::routerSelected() { getBRouterVersion(); }
@@ -241,12 +241,12 @@ QNetworkRequest CRouterBRouter::getRequest(const QVector<QPointF>& routePoints, 
           if (!nogoPolygons.isEmpty()) {
             nogoPolygons.append("|");
           }
-          nogoPolygons.append(QString("%1").arg(nogoPoints));
+          nogoPolygons.append(nogoPoints);
         } else {
           if (!nogoPolylines.isEmpty()) {
             nogoPolylines.append("|");
           }
-          nogoPolylines.append(QString("%1").arg(nogoPoints));
+          nogoPolylines.append(nogoPoints);
         }
         break;
       }
@@ -258,15 +258,15 @@ QNetworkRequest CRouterBRouter::getRequest(const QVector<QPointF>& routePoints, 
   }
 
   QUrlQuery urlQuery;
-  urlQuery.addQueryItem("lonlats", lonLats.toLatin1());
+  urlQuery.addQueryItem("lonlats", lonLats);
   if (!nogoStr.isEmpty()) {
-    urlQuery.addQueryItem("nogos", nogoStr.toLatin1());
+    urlQuery.addQueryItem("nogos", nogoStr);
   }
   if (!nogoPolygons.isEmpty()) {
-    urlQuery.addQueryItem("polygons", nogoPolygons.toLatin1());
+    urlQuery.addQueryItem("polygons", nogoPolygons);
   }
   if (!nogoPolylines.isEmpty()) {
-    urlQuery.addQueryItem("polylines", nogoPolylines.toLatin1());
+    urlQuery.addQueryItem("polylines", nogoPolylines);
   }
   urlQuery.addQueryItem("profile", comboProfile->currentData().toString());
   urlQuery.addQueryItem("alternativeidx", comboAlternative->currentData().toString());
@@ -289,28 +289,30 @@ int CRouterBRouter::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
   QList<IGisItem*> nogos;
   CGisWorkspace::self().getNogoAreas(nogos);
 
-  return synchronousRequest(points, nogos, coords, costs);
+  try {
+    return synchronousRequest(points, nogos, coords, costs);
+  } catch (const QString& msg) {
+    slotDisplayError(tr("Calculate route failed."), msg);
+    return -1;
+  }
 }
 
 int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QList<IGisItem*>& nogos, QPolygonF& coords,
-                                       qreal* costs = nullptr) {
-  qDebug() << "synchronousRequest";
+                                       qreal* costs) {
   if (!mutex.tryLock()) {
-    qDebug() << "synchronousRequest failed to lock";
     // skip further on-the-fly-requests as long a previous request is still running
     return -1;
   }
-
-  qDebug() << "synchronousRequest lock";
 
   if (setup->installMode == CRouterBRouterSetup::eModeLocal && localBRouter->isBRouterNotRunning()) {
     localBRouter->startBRouter();
   }
 
   try {
+    coords.clear();
     QNetworkReply* reply = networkAccessManager->get(getRequest(points, nogos));
 
-    auto guard = QScopeGuard([this, reply]() {
+    auto guard = qScopeGuard([this, reply]() {
       reply->deleteLater();
       mutex.unlock();
     });
@@ -318,7 +320,7 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QLi
     reply->setProperty("options", getOptions());
     reply->setProperty("time", QDateTime::currentDateTimeUtc().toMSecsSinceEpoch());
 
-    CProgressDialog* progress = new CProgressDialog(tr("Calculate route with %1").arg(getOptions()), 0, NOINT, nullptr);
+    CProgressDialog* progress = new CProgressDialog(tr("Calculate route with %1").arg(getOptions()), 0, NOINT, this);
     QEventLoop eventLoop;
     connect(progress, &CProgressDialog::rejected, reply, &QNetworkReply::abort);
     connect(progress, &CProgressDialog::rejected, &eventLoop, &QEventLoop::quit);
@@ -327,8 +329,10 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QLi
     progress->deleteLater();
 
     const QNetworkReply::NetworkError& netErr = reply->error();
-    if (netErr == QNetworkReply::RemoteHostClosedError && nogos.size() > 1 && !isMinimumVersion(1, 4, 10)) {
-      throw tr("this version of BRouter does not support more then 1 nogo-area");
+    if (netErr == QNetworkReply::OperationCanceledError) {
+      return -1;  // user cancelled via progress dialog — not an error
+    } else if (netErr == QNetworkReply::RemoteHostClosedError && nogos.size() > 1 && !isMinimumVersion(1, 4, 10)) {
+      throw tr("this version of BRouter does not support more than 1 nogo-area");
     } else if (netErr != QNetworkReply::NoError) {
       throw reply->errorString();
     }
@@ -359,19 +363,21 @@ int CRouterBRouter::synchronousRequest(const QVector<QPointF>& points, const QLi
       const QDomElement& elem = xmlLatLng.item(n).toElement();
       coords << QPointF();
       QPointF& point = coords.last();
-      point.setX(elem.attribute("lon").toFloat() * DEG_TO_RAD);
-      point.setY(elem.attribute("lat").toFloat() * DEG_TO_RAD);
+      point.setX(elem.attribute("lon").toDouble() * DEG_TO_RAD);
+      point.setY(elem.attribute("lat").toDouble() * DEG_TO_RAD);
     }
 
     // find costs of route (copied and adapted from CGisItemRte::setResultFromBrouter)
     if (costs != nullptr) {
+      *costs = 0;
       const QDomNodeList& nodes = xml.childNodes();
       for (int i = 0; i < nodes.count(); i++) {
         const QDomNode& node = nodes.at(i);
         if (node.isComment()) {
           const QString& comment = node.toComment().data();
           // ' track-length = 3181 filtered ascend = 70 plain-ascend = 5 cost=8491 energy=.0kwh time=16m 30s '
-          const QRegularExpressionMatch& match = QRegularExpression("cost\\s*=\\s*(-?\\d+)").match(comment);
+          static const QRegularExpression re("cost\\s*=\\s*(-?\\d+)");
+          const QRegularExpressionMatch& match = re.match(comment);
           if (match.hasMatch()) {
             *costs = match.captured(1).toDouble();
           }
@@ -417,9 +423,6 @@ void CRouterBRouter::calcRoute(const IGisItem::key_t& key) {
   QNetworkReply* reply = networkAccessManager->get(getRequest(points, nogos));
   auto guard = qScopeGuard([reply]() { reply->deleteLater(); });
 
-  reply->setProperty("key.item", key.item);
-  reply->setProperty("key.project", key.project);
-  reply->setProperty("key.device", key.device);
   reply->setProperty("options", getOptions());
   reply->setProperty("time", QDateTime::currentDateTimeUtc().toMSecsSinceEpoch());
 
@@ -439,9 +442,11 @@ void CRouterBRouter::calcRoute(const IGisItem::key_t& key) {
 
   try {
     const QNetworkReply::NetworkError& netErr = reply->error();
-    if (netErr == QNetworkReply::RemoteHostClosedError && reply->property("nogos").toInt() > 1 &&
-        !isMinimumVersion(1, 4, 10)) {
-      throw tr("this version of BRouter does not support more then 1 nogo-area");
+    if (netErr == QNetworkReply::OperationCanceledError) {
+      return;  // user cancelled via progress dialog — not an error
+    } else if (netErr == QNetworkReply::RemoteHostClosedError && nogos.size() > 1 &&
+               !isMinimumVersion(1, 4, 10)) {
+      throw tr("this version of BRouter does not support more than 1 nogo-area");
     } else if (netErr != QNetworkReply::NoError) {
       throw reply->errorString();
     }
@@ -465,10 +470,6 @@ void CRouterBRouter::calcRoute(const IGisItem::key_t& key) {
       throw QString(res.data());
     }
 
-    IGisItem::key_t key;
-    key.item = reply->property("key.item").toString();
-    key.project = reply->property("key.project").toString();
-    key.device = reply->property("key.device").toString();
     qint64 time = reply->property("time").toLongLong();
     time = QDateTime::currentDateTimeUtc().toMSecsSinceEpoch() - time;
 

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.h
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.h
@@ -71,7 +71,6 @@ class CRouterBRouter : public IRouter, private Ui::IRouterBRouter {
   int synchronousRequest(const QVector<QPointF>& points, const QList<IGisItem*>& nogos, QPolygonF& coords,
                          qreal* costs);
   QNetworkRequest getRequest(const QVector<QPointF>& routePoints, const QList<IGisItem*>& nogos) const;
-  QUrl getServiceUrl() const;
 
   CRouterBRouterLocal* localBRouter;
 
@@ -81,8 +80,6 @@ class CRouterBRouter : public IRouter, private Ui::IRouterBRouter {
   QMutex mutex;
   CRouterBRouterSetup* setup;
   CRouterSetup* routerSetup;
-  CRouterBRouterInfo* info;
-  CProgressDialog* progress{nullptr};
   bool isShutdown{false};
 
   static CRouterBRouter* pSelf;

--- a/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterOptimization.cpp
@@ -190,7 +190,10 @@ qreal CRouterOptimization::twoOptStep(const SGisLine& oldOrder, SGisLine& newOrd
 qreal CRouterOptimization::getRealRouteCosts(const SGisLine& line, qreal costCutoff) {
   qreal costs = 0;
   for (int i = 0; i < line.length() - 1; i++) {
-    const routing_cache_item_t* route = getRoute(line[i].coord, line[i + 1].coord);
+    // Copy coords: getRoute runs an event loop that can reassign `line`, dangling the references.
+    QPointF coord1 = line[i].coord;
+    QPointF coord2 = line[i + 1].coord;
+    const routing_cache_item_t* route = getRoute(coord1, coord2);
     if (route == nullptr) {
       return -1;
     }
@@ -255,9 +258,16 @@ const CRouterOptimization::routing_cache_item_t* CRouterOptimization::getRoute(c
 
 int CRouterOptimization::fillSubPts(SGisLine& line) {
   for (int i = 0; i < line.length() - 1; i++) {
+    QPointF coord1 = line[i].coord;
+    QPointF coord2 = line[i + 1].coord;
     line[i].subpts.clear();
-    const routing_cache_item_t* route = getRoute(line[i].coord, line[i + 1].coord);
+    const routing_cache_item_t* route = getRoute(coord1, coord2);
     if (route == nullptr) {
+      return -1;
+    }
+    // Re-check bounds: getRoute runs an event loop during which the user can abort,
+    // causing line to be reassigned and potentially shrunk.
+    if (i >= line.length() - 1) {
       return -1;
     }
     for (const QPointF& point : route->route) {

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
@@ -71,6 +71,12 @@ void CLineOpAddPoint::leftClick(const QPoint& pos) {
     // update subpoints of previous and this point
     slotTimeoutRouting();
 
+    // slotTimeoutRouting runs an event loop; the user may have aborted (right-click or undo)
+    // during it, which sets idxFocus = NOIDX. Bail out if that happened.
+    if (idxFocus == NOIDX) {
+      return;
+    }
+
     // if isPoint is true the line has been appended/prepended
     // in this case go on with adding another point
     if (isPoint) {

--- a/src/qmapshack/mouse/line/ILineOp.cpp
+++ b/src/qmapshack/mouse/line/ILineOp.cpp
@@ -201,7 +201,7 @@ void ILineOp::startDelayedRouting() {
 }
 
 void ILineOp::slotTimeoutRouting() {
-  timerRouting->stop();
+  cancelDelayedRouting();
   finalizeOperation(idxFocus);
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
 }
@@ -244,17 +244,17 @@ void ILineOp::drawLeadLine(const QPolygonF& line, QPainter& p) const {
 void ILineOp::mouseMove(const QPoint& pos) { updateLeadLines(idxFocus); }
 
 void ILineOp::leftButtonDown(const QPoint& pos) {
-  timerRouting->stop();
+  cancelDelayedRouting();
   showRoutingErrorMessage(QString());
 }
 
-void ILineOp::scaleChanged() { timerRouting->stop(); }
+void ILineOp::scaleChanged() { cancelDelayedRouting(); }
 
 void ILineOp::startMouseMove(const QPointF& point) {
   //    // as long the mouse is not taken as moving
   //    // to not trigger on-the-fly-routing
   parentHandler->startMouseMove(point.toPoint());
-  timerRouting->stop();
+  cancelDelayedRouting();
 }
 
 void ILineOp::updateLeadLines(qint32 idx) {

--- a/src/qmapshack/mouse/line/ILineOp.cpp
+++ b/src/qmapshack/mouse/line/ILineOp.cpp
@@ -315,21 +315,30 @@ void ILineOp::showRoutingErrorMessage(const QString& msg) const {
   }
 }
 
-void ILineOp::tryRouting(IGisLine::point_t& pt1, IGisLine::point_t& pt2) const {
+void ILineOp::tryRouting(qint32 idx) const {
+  // Copy coords before calcRoute: the router shows a progress dialog that runs an event loop,
+  // during which the user can abort (right-click), causing restoreFromHistory() to reallocate
+  // points and invalidate any references/pointers into it.
+  QPointF coord1 = points[idx].coord;
+  QPointF coord2 = points[idx + 1].coord;
   QPolygonF subs;
 
   try {
-    if (CRouterSetup::self().calcRoute(pt1.coord, pt2.coord, subs) >= 0) {
-      pt1.subpts.clear();
+    if (CRouterSetup::self().calcRoute(coord1, coord2, subs) >= 0) {
+      // Re-check bounds: points may have changed during calcRoute's event loop
+      if (idx >= points.size()) {
+        return;
+      }
+      points[idx].subpts.clear();
       for (const QPointF& sub : std::as_const(subs)) {
-        pt1.subpts << IGisLine::subpt_t(sub);
+        points[idx].subpts << IGisLine::subpt_t(sub);
       }
     }
     showRoutingErrorMessage(QString());
   } catch (const QString& msg) {
     showRoutingErrorMessage(msg);
   }
-  // that is a workaround for canvas loosing mouse tracking caused by CProgressDialog being modal:
+  // workaround for canvas losing mouse tracking caused by CProgressDialog being modal:
   canvas->setMouseTracking(true);
 }
 
@@ -340,11 +349,11 @@ void ILineOp::finalizeOperation(qint32 idx) {
 
   if (parentHandler->useAutoRouting()) {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
-    if (idx > 0) {
-      tryRouting(points[idx - 1], points[idx]);
+    if (idx > 0 && idx < points.size()) {
+      tryRouting(idx - 1);
     }
     if (idx < (points.size() - 1)) {
-      tryRouting(points[idx], points[idx + 1]);
+      tryRouting(idx);
     }
   } else if (parentHandler->useVectorRouting() || parentHandler->useTrackRouting()) {
     if (idx > 0) {
@@ -365,6 +374,10 @@ void ILineOp::finalizeOperation(qint32 idx) {
   }
 
   // need to move the mouse away by some pixels to trigger next routing event
+  // idx may be out of bounds if points was modified during calcRoute's event loop (e.g. abort)
+  if (idx >= points.size()) {
+    return;
+  }
   startMouseMove(points[idx].pixel);
 
   parentHandler->updateStatus();

--- a/src/qmapshack/mouse/line/ILineOp.h
+++ b/src/qmapshack/mouse/line/ILineOp.h
@@ -111,7 +111,7 @@ class ILineOp : public QObject {
   QPolygonF subLinePixel2;
 
  private:
-  void tryRouting(IGisLine::point_t& pt1, IGisLine::point_t& pt2) const;
+  void tryRouting(qint32 idx) const;
 
   QTimer* timerRouting;
   QTime buttonPressTime;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1069

### What you have done:
[comment]: # (Describe roughly.)

Used Claude Code to analyze the crash. After several iterations and  a gentle human hint that it might be the index, AI produced a sensible looking solution.

Also gave CRouterBrouter.cpp an AI review and a clean-up

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
