### PR TITLE
[QMS-1084] Fix: More delegate entries possibly hardly readable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@ V1.XX.X
 [QMS-1077] Fix: Restoring the workspace crashes if database projects are loaded but their database is missing
 [QMS-1079] Fix: DEM/POI hash backward compatibility
 [QMS-1080] Add *.ts file for Croatian translation
-
+[QMS-1084] Fix: More delegate entries possibly hardly readable
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/gis/CDBItemDelegate.cpp
+++ b/src/qmapshack/gis/CDBItemDelegate.cpp
@@ -232,15 +232,17 @@ void CDBItemDelegate::paintFolder(QPainter* p, const QStyleOptionViewItem& opt, 
     }
   }
 
-  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
-  QColor color = opt.palette.color(
-      colorGroup, opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+  const bool isSelected = (opt.state & QStyle::State_Selected) != 0;
+  const bool hasFocus = (opt.state & QStyle::State_HasFocus) != 0;
+
+  const QPalette::ColorRole colorRole = (isSelected && hasFocus) ? QPalette::HighlightedText : QPalette::WindowText;
+  QPalette::ColorGroup colorGroup = hasFocus ? QPalette::Active : QPalette::Inactive;
 
   if (item.type() > IDBItem::eTypeGroup) {
     fontName.setBold(item.getCheckState() != Qt::Unchecked);
-    color = opt.palette.color(item.getCheckState() != Qt::PartiallyChecked ? colorGroup : QPalette::Disabled,
-                              opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+    colorGroup = item.getCheckState() != Qt::PartiallyChecked ? colorGroup : QPalette::Disabled;
   }
+  const QColor& color = opt.palette.color(colorGroup, colorRole);
 
   p->setPen(color);
   p->setFont(fontName);
@@ -303,19 +305,20 @@ void CDBItemDelegate::paintItem(QPainter* p, const QStyleOptionViewItem& opt, co
     }
   }
 
-  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
-  QColor color = opt.palette.color(
-      colorGroup, opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+  const bool isSelected = (opt.state & QStyle::State_Selected) != 0;
+  const bool hasFocus = (opt.state & QStyle::State_HasFocus) != 0;
+
+  const QPalette::ColorRole colorRole = (isSelected && hasFocus) ? QPalette::HighlightedText : QPalette::WindowText;
+  QPalette::ColorGroup colorGroup = hasFocus ? QPalette::Active : QPalette::Inactive;
 
   IDBItem* parent = dynamic_cast<IDBItem*>(item.parent());
 
   if (parent && parent->type() == IDBItem::eTypeLostFound) {
-    color = opt.palette.color(parent->getCheckState() != Qt::Unchecked ? colorGroup : QPalette::Disabled,
-                              opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+    colorGroup = parent->getCheckState() != Qt::Unchecked ? colorGroup : QPalette::Disabled;
   } else {
-    color = opt.palette.color(item.getCheckState() != Qt::Unchecked ? colorGroup : QPalette::Disabled,
-                              opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+    colorGroup = item.getCheckState() != Qt::Unchecked ? colorGroup : QPalette::Disabled;
   }
+  const QColor& color = opt.palette.color(colorGroup, colorRole);
 
   p->setPen(color);
   p->setFont(fontName);

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -411,10 +411,13 @@ void CWksItemDelegate::paintProject(QPainter* p, const QStyleOptionViewItem& opt
 
   const bool isOnDevice = item.isOnDevice() != IWksItem::eTypeNone;
   const bool isVisible = item.isVisible();
-  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
-  const QColor& colorName =
-      opt.palette.color(isVisible ? colorGroup : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+  const bool isSelected = (opt.state & QStyle::State_Selected) != 0;
+  const bool hasFocus = (opt.state & QStyle::State_HasFocus) != 0;
+
+  // derive strings colors
+  const QPalette::ColorRole colorRole = (isSelected && hasFocus) ? QPalette::HighlightedText : QPalette::WindowText;
+  const QPalette::ColorGroup colorGroup = isVisible ? (hasFocus ? QPalette::Active : QPalette::Inactive) : QPalette::Disabled;
+  const QColor& colorName = opt.palette.color(colorGroup, colorRole);
 
   // draw icon
   const QPixmap& icon = item.getIcon().scaled(rectIcon.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);

--- a/src/qmapshack/map/CMapItemDelegate.cpp
+++ b/src/qmapshack/map/CMapItemDelegate.cpp
@@ -235,12 +235,13 @@ void CMapItemDelegate::paint(QPainter* p, const QStyleOptionViewItem& opt, const
   QStyledItemDelegate::paint(p, opt, index);
 
   const bool isActive = item->getStatus() == IMapItem::eStatus::Active;
+  const bool isSelected = (opt.state & QStyle::State_Selected) != 0;
+  const bool hasFocus = (opt.state & QStyle::State_HasFocus) != 0;
 
   // derive strings colors
-  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
-  QColor colorName =
-      opt.palette.color(isActive ? colorGroup : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+  const QPalette::ColorRole colorRole = (isSelected && hasFocus) ? QPalette::HighlightedText : QPalette::WindowText;
+  const QPalette::ColorGroup colorGroup = isActive ? (hasFocus ? QPalette::Active : QPalette::Inactive) : QPalette::Disabled;
+  const QColor& colorName = opt.palette.color(colorGroup, colorRole);
 
   QColor colorStatus = colorName;
   QString status;


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1084

### What you have done:
[comment]: # (Describe roughly.)

Fixed color role of **selected inactive/invisible** map/dem/workspace/database items when input focus has been lost.

Checked new behavior on platforms Ubuntu 24.04 Linux, openSUSE Leap 16 Linux, macOS Sonoma ->no negative impact.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS on platform Windows
2. Select an inactive map -> map item's background becomes blue, foreground becomes white: good readability
3. Click into map canvas -> input focus changes from item to map canvas
4. Map item has lost input focus -> map item's background becomes light gray, foreground becomes dark gray: **good readability**

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
