### PR TITLE
[QMS-1093] Fix: Auto-routed track segment endpoint jumps when next point is clicked before routing finishes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# QMapShack — Claude project notes
+
+QMapShack is a Qt/C++ desktop application for planning and analysing GPS tracks, routes, and waypoints. It loads map tiles, vector maps, and DEM data, and supports online and offline routing engines.
+
+---
+
+## Code style
+
+**All C++ is formatted with clang-format.** After editing any `.cpp` or `.h` file run:
+
+```bash
+clang-format -i <file> [<file> ...]
+```
+
+The style is defined in `.clang-format` in the project root (Google base, 120-column limit).
+
+**Every control-flow block requires braces**, even single-liner bodies:
+
+```cpp
+// correct
+if (condition) {
+  doSomething();
+}
+
+// wrong — never do this
+if (condition)
+  doSomething();
+```
+
+**Documentation comments use `/** */` doxygen blocks.** Follow the style of existing blocks (`@brief`, `@param`, `@return`). Inline member docs use `/**< */`. Plain `//` comments are for non-doxygen annotations.
+
+---
+
+## Building
+
+```bash
+cmake --build build --target qmapshack -j$(nproc)
+```
+
+The build directory is `build/` in the project root.
+
+---
+
+## Architecture: mouse/line editor
+
+The interactive line editor (for tracks, routes, and areas) lives in `src/qmapshack/mouse/line/`.
+
+### Class hierarchy
+
+```
+IMouseEditLine          – owns the point list (SGisLine), undo/redo history,
+│                          routing mode buttons, and the active ILineOp
+├── CMouseEditTrk       – edits a track (IGisItemTrk)
+├── CMouseEditRte       – edits a route (IGisItemRte)
+└── CMouseEditArea      – edits an area overlay (IGisItemOvl)
+
+ILineOp                 – base for one interactive editing operation
+├── CLineOpAddPoint     – insert new points / extend the line
+├── CLineOpMovePoint    – drag an existing point to a new position
+├── CLineOpDeletePoint  – remove a point
+└── CLineOpSelectRange  – select a range of points for bulk operations
+```
+
+`IMouseEditLine` delegates all mouse events to the active `ILineOp`. Switching the toolbar button deletes the current op and creates a new one.
+
+### Routing event-loop re-entrancy hazard
+
+**This is the most important invariant in the subsystem.**
+
+`CRouterSetup::calcRoute()` shows a `CProgressDialog` that runs a nested Qt event loop (`QEventLoop::exec()`). While that loop is spinning, the full Qt event pipeline is live — mouse moves, button clicks, and right-clicks all fire normally.
+
+Consequences for `ILineOp` subclasses:
+- `mouseMove()` fires during routing, drifting `points[idxFocus].coord` to the current cursor position.
+- A right-click calls `abortStep()` → `restoreFromHistory()`, which reallocates the `points` vector and invalidates any saved indices or pointers into it.
+- A further left-click can re-enter `leftClick()` while routing is already running.
+
+**The guard is `runRoutingAndPin(coord)`** (defined in `ILineOp`):
+1. Pins `points[idxFocus].coord = coord` before routing so the position is locked.
+2. Sets `isRouting = true` — subclasses check this at the top of `leftClick()` to block re-entrant clicks.
+3. Calls `slotTimeoutRouting()` (which calls `finalizeOperation()` → `tryRouting()`).
+4. After the event loop returns, checks `idxFocus` and `points.size()` for validity (abort during routing leaves both in an unknown state).
+5. Restores `points[idxFocus].coord = coord` to undo any drift from step 1.
+6. Returns `false` if the operation was aborted (caller must return immediately).
+
+Any future `ILineOp` subclass that triggers routing **must** use `runRoutingAndPin()` and check its return value.
+
+### CLineOpAddPoint state
+
+Two flags drive the three hover modes:
+
+| `isDragging` | `focusIsEndpoint` | Meaning |
+|---|---|---|
+| false | false | cursor near a mid-segment — click inserts a point there |
+| false | true  | cursor near the first or last point — click extends the line |
+| true  | either | a new point is attached to the cursor — click drops it |
+
+### Lead lines vs sub lines (vector/track routing)
+
+When vector or track routing is active, `updateLeadLines()` finds the underlying map/track polyline nearest to the active point and stores it in `leadLineCoord1/2` (geographic) and `leadLinePixel1/2` (screen). `GPS_Math_SubPolyline()` then finds which segment of that polyline lies between the two adjacent line points and stores the result in `subLineCoord1/2` / `subLinePixel1/2`. The sub-line is what actually becomes the routed sub-segment on drop.
+
+---
+
+## Architecture: routers
+
+`IRouter` is the abstract base. The two concrete routers are:
+
+- **`CRouterRoutino`** — offline routing using Routino databases.
+- **`CRouterBRouter`** — routing via BRouter, either as a local process (`CRouterBRouterLocal`) or via its online HTTP API.
+
+`CRouterSetup` is a singleton (`CRouterSetup::self()`) that owns the active router and exposes `calcRoute()` to the rest of the application. It emits `sigHasFastRouting(bool)` when the router capability changes (e.g. local BRouter starts or stops); `IMouseEditLine` listens to this to enable/disable the auto-routing button.
+
+Only local BRouter supports fast (on-the-fly) routing. Online BRouter and Routino do not — they require the full route to be calculated at once via `calcRoute(const IGisItem::key_t&)`.

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ V1.XX.X
 [QMS-1084] Fix: More delegate entries possibly hardly readable
 [QMS-1088] Fix: Mysterious debug output
 [QMS-1090] Fix: More project items of delegate entries possibly hardly readable
+[QMS-1093] Fix: Auto-routed track segment endpoint jumps when next point is clicked before routing finishes
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
@@ -33,25 +33,19 @@ CLineOpAddPoint::CLineOpAddPoint(SGisLine& points, CGisDraw* gis, CCanvas* canva
 CLineOpAddPoint::~CLineOpAddPoint() {}
 
 void CLineOpAddPoint::append() {
-  // this is called on construction when creating a complete new line
-  // A new point is appended to what ever line already exists,
-  // and add point mode is entered immediately.
   idxFocus = points.size();
   points.insert(idxFocus, IGisLine::point_t(points.last()));
-  addPoint = true;
-  isPoint = true;
-  // make sure that when starting the line-edit on-the-fly-routing will
-  // not trigger before the mouse has been moved a bit away from last point of line
+  isDragging = true;
+  focusIsEndpoint = true;
   startMouseMove(points.last().pixel);
 }
 
 bool CLineOpAddPoint::abortStep() {
-  if (addPoint) {
-    // cancel action and restore last state of line
+  if (isDragging) {
     cancelDelayedRouting();
     parentHandler->restoreFromHistory(points);
 
-    addPoint = false;
+    isDragging = false;
     idxFocus = NOIDX;
 
     canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
@@ -66,104 +60,65 @@ void CLineOpAddPoint::leftClick(const QPoint& pos) {
     return;
   }
 
-  if (addPoint) {
+  if (isDragging) {
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
 
-    // Pin the clicked position before routing: mouseMove during calcRoute's nested
-    // event loop drifts points[idxFocus].coord away from where the user clicked,
-    // causing the endpoint to jump when the route completes (issue #1093).
-    points[idxFocus].coord = coord;
-
-    isRouting = true;
-    slotTimeoutRouting();
-    isRouting = false;
-
-    // slotTimeoutRouting runs an event loop; the user may have aborted (right-click or undo)
-    // during it, which sets idxFocus = NOIDX. Bail out if that happened.
-    if (idxFocus == NOIDX || idxFocus >= points.size()) {
+    if (!runRoutingAndPin(coord)) {
       return;
     }
 
-    // Restore: mouseMove during the event loop may have drifted the coordinate.
-    points[idxFocus].coord = coord;
-
-    // if isPoint is true the line has been appended/prepended
-    // in this case go on with adding another point
-    if (isPoint) {
+    if (focusIsEndpoint) {
       if (idxFocus == (points.size() - 1)) {
         idxFocus++;
       }
-
-      // store current state of line to undo/redo history
       parentHandler->storeToHistory(points);
-
       points.insert(idxFocus, IGisLine::point_t(coord));
     } else {
-      // store current state of line to undo/redo history
       parentHandler->storeToHistory(points);
-      // terminate operation if the new point was inbetween a line segment.
-      addPoint = false;
+      isDragging = false;
       idxFocus = NOIDX;
     }
-  } else if (isPoint) {
-    // as isPoint is set, add a new point either at the start or end of the line
+  } else if (focusIsEndpoint) {
     if (idxFocus == (points.size() - 1)) {
       idxFocus++;
     }
-
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
     points.insert(idxFocus, IGisLine::point_t(coord));
-
-    addPoint = true;
+    isDragging = true;
   } else if (idxFocus != NOIDX) {
-    // clear current line segment
     points[idxFocus].subpts.clear();
-
-    // add a new point to line segment
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
-
     idxFocus++;
     points.insert(idxFocus, IGisLine::point_t(coord));
-
-    addPoint = true;
+    isDragging = true;
   }
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
 }
 
 void CLineOpAddPoint::mouseMove(const QPoint& pos) {
   ILineOp::mouseMove(pos);
-  if (addPoint) {
+  if (isDragging) {
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
 
     IGisLine::point_t& pt = points[idxFocus];
-    // update position of point
     pt.coord = coord;
-
-    // clear subpoints, as they have to be recalculated
-    // by the routing, if any
     pt.subpts.clear();
     if (idxFocus > 0) {
       points[idxFocus - 1].subpts.clear();
     }
 
-    // retrigger delayed routing
     startDelayedRouting();
   } else {
-    isPoint = false;
-    // find line segment close to cursor
+    focusIsEndpoint = false;
     idxFocus = isCloseToLine(pos);
-    // if none is found try to find point
     if (idxFocus == NOIDX) {
-      // if no line segment is found but a point
-      // it is either first or the last point in the line
       idxFocus = isCloseTo(pos);
-
       if ((idxFocus == 0) || (idxFocus == (points.size() - 1))) {
-        isPoint = true;
+        focusIsEndpoint = true;
       }
     }
   }
@@ -181,10 +136,10 @@ void CLineOpAddPoint::drawFg(QPainter& p) {
     return;
   }
 
-  if (addPoint) {
+  if (isDragging) {
     const IGisLine::point_t& pt = points[idxFocus];
     drawSinglePointSmall(pt.pixel, p);
-  } else if (isPoint) {
+  } else if (focusIsEndpoint) {
     const IGisLine::point_t& pt = points[idxFocus];
     drawSinglePointLarge(pt.pixel, p);
   } else if (idxFocus < (points.size() - 1)) {

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
@@ -80,6 +80,7 @@ void CLineOpAddPoint::leftClick(const QPoint& pos) {
       idxFocus = NOIDX;
     }
   } else if (focusIsEndpoint) {
+    /** idxFocus points at the last existing point; advance past it so the new point is appended. */
     if (idxFocus == (points.size() - 1)) {
       idxFocus++;
     }
@@ -91,6 +92,7 @@ void CLineOpAddPoint::leftClick(const QPoint& pos) {
     points[idxFocus].subpts.clear();
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
+    /** idxFocus is the segment start; advance to insert the new point after it, not before. */
     idxFocus++;
     points.insert(idxFocus, IGisLine::point_t(coord));
     isDragging = true;

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
@@ -62,20 +62,31 @@ bool CLineOpAddPoint::abortStep() {
 }
 
 void CLineOpAddPoint::leftClick(const QPoint& pos) {
-  if (idxFocus == NOIDX) {
+  if (idxFocus == NOIDX || isRouting) {
     return;
   }
 
   if (addPoint) {
-    // drop the new point at current position
-    // update subpoints of previous and this point
+    QPointF coord = pos;
+    gis->convertPx2Rad(coord);
+
+    // Pin the clicked position before routing: mouseMove during calcRoute's nested
+    // event loop drifts points[idxFocus].coord away from where the user clicked,
+    // causing the endpoint to jump when the route completes (issue #1093).
+    points[idxFocus].coord = coord;
+
+    isRouting = true;
     slotTimeoutRouting();
+    isRouting = false;
 
     // slotTimeoutRouting runs an event loop; the user may have aborted (right-click or undo)
     // during it, which sets idxFocus = NOIDX. Bail out if that happened.
-    if (idxFocus == NOIDX) {
+    if (idxFocus == NOIDX || idxFocus >= points.size()) {
       return;
     }
+
+    // Restore: mouseMove during the event loop may have drifted the coordinate.
+    points[idxFocus].coord = coord;
 
     // if isPoint is true the line has been appended/prepended
     // in this case go on with adding another point
@@ -87,8 +98,6 @@ void CLineOpAddPoint::leftClick(const QPoint& pos) {
       // store current state of line to undo/redo history
       parentHandler->storeToHistory(points);
 
-      QPointF coord = pos;
-      gis->convertPx2Rad(coord);
       points.insert(idxFocus, IGisLine::point_t(coord));
     } else {
       // store current state of line to undo/redo history

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.h
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.h
@@ -22,6 +22,14 @@
 
 #include "mouse/line/ILineOp.h"
 
+/**
+   @brief Line operation that adds new points to the line.
+
+   Three hover modes depending on what the cursor is nearest to:
+   - Hovering a mid-segment: left-click inserts a new point into that segment.
+   - Hovering the first or last point (focusIsEndpoint): left-click extends the line.
+   - Dragging (isDragging): a new point is attached to the cursor until the next left-click drops it.
+ */
 class CLineOpAddPoint : public ILineOp {
  public:
   CLineOpAddPoint(SGisLine& points, CGisDraw* gis, CCanvas* canvas, IMouseEditLine* parent);
@@ -33,13 +41,19 @@ class CLineOpAddPoint : public ILineOp {
 
   void drawFg(QPainter& p) override;
 
+  /**
+     @brief Enter dragging mode immediately, appending a new point at the end of the line.
+
+     Called when creating a brand-new line so that the first click in the editor already
+     has a point following the cursor.
+   */
   void append();
 
   bool abortStep() override;
 
  private:
-  bool isDragging = false;
-  bool focusIsEndpoint = false;
+  bool isDragging = false;      /**< true while a new point is attached to the cursor */
+  bool focusIsEndpoint = false; /**< true when the cursor is nearest to the first or last point */
 };
 
 #endif  // CLINEOPADDPOINT_H

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.h
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.h
@@ -38,8 +38,8 @@ class CLineOpAddPoint : public ILineOp {
   bool abortStep() override;
 
  private:
-  bool addPoint = false;
-  bool isPoint = false;
+  bool isDragging = false;
+  bool focusIsEndpoint = false;
 };
 
 #endif  // CLINEOPADDPOINT_H

--- a/src/qmapshack/mouse/line/CLineOpMovePoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpMovePoint.cpp
@@ -34,47 +34,32 @@ CLineOpMovePoint::CLineOpMovePoint(SGisLine& points, CGisDraw* gis, CCanvas* can
 CLineOpMovePoint::~CLineOpMovePoint() {}
 
 void CLineOpMovePoint::leftClick(const QPoint& pos) {
-  if (movePoint) {
+  if (isDragging) {
     if (isRouting) {
       return;
     }
 
-    // Pin the drop position before routing: mouseMove during calcRoute's nested
-    // event loop drifts points[idxFocus].coord, storing the wrong position.
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
-    points[idxFocus].coord = coord;
 
-    isRouting = true;
-    slotTimeoutRouting();
-    isRouting = false;
-
-    movePoint = false;
-
-    if (idxFocus == NOIDX || idxFocus >= points.size()) {
+    if (!runRoutingAndPin(coord)) {
       return;
     }
 
-    // Restore: mouseMove during the event loop may have drifted the coordinate.
-    points[idxFocus].coord = coord;
-
+    isDragging = false;
     parentHandler->storeToHistory(points);
   } else if (idxFocus != NOIDX) {
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
 
-    // start moving the point
     IGisLine::point_t& pt = points[idxFocus];
     pt.coord = coord;
-    // clear the subpoints from this point to the next
     pt.subpts.clear();
-
-    // clear the subpoints from the previous point to this point
     if (idxFocus != 0) {
       points[idxFocus - 1].subpts.clear();
     }
 
-    movePoint = true;
+    isDragging = true;
   }
 
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
@@ -86,12 +71,11 @@ void CLineOpMovePoint::rightButtonDown(const QPoint& pos) {
 }
 
 bool CLineOpMovePoint::abortStep() {
-  if (movePoint) {
-    // cancel action and restore last state of line
+  if (isDragging) {
     cancelDelayedRouting();
     parentHandler->restoreFromHistory(points);
 
-    movePoint = false;
+    isDragging = false;
     idxFocus = NOIDX;
 
     canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
@@ -104,26 +88,19 @@ bool CLineOpMovePoint::abortStep() {
 void CLineOpMovePoint::mouseMove(const QPoint& pos) {
   ILineOp::mouseMove(pos);
 
-  if (movePoint) {
+  if (isDragging) {
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
 
     IGisLine::point_t& pt = points[idxFocus];
-
-    // update position of point
     pt.coord = coord;
-
-    // clear subpoints, as they have to be recalculated
-    // by the routing, if any
     pt.subpts.clear();
     if (idxFocus > 0) {
       points[idxFocus - 1].subpts.clear();
     }
 
-    // retrigger delayed routing
     startDelayedRouting();
   } else {
-    // no point selected yet, find point to highlight
     idxFocus = isCloseTo(pos);
   }
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
@@ -135,7 +112,7 @@ void CLineOpMovePoint::drawFg(QPainter& p) {
   }
 
   const IGisLine::point_t& pt = points[idxFocus];
-  if (movePoint) {
+  if (isDragging) {
     drawSinglePointSmall(pt.pixel, p);
   } else {
     drawSinglePointLarge(pt.pixel, p);

--- a/src/qmapshack/mouse/line/CLineOpMovePoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpMovePoint.cpp
@@ -35,11 +35,29 @@ CLineOpMovePoint::~CLineOpMovePoint() {}
 
 void CLineOpMovePoint::leftClick(const QPoint& pos) {
   if (movePoint) {
-    // update subpoints by triggering the routing, if any.
+    if (isRouting) {
+      return;
+    }
+
+    // Pin the drop position before routing: mouseMove during calcRoute's nested
+    // event loop drifts points[idxFocus].coord, storing the wrong position.
+    QPointF coord = pos;
+    gis->convertPx2Rad(coord);
+    points[idxFocus].coord = coord;
+
+    isRouting = true;
     slotTimeoutRouting();
-    // terminate moving the point
+    isRouting = false;
+
     movePoint = false;
-    // store new state of line to undo/redo history
+
+    if (idxFocus == NOIDX || idxFocus >= points.size()) {
+      return;
+    }
+
+    // Restore: mouseMove during the event loop may have drifted the coordinate.
+    points[idxFocus].coord = coord;
+
     parentHandler->storeToHistory(points);
   } else if (idxFocus != NOIDX) {
     QPointF coord = pos;

--- a/src/qmapshack/mouse/line/CLineOpMovePoint.h
+++ b/src/qmapshack/mouse/line/CLineOpMovePoint.h
@@ -36,7 +36,7 @@ class CLineOpMovePoint : public ILineOp {
   bool abortStep() override;
 
  private:
-  bool movePoint = false;
+  bool isDragging = false;
 };
 
 #endif  // CLINEOPMOVEPOINT_H

--- a/src/qmapshack/mouse/line/CLineOpMovePoint.h
+++ b/src/qmapshack/mouse/line/CLineOpMovePoint.h
@@ -22,6 +22,13 @@
 
 #include "mouse/line/ILineOp.h"
 
+/**
+   @brief Line operation that moves an existing point to a new position.
+
+   A left-click near a point picks it up (isDragging = true); the point then follows the cursor
+   and routing fires on each mouse-move. A second left-click drops it at the new position.
+   Right-click or abortStep() cancels and restores the original position via the undo history.
+ */
 class CLineOpMovePoint : public ILineOp {
  public:
   CLineOpMovePoint(SGisLine& points, CGisDraw* gis, CCanvas* canvas, IMouseEditLine* parent);
@@ -36,7 +43,7 @@ class CLineOpMovePoint : public ILineOp {
   bool abortStep() override;
 
  private:
-  bool isDragging = false;
+  bool isDragging = false; /**< true while a point has been picked up and follows the cursor */
 };
 
 #endif  // CLINEOPMOVEPOINT_H

--- a/src/qmapshack/mouse/line/ILineOp.cpp
+++ b/src/qmapshack/mouse/line/ILineOp.cpp
@@ -29,40 +29,29 @@
 #include "mouse/line/IMouseEditLine.h"
 
 struct segment_t {
-  segment_t() : idx11(NOIDX), idx12(NOIDX), idx21(NOIDX) {}
+  qint32 seg1Start = NOIDX;  // first index of the polyline segment nearest to pt1
+  qint32 seg1End = NOIDX;    // second index of that segment (always seg1Start + 1)
+  qint32 seg2Start = NOIDX;  // first index of the polyline segment nearest to pt2
 
-  void apply(const QPolygonF& coords, const QPolygonF& pixel, QPolygonF& segCoord, QPolygonF& segPixel,
-             IDrawContext* context) {
-    QPointF pt1 = px1;
-    QPointF pt2 = px2;
-
-    context->convertPx2Rad(pt1);
-    context->convertPx2Rad(pt2);
-
-    if (idx11 != NOIDX && idx21 != NOIDX) {
-      if (idx12 == idx21) {
-        segPixel.push_back(pixel[idx12]);
-        segCoord.push_back(coords[idx12]);
-      } else if (idx11 < idx21) {
-        for (int i = idx12; i <= idx21; i++) {
-          segPixel.push_back(pixel[i]);
-          segCoord.push_back(coords[i]);
-        }
-      } else if (idx11 > idx21) {
-        for (int i = idx11; i > idx21; i--) {
-          segPixel.push_back(pixel[i]);
-          segCoord.push_back(coords[i]);
-        }
+  void apply(const QPolygonF& coords, const QPolygonF& pixel, QPolygonF& segCoord, QPolygonF& segPixel) const {
+    if (seg1Start == NOIDX || seg2Start == NOIDX) {
+      return;
+    }
+    if (seg1End == seg2Start) {
+      segPixel.push_back(pixel[seg1End]);
+      segCoord.push_back(coords[seg1End]);
+    } else if (seg1Start < seg2Start) {
+      for (int i = seg1End; i <= seg2Start; i++) {
+        segPixel.push_back(pixel[i]);
+        segCoord.push_back(coords[i]);
+      }
+    } else {
+      for (int i = seg1Start; i > seg2Start; i--) {
+        segPixel.push_back(pixel[i]);
+        segCoord.push_back(coords[i]);
       }
     }
   }
-
-  qint32 idx11;
-  qint32 idx12;
-  qint32 idx21;
-
-  QPointF px1;
-  QPointF px2;
 };
 
 static inline qreal distance(const QPointF& pa, const QPointF& pb) {
@@ -74,17 +63,13 @@ static inline qreal distance(const QPointF& pa, const QPointF& pb) {
 void GPS_Math_SubPolyline(const QPointF& pt1, const QPointF& pt2, qint32 threshold, const QPolygonF& pixel,
                           segment_t& result) {
   PJ_UV p1, p2;
-  qreal dx, dy;   // delta x and y defined by p1 and p2
-  qreal d_p1_p2;  // distance between p1 and p2
-  qreal x, y;     // coord. (x,y) of the point on line defined by [p1,p2] close to pt
+  qreal dx, dy;
+  qreal d_p1_p2;
+  qreal x, y;
   qreal shortest1 = threshold;
   qreal shortest2 = threshold;
-  qint32 idx11 = NOIDX, idx21 = NOIDX, idx12 = NOIDX;
+  qint32 seg1Start = NOIDX, seg1End = NOIDX, seg2Start = NOIDX;
 
-  QPointF pt11;
-  QPointF pt21;
-
-  // find points on line closest to pt1 and pt2
   const qint32 len = pixel.size();
   for (qint32 i = 1; i < len; ++i) {
     p1.u = pixel[i - 1].x();
@@ -96,88 +81,66 @@ void GPS_Math_SubPolyline(const QPointF& pt1, const QPointF& pt2, qint32 thresho
     dy = p2.v - p1.v;
     d_p1_p2 = qSqrt(dx * dx + dy * dy);
 
-    // find point on line closest to pt1
-    // ratio u the tangent point will divide d_p1_p2
     qreal u = ((pt1.x() - p1.u) * dx + (pt1.y() - p1.v) * dy) / (d_p1_p2 * d_p1_p2);
 
     if (u >= 0.0 && u <= 1.0) {
       x = p1.u + u * dx;
       y = p1.v + u * dy;
-
-      qreal distance = qSqrt((x - pt1.x()) * (x - pt1.x()) + (y - pt1.y()) * (y - pt1.y()));
-
-      if (distance < shortest1) {
-        idx11 = i - 1;
-        idx12 = i;
-        pt11.setX(x);
-        pt11.setY(y);
-        shortest1 = distance;
+      qreal dist = qSqrt((x - pt1.x()) * (x - pt1.x()) + (y - pt1.y()) * (y - pt1.y()));
+      if (dist < shortest1) {
+        seg1Start = i - 1;
+        seg1End = i;
+        shortest1 = dist;
       }
     }
 
-    // find point on line closest to pt2
-    // ratio u the tangent point will divide d_p1_p2
     u = ((pt2.x() - p1.u) * dx + (pt2.y() - p1.v) * dy) / (d_p1_p2 * d_p1_p2);
 
     if (u >= 0.0 && u <= 1.0) {
       x = p1.u + u * dx;
       y = p1.v + u * dy;
-
-      qreal distance = qSqrt((x - pt2.x()) * (x - pt2.x()) + (y - pt2.y()) * (y - pt2.y()));
-
-      if (distance < shortest2) {
-        idx21 = i - 1;
-        pt21.setX(x);
-        pt21.setY(y);
-        shortest2 = distance;
+      qreal dist = qSqrt((x - pt2.x()) * (x - pt2.x()) + (y - pt2.y()) * (y - pt2.y()));
+      if (dist < shortest2) {
+        seg2Start = i - 1;
+        shortest2 = dist;
       }
     }
   }
 
-  // if 1st point can't be found test for distance to both ends
-  if (idx11 == NOIDX) {
+  // fall back to nearest endpoint if no segment projection was found
+  if (seg1Start == NOIDX) {
     QPointF px = pixel.first();
     qreal dist = distance(px, pt1);
     if (dist < (threshold << 1)) {
-      idx11 = 0;
-      idx12 = 1;
-      pt11 = px;
+      seg1Start = 0;
+      seg1End = 1;
     } else {
       px = pixel.last();
-      qreal dist = distance(px, pt1);
+      dist = distance(px, pt1);
       if (dist < (threshold << 1)) {
-        idx11 = pixel.size() - 2;
-        idx12 = pixel.size() - 1;
-        pt11 = px;
+        seg1Start = pixel.size() - 2;
+        seg1End = pixel.size() - 1;
       }
     }
   }
 
-  // if 2nd point can't be found test for distance to both ends
-  if (idx21 == NOIDX) {
+  if (seg2Start == NOIDX) {
     QPointF px = pixel.first();
     qreal dist = distance(px, pt2);
-
     if (dist < (threshold << 1)) {
-      idx21 = 0;
-      pt21 = px;
+      seg2Start = 0;
     } else {
       px = pixel.last();
-      qreal dist = distance(px, pt2);
+      dist = distance(px, pt2);
       if (dist < (threshold << 1)) {
-        idx21 = pixel.size() - 2;
-        pt21 = px;
+        seg2Start = pixel.size() - 2;
       }
     }
   }
 
-  //    qDebug() << pixel.size() << idx11 << idx12 << idx21 << pt1 << pt2 << pt11 << pt21;
-
-  result.idx11 = idx11;
-  result.idx12 = idx12;
-  result.idx21 = idx21;
-  result.px1 = pt11;
-  result.px2 = pt21;
+  result.seg1Start = seg1Start;
+  result.seg1End = seg1End;
+  result.seg2Start = seg2Start;
 }
 
 ILineOp::ILineOp(SGisLine& points, CGisDraw* gis, CCanvas* canvas, IMouseEditLine* parent)
@@ -282,7 +245,7 @@ void ILineOp::updateLeadLines(qint32 idx) {
 
         segment_t result;
         GPS_Math_SubPolyline(pt1.pixel, pt2.pixel, 10, leadLinePixel1, result);
-        result.apply(leadLineCoord1, leadLinePixel1, subLineCoord1, subLinePixel1, gis);
+        result.apply(leadLineCoord1, leadLinePixel1, subLineCoord1, subLinePixel1);
       }
     }
 
@@ -300,7 +263,7 @@ void ILineOp::updateLeadLines(qint32 idx) {
 
         segment_t result;
         GPS_Math_SubPolyline(pt1.pixel, pt2.pixel, 10, leadLinePixel2, result);
-        result.apply(leadLineCoord2, leadLinePixel2, subLineCoord2, subLinePixel2, gis);
+        result.apply(leadLineCoord2, leadLinePixel2, subLineCoord2, subLinePixel2);
       }
     }
   }
@@ -382,6 +345,19 @@ void ILineOp::finalizeOperation(qint32 idx) {
   startMouseMove(points[idx].pixel);
 
   parentHandler->updateStatus();
+}
+
+bool ILineOp::runRoutingAndPin(const QPointF& coord) {
+  points[idxFocus].coord = coord;
+  isRouting = true;
+  slotTimeoutRouting();
+  isRouting = false;
+  if (idxFocus == NOIDX || idxFocus >= points.size()) {
+    return false;
+  }
+  // restore: mouseMove during the event loop may have drifted the coordinate
+  points[idxFocus].coord = coord;
+  return true;
 }
 
 qint32 ILineOp::isCloseTo(const QPoint& pos) const {

--- a/src/qmapshack/mouse/line/ILineOp.cpp
+++ b/src/qmapshack/mouse/line/ILineOp.cpp
@@ -28,11 +28,18 @@
 #include "gis/rte/router/CRouterSetup.h"
 #include "mouse/line/IMouseEditLine.h"
 
+/**
+   Identifies the two polyline segments (by index) whose perpendicular projections are closest
+   to two query points pt1 and pt2, as computed by GPS_Math_SubPolyline().
+ */
 struct segment_t {
-  qint32 seg1Start = NOIDX;  // first index of the polyline segment nearest to pt1
-  qint32 seg1End = NOIDX;    // second index of that segment (always seg1Start + 1)
-  qint32 seg2Start = NOIDX;  // first index of the polyline segment nearest to pt2
+  qint32 seg1Start = NOIDX; /**< first index of the polyline segment nearest to pt1 */
+  qint32 seg1End = NOIDX;   /**< second index of that segment (always seg1Start + 1) */
+  qint32 seg2Start = NOIDX; /**< first index of the polyline segment nearest to pt2 */
 
+  /**
+     @brief Extracts the polyline vertices that lie between the two nearest segments.
+   */
   void apply(const QPolygonF& coords, const QPolygonF& pixel, QPolygonF& segCoord, QPolygonF& segPixel) const {
     if (seg1Start == NOIDX || seg2Start == NOIDX) {
       return;
@@ -60,6 +67,20 @@ static inline qreal distance(const QPointF& pa, const QPointF& pb) {
   return qSqrt(dx * dx + dy * dy);
 }
 
+/**
+   @brief Find the sub-polyline in @p pixel that lies between two query points.
+
+   For each query point, finds the segment in @p pixel whose perpendicular projection is closest
+   (within @p threshold pixels). If no perpendicular projection lands within the threshold, falls
+   back to the nearest endpoint (within 2 * @p threshold). The resulting segment indices allow
+   segment_t::apply() to extract the vertices between the two query points.
+
+   @param pt1       first query point in pixel coordinates
+   @param pt2       second query point in pixel coordinates
+   @param threshold maximum pixel distance for a segment projection to be considered
+   @param pixel     the candidate polyline in pixel coordinates
+   @param result    filled with the segment indices nearest to pt1 and pt2
+ */
 void GPS_Math_SubPolyline(const QPointF& pt1, const QPointF& pt2, qint32 threshold, const QPolygonF& pixel,
                           segment_t& result) {
   PJ_UV p1, p2;
@@ -214,8 +235,9 @@ void ILineOp::leftButtonDown(const QPoint& pos) {
 void ILineOp::scaleChanged() { cancelDelayedRouting(); }
 
 void ILineOp::startMouseMove(const QPointF& point) {
-  //    // as long the mouse is not taken as moving
-  //    // to not trigger on-the-fly-routing
+  /** After finalizeOperation() we reposition the virtual mouse cursor onto the just-placed
+      point so that the next mouse move is measured from there, preventing an immediate
+      re-trigger of on-the-fly routing before the cursor has actually moved. */
   parentHandler->startMouseMove(point.toPoint());
   cancelDelayedRouting();
 }

--- a/src/qmapshack/mouse/line/ILineOp.h
+++ b/src/qmapshack/mouse/line/ILineOp.h
@@ -81,6 +81,7 @@ class ILineOp : public QObject {
   void updateLeadLines(qint32 idx);
 
   void startMouseMove(const QPointF& point);
+  bool runRoutingAndPin(const QPointF& coord);
 
   IMouseEditLine* parentHandler;
   SGisLine& points;

--- a/src/qmapshack/mouse/line/ILineOp.h
+++ b/src/qmapshack/mouse/line/ILineOp.h
@@ -34,6 +34,14 @@ class CCanvas;
 class QPainter;
 class IMouseEditLine;
 
+/**
+   @brief Base class for a single interactive line-editing operation (add, move, delete, select-range).
+
+   @warning CRouterSetup::calcRoute() opens a CProgressDialog that spins a nested Qt event loop.
+   Mouse events — including further left-clicks and right-clicks — therefore fire while routing is
+   in progress. Every subclass that calls runRoutingAndPin() must check isRouting on entry to
+   leftClick() and re-validate idxFocus and points.size() after the call returns.
+ */
 class ILineOp : public QObject {
   Q_OBJECT
  public:
@@ -70,7 +78,15 @@ class ILineOp : public QObject {
 
  protected:
   virtual void cancelDelayedRouting();
+
+  /**
+     @brief Start the routing debounce timer (auto-routing) or route immediately (vector/track).
+   */
   virtual void startDelayedRouting();
+
+  /**
+     @brief Commit routed sub-segments for the segment(s) adjacent to idx and refresh the display.
+   */
   virtual void finalizeOperation(qint32 idx);
   qint32 isCloseTo(const QPoint& pos) const;
   qint32 isCloseToLine(const QPoint& pos) const;
@@ -78,9 +94,22 @@ class ILineOp : public QObject {
   void drawSinglePointSmall(const QPointF& pt, QPainter& p);
   void drawSinglePointLarge(const QPointF& pt, QPainter& p);
   void drawLeadLine(const QPolygonF& line, QPainter& p) const;
+
+  /**
+     @brief Rebuild the lead-line and sub-line highlights for vector/track routing around idx.
+   */
   void updateLeadLines(qint32 idx);
 
   void startMouseMove(const QPointF& point);
+
+  /**
+     @brief Pin coord at points[idxFocus], run routing synchronously, then restore coord.
+
+     The restore is necessary because mouseMove() fires during the routing event loop and
+     drifts points[idxFocus].coord to the current cursor position.
+
+     @return false if the operation was aborted during routing (idxFocus or points invalidated).
+   */
   bool runRoutingAndPin(const QPointF& coord);
 
   IMouseEditLine* parentHandler;
@@ -90,7 +119,7 @@ class ILineOp : public QObject {
 
   QCursor cursor;
 
-  qint32 idxFocus = NOIDX;
+  qint32 idxFocus = NOIDX; /**< index into points[] of the currently active/hovered point */
 
   QPoint lastPos;
   QPoint firstPos;
@@ -101,17 +130,19 @@ class ILineOp : public QObject {
   const QBrush brushBgPoint{Qt::white};
   const QBrush brushFgPoint{Qt::red};
 
+  /**< Full underlying map/track polyline nearest to the active point (vector/track routing). */
   QPolygonF leadLineCoord1;
   QPolygonF leadLineCoord2;
   QPolygonF leadLinePixel1;
   QPolygonF leadLinePixel2;
 
+  /**< Portion of the lead line that maps to the routed sub-segment. */
   QPolygonF subLineCoord1;
   QPolygonF subLineCoord2;
   QPolygonF subLinePixel1;
   QPolygonF subLinePixel2;
 
-  bool isRouting = false;
+  bool isRouting = false; /**< Re-entrancy guard: true while runRoutingAndPin() runs its nested event loop. */
 
  private:
   void tryRouting(qint32 idx) const;

--- a/src/qmapshack/mouse/line/ILineOp.h
+++ b/src/qmapshack/mouse/line/ILineOp.h
@@ -110,6 +110,8 @@ class ILineOp : public QObject {
   QPolygonF subLinePixel1;
   QPolygonF subLinePixel2;
 
+  bool isRouting = false;
+
  private:
   void tryRouting(qint32 idx) const;
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1093

### What you have done:
[comment]: # (Describe roughly.)

Root cause: When the user left-clicks to fix point B while auto-routing is active, slotTimeoutRouting() calls calcRoute() which spins a nested Qt event loop (progress dialog). During that event loop, mouseMove events update points[idxFocus].coord to wherever the mouse drifts (toward C). When routing finishes, the coord has moved to B' — so storeToHistory saves the wrong position, causing the endpoint to jump.

  Three-part fix applied to both CLineOpAddPoint and CLineOpMovePoint:

  1. Pin before routing — set points[idxFocus].coord to the clicked position right before calling slotTimeoutRouting(), so the router uses the correct target even if mouseMove fires during the event loop
  2. Restore after routing — reset points[idxFocus].coord back to the clicked coordinate after slotTimeoutRouting() returns, undoing any drift
  3. Re-entrancy guard — check isRouting at the top of leftClick() to silently drop any click that arrives during the nested event loop (added to ILineOp as a shared protected member)


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
