### PR TITLE
[QMS-1088] Fix: Mysterious debug output

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V1.XX.X
 [QMS-1079] Fix: DEM/POI hash backward compatibility
 [QMS-1080] Add *.ts file for Croatian translation
 [QMS-1084] Fix: More delegate entries possibly hardly readable
+[QMS-1088] Fix: Mysterious debug output
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -707,7 +707,7 @@ void CCanvas::leaveEvent(QEvent*) {
 }
 
 void CCanvas::keyPressEvent(QKeyEvent* e) {
-  qDebug() << Qt::hex << e->key();
+  //    qDebug() << Qt::hex << e->key();
   bool doUpdate = true;
 
   switch (e->key()) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1088

### What you have done:
[comment]: # (Describe roughly.)

Commented `qDebug() << Qt::hex << e->key();` statement.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS with debug switch
2. Click into map canvas
3. Press any keyboard key
4. See no more debug output lines of kind `2026-05-28 9:12:47.411 [debug] 1000012`

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
