### PR TITLE
[QMS-1071] Fix: Valid DEM file may not be loaded

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-1061] Fix: File not found error with non-ASCII characters in path (Umlauts)
 [QMS-1064] Fix: Crash in progress dialog while optimizing a route
 [QMS-1067] Fix: Wrong encoding still appears in logfile
+[QMS-1071] Fix: Valid DEM file may not be loaded
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/dem/CDemItem.cpp
+++ b/src/qmapshack/dem/CDemItem.cpp
@@ -52,7 +52,7 @@ void CDemItem::setFilename(const QString& name, const QString& fallbackKey) {
   QFile f(filename);
   if (f.exists() && f.open(QIODevice::ReadOnly)) {
     QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(f.read(qMin(1024, f.size())));
+    md5.addData(f.read(4096));
     key = md5.result().toHex();
     f.close();
   } else {

--- a/src/qmapshack/dem/CDemItem.h
+++ b/src/qmapshack/dem/CDemItem.h
@@ -172,7 +172,7 @@ class CDemItem : public QObject, public IMapItem, public QTreeWidgetItem {
 
   CDemDraw* dem;
   /**
-     @brief A MD5 hash over the first 1024 bytes of the map file, to identify the map
+     @brief A MD5 hash over the first 4096 bytes of the dem file for identification
    */
   QString key;
   /**

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -59,7 +59,7 @@ void CMapItem::setFilename(const QString& name, const QString& fallbackKey) {
   QFile f(filename);
   if (f.exists() && f.open(QIODevice::ReadOnly)) {
     QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(f.read(qMin(0x1000LL, f.size())));
+    md5.addData(f.read(4096));
     key = md5.result().toHex();
     f.close();
   } else {

--- a/src/qmapshack/map/CMapItem.h
+++ b/src/qmapshack/map/CMapItem.h
@@ -167,7 +167,7 @@ class CMapItem : public QObject, public IMapItem, public QTreeWidgetItem {
 
   CMapDraw* map;
   /**
-     @brief A MD5 hash over the first 1024 bytes of the map file, to identify the map
+     @brief A MD5 hash over the first 4096 bytes of the map file for identification
    */
   QString key;
   /**

--- a/src/qmapshack/poi/CPoiDraw.cpp
+++ b/src/qmapshack/poi/CPoiDraw.cpp
@@ -194,11 +194,10 @@ void CPoiDraw::buildPoiList() {
       item->filename = dir.absoluteFilePath(filename);
       item->updateIcon();
 
-      // calculate MD5 hash from the file's first 1024 bytes
       QFile f(dir.absoluteFilePath(filename));
       openFileCheckSuccess(QIODevice::ReadOnly, f);
       md5.reset();
-      md5.addData(f.read(1024));
+      md5.addData(f.read(4096));
       item->key = md5.result().toHex();
       f.close();
     }

--- a/src/qmapshack/poi/CPoiFileItem.h
+++ b/src/qmapshack/poi/CPoiFileItem.h
@@ -95,7 +95,7 @@ class CPoiFileItem : public QTreeWidgetItem {
   friend class CPoiDraw;
   CPoiDraw* poi;
   /**
-     @brief A MD5 hash over the first 1024 bytes of the map file, to identify the map
+     @brief A MD5 hash over the first 4096 bytes of the poi file for identification
    */
   QString key;
   /**


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1071

### What you have done:
[comment]: # (Describe roughly.)

Adjusted **DEM and POI files** _key_ generation to map files _key_ generation :
using now first 4096 bytes of file contents for **DEM and POI files** too.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Try to load both DEM files attached to issue [#1071](https://github.com/Maproom/qmapshack/issues/1071)
2. See that both are successfully loaded

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
