### PR TITLE
[QMS-1090] Fix: More project items of delegate entries possibly hardly readable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-1080] Add *.ts file for Croatian translation
 [QMS-1084] Fix: More delegate entries possibly hardly readable
 [QMS-1088] Fix: Mysterious debug output
+[QMS-1090] Fix: More project items of delegate entries possibly hardly readable
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -548,10 +548,13 @@ void CWksItemDelegate::paintDevice(QPainter* p, const QStyleOptionViewItem& opt,
       getRectanglesDevice(opt, item);
 
   const bool isVisible = item.isVisible();
-  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
-  const QColor& colorName =
-      opt.palette.color(isVisible ? colorGroup : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+  const bool isSelected = (opt.state & QStyle::State_Selected) != 0;
+  const bool hasFocus = (opt.state & QStyle::State_HasFocus) != 0;
+
+  // derive strings colors
+  const QPalette::ColorRole colorRole = (isSelected && hasFocus) ? QPalette::HighlightedText : QPalette::WindowText;
+  const QPalette::ColorGroup colorGroup = isVisible ? (hasFocus ? QPalette::Active : QPalette::Inactive) : QPalette::Disabled;
+  const QColor& colorName = opt.palette.color(colorGroup, colorRole);
 
   // draw name
   fontName.setBold(item.hasUserFocus());
@@ -585,11 +588,14 @@ void CWksItemDelegate::paintItem(QPainter* p, const QStyleOptionViewItem& opt, c
   auto [fontName, fontStatus, rectIcon, rectName, rectStatus, rectChanged] = getRectanglesItem(opt, item);
 
   const bool isVisible = item.isVisible();
+  const bool isSelected = (opt.state & QStyle::State_Selected) != 0;
+  const bool hasFocus = (opt.state & QStyle::State_HasFocus) != 0;
   const QIcon::Mode iconMode = isVisible ? QIcon::Normal : QIcon::Disabled;
-  QPalette::ColorGroup colorGroup = (opt.state & QStyle::State_HasFocus) ? QPalette::Active : QPalette::Inactive;
-  const QColor& colorName =
-      opt.palette.color(isVisible ? colorGroup : QPalette::Disabled,
-                        opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::WindowText);
+
+  // derive strings colors
+  const QPalette::ColorRole colorRole = (isSelected && hasFocus) ? QPalette::HighlightedText : QPalette::WindowText;
+  const QPalette::ColorGroup colorGroup = isVisible ? (hasFocus ? QPalette::Active : QPalette::Inactive) : QPalette::Disabled;
+  const QColor& colorName = opt.palette.color(colorGroup, colorRole);
 
   // draw name
   fontName.setBold(item.hasUserFocus());


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1090

### What you have done:
[comment]: # (Describe roughly.)

Fixed color role of selected project items contained in an inactive/invisible workspace project when input focus has been lost.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS on platform Windows
2. Set a workspace project containing project items to invisible
3. Expand project
4. Select one of it's project items -> item's background becomes blue, foreground becomes white: good readability
5. Click into map canvas -> input focus changes from item to map canvas
6. Project item has lost input focus -> item's background becomes light gray, foreground becomes darker gray: **good readability**

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
