### PR TITLE
[QMS-1083] Fix: Leftover segment after breaking track generation by r…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-1077] Fix: Restoring the workspace crashes if database projects are loaded but their database is missing
 [QMS-1079] Fix: DEM/POI hash backward compatibility
 [QMS-1080] Add *.ts file for Croatian translation
+[QMS-1083] Fix: Leftover segment after breaking track generation by right-click
 [QMS-1084] Fix: More delegate entries possibly hardly readable
 [QMS-1088] Fix: Mysterious debug output
 [QMS-1090] Fix: More project items of delegate entries possibly hardly readable

--- a/src/qmapshack/mouse/line/ILineOp.cpp
+++ b/src/qmapshack/mouse/line/ILineOp.cpp
@@ -325,8 +325,9 @@ void ILineOp::tryRouting(qint32 idx) const {
 
   try {
     if (CRouterSetup::self().calcRoute(coord1, coord2, subs) >= 0) {
-      // Re-check bounds: points may have changed during calcRoute's event loop
-      if (idx >= points.size()) {
+      // Re-check bounds: if the user aborted during calcRoute's event loop,
+      // points[idx+1] may no longer exist — don't write stale subpoints.
+      if (idx + 1 >= points.size()) {
         return;
       }
       points[idx].subpts.clear();


### PR DESCRIPTION
…ight-click

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1083

### What you have done:
[comment]: # (Describe roughly.)

Check if the user aborted the routing right after the router returned from calculation. This is indicated by a missing end point (out of index)


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
