### PR TITLE
[QMS-1079] Fix/dem poi hash backward compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,9 @@ V1.XX.X
 [QMS-1071] Fix: Valid DEM file may not be loaded
 [QMS-1075] Disable "O", "V" and "T" buttons when drawing a route
 [QMS-1077] Fix: Restoring the workspace crashes if database projects are loaded but their database is missing
+[QMS-1079] Fix: DEM/POI hash backward compatibility
 [QMS-1080] Add *.ts file for Croatian translation
+
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/dem/CDemDraw.cpp
+++ b/src/qmapshack/dem/CDemDraw.cpp
@@ -178,25 +178,42 @@ void CDemDraw::loadDemList(QSettings& cfg) {
     // We have a key but no dem found. Either the dem is missing or
     // the dem has a new hash due to changes -> create a new dem item to investigate
     if (dem == nullptr) {
-      cfg.beginGroup(key);
-      const QString& filename = cfg.value("filename", "").toString();
-      dem = createDemItem(filename, key);
-      cfg.endGroup();
+      // Hash algorithm may have changed (1024→4096 bytes): search by short key
+      for (auto it = demsFound.begin(); it != demsFound.end(); ++it) {
+        if (it.value()->getShortKey() == key) {
+          dem = demsFound.take(it.key());
+          break;
+        }
+      }
+
+      if (dem == nullptr) {
+        cfg.beginGroup(key);
+        const QString& filename = cfg.value("filename", "").toString();
+        cfg.endGroup();
+        dem = createDemItem(filename, key);
+      }
     }
 
-    // If the dem content changed the derived key will not match the one
-    // we expect. Delete this dem item, as it will have a reincarnation
-    // as new dem.
-    // If the dem path is not part of the dem paths list also delete
-    // the file as it is no longer part of the used dems.
+    // If neither the long nor short key matches, the content changed.
+    // If the dem path is not part of the dem paths list also delete it.
     QFileInfo fi(dem->getFilename());
-    if (key != dem->getKey() || !demPaths.contains(fi.absolutePath())) {
+    if ((key != dem->getKey() && key != dem->getShortKey()) || !demPaths.contains(fi.absolutePath())) {
       delete dem;
       continue;
     }
 
-    // finally load the config and add the item to the list
+    // If the stored key is the old short key, temporarily use it to read the config
+    // so settings are found; the item retains its new long key for future saves (migration).
+    const QString longKey = dem->getKey();
+    if (key != longKey) {
+      dem->overrideKey(key);
+    }
     dem->loadConfig(cfg, true);
+    if (key != longKey) {
+      dem->overrideKey(longKey);
+      // Safe to restore before the async activation timer fires: activate()
+      // reads only the shadow config (populated above), never the main QSettings.
+    }
 
     demList->addDem(dem);
   }

--- a/src/qmapshack/dem/CDemItem.cpp
+++ b/src/qmapshack/dem/CDemItem.cpp
@@ -51,12 +51,18 @@ void CDemItem::setFilename(const QString& name, const QString& fallbackKey) {
 
   QFile f(filename);
   if (f.exists() && f.open(QIODevice::ReadOnly)) {
-    QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(f.read(4096));
-    key = md5.result().toHex();
+    QByteArray header = f.read(4096);
     f.close();
+
+    QCryptographicHash md5(QCryptographicHash::Md5);
+    md5.addData(header.left(1024));
+    shortKey = md5.result().toHex();
+
+    md5.reset();
+    md5.addData(header);
+    key = md5.result().toHex();
   } else {
-    key = fallbackKey;
+    shortKey = key = fallbackKey;
   }
 }
 

--- a/src/qmapshack/dem/CDemItem.h
+++ b/src/qmapshack/dem/CDemItem.h
@@ -45,6 +45,8 @@ class CDemItem : public QObject, public IMapItem, public QTreeWidgetItem {
    * @param fallbackKey
    */
   void setFilename(const QString& name, const QString& fallbackKey);
+  void overrideKey(const QString& k) { key = k; }
+  const QString& getShortKey() const { return shortKey; }
   /**
    * @brief Save the map's configuration into the given QSettings object
    *
@@ -175,6 +177,10 @@ class CDemItem : public QObject, public IMapItem, public QTreeWidgetItem {
      @brief A MD5 hash over the first 4096 bytes of the dem file for identification
    */
   QString key;
+  /**
+     @brief A MD5 hash over the first 1024 bytes, kept for backward-compatibility config lookup
+   */
+  QString shortKey;
   /**
      @brief List of map files forming that particular map
    */

--- a/src/qmapshack/poi/CPoiDraw.cpp
+++ b/src/qmapshack/poi/CPoiDraw.cpp
@@ -18,6 +18,7 @@
 
 #include "poi/CPoiDraw.h"
 
+#include <QScopeGuard>
 #include <QtWidgets>
 
 #include "CMainWindow.h"
@@ -196,10 +197,16 @@ void CPoiDraw::buildPoiList() {
 
       QFile f(dir.absoluteFilePath(filename));
       openFileCheckSuccess(QIODevice::ReadOnly, f);
-      md5.reset();
-      md5.addData(f.read(4096));
-      item->key = md5.result().toHex();
+      QByteArray header = f.read(4096);
       f.close();
+
+      md5.reset();
+      md5.addData(header.left(1024));
+      item->shortKey = md5.result().toHex();
+
+      md5.reset();
+      md5.addData(header);
+      item->key = md5.result().toHex();
     }
   }
 
@@ -248,11 +255,16 @@ void CPoiDraw::restoreActivePoisList(const QStringList& keys) {
     for (int i = 0; i < poiList->count(); i++) {
       CPoiFileItem* item = poiList->item(i);
 
-      if (item && item->key == key) {
+      if (item && (item->key == key || item->shortKey == key)) {
         /**
             @Note   the item will load it's configuration upon successful activation
                     by calling loadConfigForPoiItem().
          */
+        // If matched by short key, temporarily use it so config is read from the correct
+        // settings group; the long key is restored afterwards for future saves (migration).
+        const QString longKey = item->key;
+        if (item->key != key) item->key = key;
+        const auto restoreKey = qScopeGuard([&]() { item->key = longKey; });
         item->activate();
         break;
       }
@@ -269,7 +281,12 @@ void CPoiDraw::restoreActivePoisList(const QStringList& keys, QSettings& cfg) {
     for (int i = 0; i < poiList->count(); i++) {
       CPoiFileItem* item = poiList->item(i);
 
-      if (item && item->key == key) {
+      if (item && (item->key == key || item->shortKey == key)) {
+        // If matched by short key, temporarily use it so config is read from the correct
+        // settings group; the long key is restored afterwards for future saves (migration).
+        const QString longKey = item->key;
+        if (item->key != key) item->key = key;
+        const auto restoreKey = qScopeGuard([&]() { item->key = longKey; });
         if (item->activate()) {
           item->loadConfig(cfg);
         }

--- a/src/qmapshack/poi/CPoiFileItem.h
+++ b/src/qmapshack/poi/CPoiFileItem.h
@@ -99,6 +99,10 @@ class CPoiFileItem : public QTreeWidgetItem {
    */
   QString key;
   /**
+     @brief A MD5 hash over the first 1024 bytes, kept for backward-compatibility config lookup
+   */
+  QString shortKey;
+  /**
      @brief List of map files forming that particular map
    */
   QString filename;


### PR DESCRIPTION
### What is the linked issue for this pull request:

QMS-#1079

### What you have done:

Commit 38cd1fc9 (QMS-1071) changed the MD5 hash used to identify DEM and POI files
from the first 1024 bytes to the first 4096 bytes. This broke backward compatibility:
settings written by any previous build store the old 1024-byte hash as the config key.
The new binary computes a different key, so all DEMs and POIs appear as "Unused" on
startup even though files and paths are correct.

Maps are not affected (their hash was already effectively 4096 bytes via `qMin(0x1000LL, f.size())`).

Fix: each item now computes both the short (1024-byte) and long (4096-byte) hash in a
single file read. When restoring from config, the stored key is compared against both.
If it matches the short key, it is used temporarily to read settings from the correct
config group, then the long key is restored immediately — so the next save automatically
migrates to the new key.

### Steps to perform a simple smoke test:

1. Configure and activate at least one DEM and one POI file with a previous build of QMapShack (pre QMS-1071), so their keys are stored in the config.
2. Replace the executable with this build.
3. Start QMapShack and open the DEM list and POI list.
4. Verify that previously active DEMs and POIs are restored correctly.
5. Restart QMapShack a second time and verify they are still active (migration to new key completed).

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes (no user-facing strings added)

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
