### PR TITLE
[QMS-1095] Fix: Invalid track ascent/descent at track creation (issue 2)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ V1.XX.X
 [QMS-1088] Fix: Mysterious debug output
 [QMS-1090] Fix: More project items of delegate entries possibly hardly readable
 [QMS-1093] Fix: Auto-routed track segment endpoint jumps when next point is clicked before routing finishes
+[QMS-1095] Fix: Invalid track ascent/descent at track creation
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -502,18 +502,22 @@ void CWksItemDelegate::paintProject(QPainter* p, const QStyleOptionViewItem& opt
       status += QString("%1%2%3 ").arg(QChar(0x21A6)).arg(val, unit);
     }
 
-    qreal ascent = project->getTotalAscent();
-    if (ascent < NOFLOAT && !qFuzzyIsNull(ascent) && itemStatusControl.prj.ascent) {
-      QString unit, val;
-      IUnit::self().meter2elevation(ascent, val, unit);
-      status += QString("%1%2%3 ").arg(QChar(0x2197)).arg(val, unit);
-    }
+    if (!project->isTrkElevationInvalid()) {
 
-    qreal descent = project->getTotalDescent();
-    if (descent < NOFLOAT && !qFuzzyIsNull(descent) && itemStatusControl.prj.descent) {
-      QString unit, val;
-      IUnit::self().meter2elevation(descent, val, unit);
-      status += QString("%1%2%3 ").arg(QChar(0x2198)).arg(val, unit);
+      qreal ascent = project->getTotalAscent();
+      if (ascent < NOFLOAT && !qFuzzyIsNull(ascent) && itemStatusControl.prj.ascent) {
+        QString unit, val;
+        IUnit::self().meter2elevation(ascent, val, unit);
+        status += QString("%1%2%3 ").arg(QChar(0x2197)).arg(val, unit);
+      }
+
+      qreal descent = project->getTotalDescent();
+      if (descent < NOFLOAT && !qFuzzyIsNull(descent) && itemStatusControl.prj.descent) {
+        QString unit, val;
+        IUnit::self().meter2elevation(descent, val, unit);
+        status += QString("%1%2%3 ").arg(QChar(0x2198)).arg(val, unit);
+      }
+
     }
 
     if (itemStatusControl.prj.gisStats) {
@@ -626,19 +630,24 @@ void CWksItemDelegate::paintItem(QPainter* p, const QStyleOptionViewItem& opt, c
         status += QString("%1%2%3 ").arg(QChar(0x21A6)).arg(val, unit);
       }
 
-      qreal ascent = trk->getTotalAscent();
-      if (ascent != NOFLOAT && !qFuzzyIsNull(ascent) && itemStatusControl.trk.ascent) {
-        QString unit, val;
-        IUnit::self().meter2elevation(ascent, val, unit);
-        status += QString("%1%2%3 ").arg(QChar(0x2197)).arg(val, unit);
+      if (!trk->isTrkElevationInvalid()) {
+
+        qreal ascent = trk->getTotalAscent();
+        if (ascent != NOFLOAT && !qFuzzyIsNull(ascent) && itemStatusControl.trk.ascent) {
+          QString unit, val;
+          IUnit::self().meter2elevation(ascent, val, unit);
+          status += QString("%1%2%3 ").arg(QChar(0x2197)).arg(val, unit);
+        }
+
+        qreal descent = trk->getTotalDescent();
+        if (descent != NOFLOAT && !qFuzzyIsNull(descent) && itemStatusControl.trk.descent) {
+          QString unit, val;
+          IUnit::self().meter2elevation(descent, val, unit);
+          status += QString("%1%2%3 ").arg(QChar(0x2198)).arg(val, unit);
+        }
+
       }
 
-      qreal descent = trk->getTotalDescent();
-      if (descent != NOFLOAT && !qFuzzyIsNull(descent) && itemStatusControl.trk.descent) {
-        QString unit, val;
-        IUnit::self().meter2elevation(descent, val, unit);
-        status += QString("%1%2%3 ").arg(QChar(0x2198)).arg(val, unit);
-      }
     }
 
     const CGisItemWpt* wpt = dynamic_cast<const CGisItemWpt*>(&item);

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -826,6 +826,7 @@ void IGisProject::updateItemCounters() {
   totalDescent = 0;
   totalElapsedSeconds = 0;
   totalElapsedSecondsMoving = 0;
+  trkElevationInvalid = false;
 
   QByteArray buffer;
   QDataStream stream(&buffer, QIODevice::WriteOnly);
@@ -846,6 +847,7 @@ void IGisProject::updateItemCounters() {
       totalDistance += trk->getTotalDistance();
       totalAscent += trk->getTotalAscent();
       totalDescent += trk->getTotalDescent();
+      trkElevationInvalid |= trk->isTrkElevationInvalid();
       totalElapsedSeconds += trk->getTotalElapsedSeconds();
       totalElapsedSecondsMoving += trk->getTotalElapsedSecondsMoving();
       stream << trk->getHash();

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -264,6 +264,7 @@ class IGisProject : public IWksItem {
   qreal getTotalDistance() const { return totalDistance; }
   qreal getTotalAscent() const { return totalAscent; }
   qreal getTotalDescent() const { return totalDescent; }
+  bool isTrkElevationInvalid() const { return trkElevationInvalid; }
   qreal getTotalElapsedSeconds() const { return totalElapsedSeconds; }
   qreal getTotalElapsedSecondsMoving() const { return totalElapsedSecondsMoving; }
 
@@ -503,6 +504,7 @@ class IGisProject : public IWksItem {
   qreal totalDistance = 0;
   qreal totalAscent = 0;
   qreal totalDescent = 0;
+  bool trkElevationInvalid = false;
   quint32 totalElapsedSeconds = 0;
   quint32 totalElapsedSecondsMoving = 0;
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1095

### What you have done:
[comment]: # (Describe roughly.)

Do no longer show huge and invalid ascent/descent values in workspace project and project's track (issue 2 of https://github.com/Maproom/qmapshack/issues/1095).
Do not show any ascent/descent values instead of invalid ones.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Create a track where only parts of track are covered by elevation (DEM) data
2. Save track in project
3. Do not see huge and invalid ascent/descent values in project
4. Do not see huge and invalid ascent/descent values in project's track item

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
