### PR TITLE
[QMS-1075] Disable "O", "V" and "T" buttons when drawing a route

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V1.XX.X
 [QMS-1064] Fix: Crash in progress dialog while optimizing a route
 [QMS-1067] Fix: Wrong encoding still appears in logfile
 [QMS-1071] Fix: Valid DEM file may not be loaded
+[QMS-1075] Disable "O", "V" and "T" buttons when drawing a route
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/gis/IGisLine.h
+++ b/src/qmapshack/gis/IGisLine.h
@@ -29,6 +29,8 @@ class CGisDraw;
 class CDemDraw;
 struct SGisLine;
 
+#define ASCENT_THRESHOLD 5
+
 class IGisLine {
  public:
   IGisLine() = default;

--- a/src/qmapshack/gis/trk/CGisItemTrk.h
+++ b/src/qmapshack/gis/trk/CGisItemTrk.h
@@ -51,7 +51,6 @@ class CProgressDialog;
 class CPropertyTrk;
 class CCanvas;
 
-#define ASCENT_THRESHOLD 5
 #define MIN_WIDTH_INFO_BOX 300
 
 class CGisItemTrk : public IGisItem, public IGisLine {

--- a/src/qmapshack/mouse/CMouseEditArea.cpp
+++ b/src/qmapshack/mouse/CMouseEditArea.cpp
@@ -26,13 +26,13 @@
 #include "gis/ovl/CGisItemOvlArea.h"
 
 CMouseEditArea::CMouseEditArea(const QPointF& point, CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
-    : IMouseEditLine(IGisItem::key_t(), point, false, tr("Area"), gis, canvas, mouse) {
-  startNewLine(point);
+    : IMouseEditLine(IGisItem::key_t(), point, false, IWksItem::eTypeOvl, gis, canvas, mouse) {
+  startNewLine();
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
 }
 
 CMouseEditArea::CMouseEditArea(CGisItemOvlArea& area, CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
-    : IMouseEditLine(area.getKey(), area, false, tr("Area"), gis, canvas, mouse) {
+    : IMouseEditLine(area.getKey(), area, false, IWksItem::eTypeOvl, gis, canvas, mouse) {
   canvas->reportStatus(key.item, tr("<b>Edit Area</b><br/>Select a function and a routing mode via the tool buttons. "
                                     "Next select a point of the line. Only points marked with a large square can be "
                                     "changed. The ones with a black dot are subpoints introduced by routing.<br/>") +

--- a/src/qmapshack/mouse/CMouseEditRte.cpp
+++ b/src/qmapshack/mouse/CMouseEditRte.cpp
@@ -27,13 +27,13 @@
 #include "mouse/line/CScrOptEditLine.h"
 
 CMouseEditRte::CMouseEditRte(const QPointF& point, CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
-    : IMouseEditLine(IGisItem::key_t(), point, true, tr("Route"), gis, canvas, mouse) {
-  startNewLine(point);
+    : IMouseEditLine(IGisItem::key_t(), point, true, IWksItem::eTypeRte, gis, canvas, mouse) {
+  startNewLine();
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
 }
 
 CMouseEditRte::CMouseEditRte(CGisItemRte& rte, CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
-    : IMouseEditLine(rte.getKey(), rte, true, tr("Route"), gis, canvas, mouse) {
+    : IMouseEditLine(rte.getKey(), rte, true, IWksItem::eTypeRte, gis, canvas, mouse) {
   canvas->reportStatus(key.item,
                        tr("<b>Edit Route Points</b><br/>Select a function and a routing mode via the tool buttons. "
                           "Next select a point of the line. Only points marked with a large square can be changed. The "

--- a/src/qmapshack/mouse/CMouseEditTrk.cpp
+++ b/src/qmapshack/mouse/CMouseEditTrk.cpp
@@ -27,13 +27,13 @@
 #include "gis/trk/CGisItemTrk.h"
 
 CMouseEditTrk::CMouseEditTrk(const QPointF& point, CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
-    : IMouseEditLine(IGisItem::key_t(), point, true, tr("Track"), gis, canvas, mouse) {
-  startNewLine(point);
+    : IMouseEditLine(IGisItem::key_t(), point, true, IWksItem::eTypeTrk, gis, canvas, mouse) {
+  startNewLine();
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
 }
 
 CMouseEditTrk::CMouseEditTrk(CGisItemTrk& trk, CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
-    : IMouseEditLine(trk.getKey(), trk, true, tr("Track"), gis, canvas, mouse), isNewLine(false) {
+    : IMouseEditLine(trk.getKey(), trk, true, IWksItem::eTypeTrk, gis, canvas, mouse), isNewLine(false) {
   canvas->reportStatus(key.item,
                        tr("<b>Edit Track Points</b><br/>Select a function and a routing mode via the tool buttons. "
                           "Next select a point of the line. Only points marked with a large square can be changed. The "

--- a/src/qmapshack/mouse/line/IMouseEditLine.cpp
+++ b/src/qmapshack/mouse/line/IMouseEditLine.cpp
@@ -26,9 +26,8 @@
 #include "gis/CGisDraw.h"
 #include "gis/GeoMath.h"
 #include "gis/IGisLine.h"
-#include "gis/rte/router/CRouterSetup.h"
 #include "gis/rte/router/CRouterOptimization.h"
-#include "gis/trk/CGisItemTrk.h"
+#include "gis/rte/router/CRouterSetup.h"
 #include "helpers/CDraw.h"
 #include "helpers/CSettings.h"
 #include "mouse/CMouseAdapter.h"
@@ -39,8 +38,8 @@
 #include "mouse/line/CScrOptEditLine.h"
 #include "units/IUnit.h"
 
-IMouseEditLine::IMouseEditLine(const IGisItem::key_t& key, const QPointF& point, bool enableStatus, const QString& type,
-                               CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
+IMouseEditLine::IMouseEditLine(const IGisItem::key_t& key, const QPointF& point, bool enableStatus,
+                               IWksItem::type_e type, CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
     : IMouse(gis, canvas, mouse), key(key), enableStatus(enableStatus), type(type) {
   commonSetup();
   scrOptEditLine->pushSaveOrig->hide();  // hide as there is no original
@@ -51,7 +50,7 @@ IMouseEditLine::IMouseEditLine(const IGisItem::key_t& key, const QPointF& point,
   storeToHistory(points);
 }
 
-IMouseEditLine::IMouseEditLine(const IGisItem::key_t& key, IGisLine& src, bool enableStatus, const QString& type,
+IMouseEditLine::IMouseEditLine(const IGisItem::key_t& key, IGisLine& src, bool enableStatus, IWksItem::type_e type,
                                CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse)
     : IMouse(gis, canvas, mouse), key(key), enableStatus(enableStatus), type(type) {
   commonSetup();
@@ -96,6 +95,14 @@ void IMouseEditLine::commonSetup() {
   connect(scrOptEditLine->toolAddPoint, &QPushButton::clicked, this, &IMouseEditLine::slotAddPoint);
   connect(scrOptEditLine->toolDeletePoint, &QPushButton::clicked, this, &IMouseEditLine::slotDeletePoint);
 
+  if (type == IWksItem::eTypeRte) {
+    scrOptEditLine->toolNoRoute->setDisabled(true);
+    scrOptEditLine->toolVectorRoute->setDisabled(true);
+    scrOptEditLine->toolTrackRoute->setDisabled(true);
+  } else if (type == IWksItem::eTypeOvl) {
+    scrOptEditLine->pushOptimize->setDisabled(true);
+  }
+
   connect(scrOptEditLine->toolNoRoute, &QPushButton::clicked, this, &IMouseEditLine::slotNoRouting);
   connect(scrOptEditLine->toolAutoRoute, &QPushButton::clicked, this, &IMouseEditLine::slotAutoRouting);
   connect(scrOptEditLine->toolVectorRoute, &QPushButton::clicked, this, &IMouseEditLine::slotVectorRouting);
@@ -133,7 +140,7 @@ void IMouseEditLine::commonSetup() {
 
 void IMouseEditLine::abortStep() {
   // at first try to abort a step within the current operation (px. stop adding a new waypoint)
-  if (!lineOp->abortStep()) {
+  if (lineOp != nullptr && !lineOp->abortStep()) {
     // if within operation nothing can be aborted, then abort the whole operation
     // this equals clicking the `abort` button
     slotAbortEx(true);
@@ -218,7 +225,7 @@ void IMouseEditLine::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QRec
   lineOp->drawFg(p);
 }
 
-void IMouseEditLine::startNewLine(const QPointF& point) {
+void IMouseEditLine::startNewLine() {
   scrOptEditLine->toolAddPoint->setChecked(true);
   slotAddPoint();
 
@@ -317,11 +324,17 @@ void IMouseEditLine::slotTrackRouting() {
 }
 
 void IMouseEditLine::slotHasFastRouting(bool on) {
-  if (scrOptEditLine->toolAutoRoute->isChecked() && !on) {
-    scrOptEditLine->toolNoRoute->setChecked(true);
+  if (type == IWksItem::eTypeRte) {
+    scrOptEditLine->toolNoRoute->setEnabled(!on);
+    scrOptEditLine->toolNoRoute->setChecked(!on);
+    scrOptEditLine->toolAutoRoute->setEnabled(on);
+    scrOptEditLine->toolAutoRoute->setChecked(on);
+  } else {
+    if (scrOptEditLine->toolAutoRoute->isChecked() && !on) {
+      scrOptEditLine->toolNoRoute->setChecked(true);
+    }
+    scrOptEditLine->toolAutoRoute->setEnabled(on);
   }
-  scrOptEditLine->toolAutoRoute->setEnabled(on);
-  scrOptEditLine->toolAutoRoute->setCheckable(on);
 }
 
 void IMouseEditLine::slotOptimize() {
@@ -354,7 +367,7 @@ void IMouseEditLine::slotOptimize() {
 
 void IMouseEditLine::changeCursor() {
   cursor = lineOp->getCursor();
-  if (QApplication::overrideCursor() != 0) {
+  if (QApplication::overrideCursor() != nullptr) {
     CCanvas::changeOverrideCursor(cursor, "IMouseEditLine::changeCursor");
   }
 }
@@ -364,8 +377,8 @@ void IMouseEditLine::slotAbortEx(bool showMB) {
   bool doAbort = (idxHistory == 0) || !showMB;
   if (!doAbort) {
     doAbort = (QMessageBox::Yes ==
-               QMessageBox::question(nullptr, "Abort",
-                                     "Do you really want to abort?\nAny modifications done will be discarded.",
+               QMessageBox::question(CMainWindow::self().getBestWidgetForParent(), tr("Abort"),
+                                     tr("Do you really want to abort?\nAny modifications done will be discarded."),
                                      QMessageBox::Yes | QMessageBox::No));
   }
 
@@ -496,7 +509,12 @@ void IMouseEditLine::updateStatus() {
 
   QString msg, val, unit;
 
-  msg += tr("<b>%1 Metrics</b>").arg(type);
+  const QString& strType = type == IWksItem::eTypeRte   ? tr("Route")
+                           : type == IWksItem::eTypeTrk ? tr("Track")
+                           : type == IWksItem::eTypeOvl ? tr("Area")
+                                                        : "???";
+
+  msg += tr("<b>%1 Metrics</b>").arg(strType);
   msg += "<table>";
   IUnit::self().meter2distance(dist, val, unit);
   msg += "<tr><td>" + tr("Distance:") + "</td><td>" + QString("&nbsp;%1 %2").arg(val, unit) + "</td></tr>";

--- a/src/qmapshack/mouse/line/IMouseEditLine.h
+++ b/src/qmapshack/mouse/line/IMouseEditLine.h
@@ -20,8 +20,6 @@
 #ifndef IMOUSEEDITLINE_H
 #define IMOUSEEDITLINE_H
 
-#include <QDebug>
-#include <QPointer>
 #include <QPolygonF>
 
 #include "gis/IGisItem.h"
@@ -38,15 +36,13 @@ class ILineOp;
 class IMouseEditLine : public IMouse {
   Q_OBJECT
  public:
-  enum features_e { eFeatureSnapToLines = 0x01, eFeatureRouting = 0x02 };
-
   /**
      @brief Start to create a new track with given point as first track point
      @param point     the starting point
      @param gis       the draw context to use
      @param parent    the canvas to use
    */
-  IMouseEditLine(const IGisItem::key_t& key, const QPointF& point, bool enableStatus, const QString& type,
+  IMouseEditLine(const IGisItem::key_t& key, const QPointF& point, bool enableStatus, IWksItem::type_e type,
                  CGisDraw* gis, CCanvas* canvas, CMouseAdapter* mouse);
   /**
      @brief Edit an existing track
@@ -54,7 +50,7 @@ class IMouseEditLine : public IMouse {
      @param gis       the draw context to use
      @param parent    the canvas to use
    */
-  IMouseEditLine(const IGisItem::key_t& key, IGisLine& src, bool enableStatus, const QString& type, CGisDraw* gis,
+  IMouseEditLine(const IGisItem::key_t& key, IGisLine& src, bool enableStatus, IWksItem::type_e type, CGisDraw* gis,
                  CCanvas* canvas, CMouseAdapter* mouse);
   virtual ~IMouseEditLine();
 
@@ -124,10 +120,7 @@ class IMouseEditLine : public IMouse {
    */
   virtual IGisLine* getGisLine() const = 0;
 
-  virtual void startNewLine(const QPointF& point);
-
-  /// shadow cursor needed to restore cursor after some actions providing their own cursor.
-  QCursor cursor1;
+  virtual void startNewLine();
 
   /// the abstract line object to edit
   SGisLine points;
@@ -159,7 +152,7 @@ class IMouseEditLine : public IMouse {
 
   bool enableStatus;
 
-  QString type;
+  IWksItem::type_e type;
 
   CRouterOptimization optimizer;
 };


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1075

### What you have done:
[comment]: # (Describe roughly.)

* Disable "O", "V" and "T" for routes
* Do a code review of IMouseEditLine by AI, fixing all reasonable complains

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

* Add a track: all 4 tool buttons should be enabled and checkable
* Add a route: only "A" button should be checkable.


### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
