### PR TITLE
[QMS-1077] Fix: Restoring the workspace crashes if database projects …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-1069] Fix: Crash when aborting a route calculation
 [QMS-1071] Fix: Valid DEM file may not be loaded
 [QMS-1075] Disable "O", "V" and "T" buttons when drawing a route
+[QMS-1077] Fix: Restoring the workspace crashes if database projects are loaded but their database is missing
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -874,7 +874,6 @@ void CGisListWks::slotLoadWorkspace() {
         project->setVisibility(visible);
 
         project->IGisProject::operator<<(stream);
-        dbProject->restoreDBLink();
 
         if (!project->isValid()) {
           project->destroyLater();

--- a/src/qmapshack/gis/db/CDBProject.cpp
+++ b/src/qmapshack/gis/db/CDBProject.cpp
@@ -151,6 +151,11 @@ CDBProject::~CDBProject() {
   }
 }
 
+bool CDBProject::isPossibleToLoad() {
+  restoreDBLink();
+  return valid;
+}
+
 void CDBProject::restoreDBLink() {
   db = QSqlDatabase::database(filename);
 

--- a/src/qmapshack/gis/db/CDBProject.h
+++ b/src/qmapshack/gis/db/CDBProject.h
@@ -52,7 +52,25 @@ class CDBProject : public IGisProject {
      Typically this is done after the project has been restored in the workspace on application's startup.
 
    */
+  /**
+   * @brief Restore database link after the project has been restored from binary storage.
+   *
+   * Looks up the project's key in the database and, if found, sets the internal database
+   * handle, folder id, and marks the project as valid. Called automatically by
+   * isPossibleToLoad() during workspace restoration.
+   */
   void restoreDBLink();
+
+  /**
+   * @brief Check whether the backing database is available before starting the load thread.
+   *
+   * Calls restoreDBLink() to verify the database connection exists and the project folder
+   * can be found. Returns false (and leaves the project invalid) if the database is not
+   * registered — e.g. when QMapShack is started with a different configuration file via -c.
+   *
+   * @return true if the database link was restored successfully, false otherwise.
+   */
+  bool isPossibleToLoad() override;
 
   const bool canSave() const override { return true; }
 

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -428,6 +428,20 @@ class IGisProject : public IWksItem {
   using IWksItem::updateDecoration;
   void genKey() const;
   virtual void setupName(const QString& defaultName);
+  /**
+   * @brief Check whether it is possible to load items into the project.
+   *
+   * Called by IGisProject::operator<<() after all item data has been read from the stream,
+   * but before the background load thread is started. If this returns false the thread is
+   * not started and the project remains invalid, so the caller can safely discard it.
+   *
+   * The default implementation always returns true. Derived classes that depend on external
+   * resources (e.g. a database connection) should override this to verify that those
+   * resources are available before committing to a load.
+   *
+   * @return true if loading should proceed, false to skip the load thread entirely.
+   */
+  virtual bool isPossibleToLoad() { return true; }
   void markAsSaved();
   void readMetadata(const QDomNode& xml, metadata_t& metadata);
   void updateItems();

--- a/src/qmapshack/gis/qms/serialization.cpp
+++ b/src/qmapshack/gis/qms/serialization.cpp
@@ -888,6 +888,7 @@ QDataStream& IGisProject::operator<<(QDataStream& stream) {
     QString tmp;
     stream >> tmp;
   }
+
   stream >> metadata.name;
   stream >> metadata.desc;
   stream >> metadata.author;
@@ -896,6 +897,7 @@ QDataStream& IGisProject::operator<<(QDataStream& stream) {
   stream >> metadata.time;
   stream >> metadata.keywords;
   stream >> metadata.bounds;
+
   if (version > 1) {
     stream >> key;
   }
@@ -918,6 +920,11 @@ QDataStream& IGisProject::operator<<(QDataStream& stream) {
     qint32 tmp;
     stream >> tmp;
     sortingFolder = (sorting_folder_e)tmp;
+  }
+
+  if (!isPossibleToLoad()) {
+    qDebug() << "skip restoring" << metadata.name;
+    return stream;
   }
 
   QList<temp_item_data_t> items;


### PR DESCRIPTION
…are loaded but their database is missing

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1077

### What you have done:
[comment]: # (Describe roughly.)

Add a check into the serialization method checking if a project can be loaded. This is always true for all kind of projects. For database projects it checks the database link. If it fails loading the project is aborted.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
