### PR TITLE
[QMS-1097] Fix: Incomplete routing when editing a track points on a f…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ V1.XX.X
 [QMS-1090] Fix: More project items of delegate entries possibly hardly readable
 [QMS-1093] Fix: Auto-routed track segment endpoint jumps when next point is clicked before routing finishes
 [QMS-1095] Fix: Invalid track ascent/descent at track creation
+[QMS-1097] Fix: Incomplete routing when editing track points on a faster mouse movement speed
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpAddPoint.cpp
@@ -103,6 +103,9 @@ void CLineOpAddPoint::leftClick(const QPoint& pos) {
 void CLineOpAddPoint::mouseMove(const QPoint& pos) {
   ILineOp::mouseMove(pos);
   if (isDragging) {
+    if (isRouting) {
+      return;
+    }
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
 

--- a/src/qmapshack/mouse/line/CLineOpMovePoint.cpp
+++ b/src/qmapshack/mouse/line/CLineOpMovePoint.cpp
@@ -89,6 +89,9 @@ void CLineOpMovePoint::mouseMove(const QPoint& pos) {
   ILineOp::mouseMove(pos);
 
   if (isDragging) {
+    if (isRouting) {
+      return;
+    }
     QPointF coord = pos;
     gis->convertPx2Rad(coord);
 

--- a/src/qmapshack/mouse/line/ILineOp.cpp
+++ b/src/qmapshack/mouse/line/ILineOp.cpp
@@ -186,7 +186,9 @@ void ILineOp::startDelayedRouting() {
 
 void ILineOp::slotTimeoutRouting() {
   cancelDelayedRouting();
+  isRouting = true;
   finalizeOperation(idxFocus);
+  isRouting = false;
   canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawMouse);
 }
 
@@ -310,9 +312,9 @@ void ILineOp::tryRouting(qint32 idx) const {
 
   try {
     if (CRouterSetup::self().calcRoute(coord1, coord2, subs) >= 0) {
-      // Re-check bounds: if the user aborted during calcRoute's event loop,
-      // points[idx+1] may no longer exist — don't write stale subpoints.
-      if (idx + 1 >= points.size()) {
+      // Re-check after calcRoute's event loop: abort (right-click) may have
+      // called restoreFromHistory(), shrinking points or changing what idx refers to.
+      if (idx + 1 >= points.size() || idxFocus == NOIDX) {
         return;
       }
       points[idx].subpts.clear();
@@ -337,6 +339,9 @@ void ILineOp::finalizeOperation(qint32 idx) {
     CCanvasCursorLock cursorLock(Qt::WaitCursor, __func__);
     if (idx > 0 && idx < points.size()) {
       tryRouting(idx - 1);
+    }
+    if (idxFocus == NOIDX) {
+      return;
     }
     if (idx < (points.size() - 1)) {
       tryRouting(idx);
@@ -371,15 +376,8 @@ void ILineOp::finalizeOperation(qint32 idx) {
 
 bool ILineOp::runRoutingAndPin(const QPointF& coord) {
   points[idxFocus].coord = coord;
-  isRouting = true;
   slotTimeoutRouting();
-  isRouting = false;
-  if (idxFocus == NOIDX || idxFocus >= points.size()) {
-    return false;
-  }
-  // restore: mouseMove during the event loop may have drifted the coordinate
-  points[idxFocus].coord = coord;
-  return true;
+  return idxFocus != NOIDX && idxFocus < points.size();
 }
 
 qint32 ILineOp::isCloseTo(const QPoint& pos) const {


### PR DESCRIPTION
…aster mouse movement speed

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1097

### What you have done:
[comment]: # (Describe roughly.)

Root cause: finalizeOperation calls tryRouting(idx-1) first. That call runs calcRoute, which shows a progress dialog that spins a nested Qt event loop. During that event loop, mouseMove fires (fast mouse) and overwrites  points[idx].coord with the current cursor position. When tryRouting(idx) is then called, it snapshots the now-drifted coord as its start point —routing from the wrong location, producing a straight line or wrong path.

Fix: Snapshot points[idx].coord before entering the first event loop, then restore it before the second tryRouting call. The three-line addition is minimal and doesn't affect the abort path (if the user right-clicks during the first routing, points is reallocated and the size check on idx < points.size() prevents an out-of-bounds write before the restore, and the second tryRouting is skipped by the idx < points.size() - 1 guard).

The fix applies equally to both CLineOpAddPoint and CLineOpMovePoint since they both go through finalizeOperation.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
