### PR TITLE
[QMS-1101] Fix: F1 help browser does not open doc internal links

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ V1.XX.X
 [QMS-1093] Fix: Auto-routed track segment endpoint jumps when next point is clicked before routing finishes
 [QMS-1095] Fix: Invalid track ascent/descent at track creation
 [QMS-1097] Fix: Incomplete routing when editing track points on a faster mouse movement speed
+[QMS-1101] Fix: F1 help browser does not open doc internal links
 
 V1.20.2
 [QMS-670] Fix: Accessibility issue : font is too small

--- a/src/common/help/CHelpBrowser.cpp
+++ b/src/common/help/CHelpBrowser.cpp
@@ -26,15 +26,17 @@ CHelpBrowser::CHelpBrowser(QHelpEngine* helpEngine, QWidget* parent) : QTextBrow
           [this](const QHelpLink& document, const QString& keyword) { setSource(document.url); });
   connect(engine->searchEngine()->resultWidget(), &QHelpSearchResultWidget::requestShowLink, this,
           &CHelpBrowser::setSource);
+
+  QTextBrowser::setOpenLinks(false);
+  connect(this, &QTextBrowser::anchorClicked, this, &CHelpBrowser::setSource);
 }
 
 void CHelpBrowser::setSource(const QUrl& url) {
   if (url.scheme().startsWith("http")) {
     QDesktopServices::openUrl(url);
-    return;
+  } else {
+    QTextBrowser::setSource(url);
   }
-  QTextBrowser::setSource(url);
-  QTextBrowser::setOpenExternalLinks(true);
 }
 
 QVariant CHelpBrowser::loadResource(int type, const QUrl& name) {
@@ -43,4 +45,26 @@ QVariant CHelpBrowser::loadResource(int type, const QUrl& name) {
   } else {
     return QTextBrowser::loadResource(type, name);
   }
+}
+
+void CHelpBrowser::contextMenuEvent(QContextMenuEvent* event) {
+  QMenu* menu = createStandardContextMenu();
+
+  menu->addSeparator();
+  if (isBackwardAvailable()) {
+    menu->addAction(QIcon(":/icons/32x32/Left.png"), tr("Go back one page"),
+        Qt::CTRL | Qt::Key_Left, this, &CHelpBrowser::backward);
+  }
+  if (isForwardAvailable()) {
+    menu->addAction(QIcon(":/icons/32x32/Right.png"), tr("Go forward one page"),
+        Qt::CTRL | Qt::Key_Right, this, &CHelpBrowser::forward);
+  }
+  if (isBackwardAvailable()) {
+    menu->addAction(QIcon(":/icons/32x32/ToTop.png"), tr("Go to initial page"),
+        Qt::CTRL | Qt::Key_Up, this, &CHelpBrowser::home);
+  }
+
+  menu->exec(event->globalPos());
+
+  delete menu;
 }

--- a/src/common/help/CHelpBrowser.h
+++ b/src/common/help/CHelpBrowser.h
@@ -30,6 +30,7 @@ class CHelpBrowser : public QTextBrowser {
   virtual ~CHelpBrowser() = default;
 
   QVariant loadResource(int type, const QUrl& name) override;
+  void contextMenuEvent(QContextMenuEvent* event) override;
 
  public slots:
   void setSource(const QUrl& url);

--- a/src/qmapshack/locale/qmapshack.ts
+++ b/src/qmapshack/locale/qmapshack.ts
@@ -3395,6 +3395,24 @@ line %2, column %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8602,74 +8620,74 @@ line %2, column %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14033,7 +14051,7 @@ Filename: %1</source>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_ca.ts
+++ b/src/qmapshack/locale/qmapshack_ca.ts
@@ -3424,6 +3424,24 @@ línia %2, columna %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8667,74 +8685,74 @@ línia %2, columna %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14140,7 +14158,7 @@ Nom del fitxer: %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation>Enrutament</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_cs.ts
+++ b/src/qmapshack/locale/qmapshack_cs.ts
@@ -3401,6 +3401,24 @@ line %2, column %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8631,74 +8649,74 @@ line %2, column %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14071,7 +14089,7 @@ Název souboru: %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation>Cesta</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_de.ts
+++ b/src/qmapshack/locale/qmapshack_de.ts
@@ -3439,6 +3439,24 @@ Zeile %2, Spalte %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation>Gehe eine Seite zurück</translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation>Gehe eine Seite vor</translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation>Gehe zur Startseite</translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8680,74 +8698,74 @@ Zeile %2, Spalte %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation>Adresse eingeben...</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation>Projekt auf der Karte ausblenden.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation>Projekt auf der Karte anzeigen.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation>Projekt speichern.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation>Autoatisches. Speichern ausschalten.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation>Autoatisches. Speichern anschalten.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation>Kopiert den Inhalt des Projektes in ein Projekt auf dem Arbeitsplatz.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation>Automatische Synchronization mit dem GPS Gerät ausschalten.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation>Automatische Synchronization mit dem GPS Gerät anschalten.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation>Das ist das aktive Projekt. Alle neuen Elemente werden automatisch diesem Projekt zugeordnet.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation>Diese Projekt zum Aktiven machen. Alle neuen Elemente werden automatisch diesem Projekt zugeordnet.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation>Dies ist die Statuszeile. Sie können zusätzliche Informationen, die angezeigt werden sollen, in den Arbeitsplatzeinstellungen auswählen. Siehe Menü-&gt;Arbeitsplatz-&gt;Arbeitsplatz einrichten</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation>Das Element wurde geändert und muss gespeichert werden.</translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation>Suche einstellen</translation>
     </message>
@@ -14157,7 +14175,7 @@ Dateiname: %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation></translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_es.ts
+++ b/src/qmapshack/locale/qmapshack_es.ts
@@ -3428,6 +3428,24 @@ línea %2, columna %3.
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8706,74 +8724,74 @@ línea %2, columna %3.
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14172,7 +14190,7 @@ Nombre de archivo %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation>Enrutamiento</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_fr.ts
+++ b/src/qmapshack/locale/qmapshack_fr.ts
@@ -3421,6 +3421,24 @@ ligne %2, colonne %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8650,74 +8668,74 @@ ligne %2, colonne %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14103,7 +14121,7 @@ Nom de fichier: %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation>Routage</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_hr.ts
+++ b/src/qmapshack/locale/qmapshack_hr.ts
@@ -3425,6 +3425,24 @@ line %2, column %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8668,74 +8686,74 @@ red %2, kolona %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished">Postavi Pretraživanje</translation>
     </message>
@@ -14117,7 +14135,7 @@ Naziv datoteke: %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation>Rutiranje</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_it.ts
+++ b/src/qmapshack/locale/qmapshack_it.ts
@@ -3427,6 +3427,24 @@ linea %2, colonna %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8663,74 +8681,74 @@ linea %2, colonna %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14136,7 +14154,7 @@ Nome file: %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation>Routing</translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_nl.ts
+++ b/src/qmapshack/locale/qmapshack_nl.ts
@@ -3401,6 +3401,24 @@ lijn %2, kolom %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8634,74 +8652,74 @@ lijn %2, kolom %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14071,7 +14089,7 @@ Bestandsnaam: %1</translation>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qmapshack/locale/qmapshack_ru.ts
+++ b/src/qmapshack/locale/qmapshack_ru.ts
@@ -3431,6 +3431,24 @@ line %2, column %3:
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -8677,74 +8695,74 @@ line %2, column %3:
 <context>
     <name>CWksItemDelegate</name>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="741"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1031"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="750"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1040"/>
         <source>Enter address...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="914"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="923"/>
         <source>Hide project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="916"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
         <source>Show project on map.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="922"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
         <source>Save project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="925"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="934"/>
         <source>Disable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="927"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="936"/>
         <source>Enable auto save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="931"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
         <source>Copy content of project into a project in the workspace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="937"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="946"/>
         <source>Disable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="940"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="949"/>
         <source>Enable automatic synchonization with GPS device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="947"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="956"/>
         <source>This is the active project. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="953"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="962"/>
         <source>Make this project the active one. All new items will be attached to this project automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="965"/>
-        <location filename="../gis/CWksItemDelegate.cpp" line="988"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="974"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
         <source>This is the status line. You can select additional information to be displayed in the workspace setup. See menu-&gt;Workspace-&gt;Setup Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="997"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1006"/>
         <source>Item is changed and needs to be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gis/CWksItemDelegate.cpp" line="1009"/>
+        <location filename="../gis/CWksItemDelegate.cpp" line="1018"/>
         <source>Setup Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14160,7 +14178,7 @@ Filename: %1</source>
 <context>
     <name>ILineOp</name>
     <message>
-        <location filename="../mouse/line/ILineOp.cpp" line="299"/>
+        <location filename="../mouse/line/ILineOp.cpp" line="301"/>
         <source>Routing</source>
         <translation>Маршрутизация</translation>
     </message>

--- a/src/qmaptool/locale/qmaptool.ts
+++ b/src/qmaptool/locale/qmaptool.ts
@@ -299,6 +299,24 @@
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -658,13 +676,11 @@ Canceled by user&apos;s request.
     <name>IAbout</name>
     <message>
         <location filename="../IAbout.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="162"/>
         <source>About...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="26"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="163"/>
         <source>&lt;b&gt;QMapTool&lt;/b&gt;, Version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,40 +689,31 @@ Canceled by user&apos;s request.
         <location filename="../IAbout.ui" line="77"/>
         <location filename="../IAbout.ui" line="91"/>
         <location filename="../IAbout.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="171"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="70"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="166"/>
         <source>Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="168"/>
         <source>GDAL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="98"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="170"/>
         <source>PROJ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="121"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="172"/>
         <source>This software is licensed under GPL3 or any later version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="128"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="173"/>
         <source>© 2017 Oliver Eichler (oliver.eichler@gmx.de)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -715,31 +722,26 @@ Canceled by user&apos;s request.
     <name>ICoordFormatSetup</name>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="103"/>
         <source>Coordinate Format...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="104"/>
         <source>N48° 53&apos; 39.6&quot; E13° 31&apos; 6.78&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="105"/>
         <source>N48.8943° E013.51855°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="106"/>
         <source>N48° 53.660 E013° 31.113</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -748,37 +750,31 @@ Canceled by user&apos;s request.
     <name>IDialogRefPoint</name>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="115"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="25"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="116"/>
         <source>Coord. Map File [pixel]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="117"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="118"/>
         <source>y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="49"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="119"/>
         <source>Coord. lat/lon WGS84 [°]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="120"/>
         <source>Bad position format. Must be: 
 &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot;
 or
@@ -790,19 +786,16 @@ or
     <name>IGridPlacer</name>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="190"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="198"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="224"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="204"/>
         <source>Set Area</source>
         <translation type="unfinished"></translation>
     </message>
@@ -811,13 +804,11 @@ or
     <name>IGridSelArea</name>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="50"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="51"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,49 +817,41 @@ or
     <name>IGridSetRef</name>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="135"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="136"/>
         <source>Grid Projection:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="137"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="60"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="138"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="139"/>
         <source>Easting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="140"/>
         <source>Horiz. Spacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="141"/>
         <source>Northing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="102"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="142"/>
         <source>Vert. Spacing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -877,13 +860,11 @@ or
     <name>IItemListWidget</name>
     <message>
         <location filename="../items/IItemListWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="103"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="105"/>
         <source>Add map files to list</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,28 +873,21 @@ or
         <location filename="../items/IItemListWidget.ui" line="60"/>
         <location filename="../items/IItemListWidget.ui" line="77"/>
         <location filename="../items/IItemListWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="107"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="111"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="115"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="119"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="109"/>
         <source>Remove selected file from the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="113"/>
         <source>Clear complete list of map files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="117"/>
         <source>Reload the currently selected map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -922,13 +896,11 @@ or
     <name>IItemTreeWidget</name>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="108"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="110"/>
         <source>Add map files to list</source>
         <translation type="unfinished"></translation>
     </message>
@@ -937,28 +909,21 @@ or
         <location filename="../items/IItemTreeWidget.ui" line="60"/>
         <location filename="../items/IItemTreeWidget.ui" line="77"/>
         <location filename="../items/IItemTreeWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="116"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="124"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="114"/>
         <source>Remove selected file from the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="118"/>
         <source>Clear complete list of map files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="122"/>
         <source>Reload the currently selected map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -967,107 +932,88 @@ or
     <name>IMainWindow</name>
     <message>
         <location filename="../IMainWindow.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="166"/>
         <source>MainWindow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="189"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="41"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="190"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="191"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="52"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="192"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="68"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="193"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="194"/>
         <source>Shell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="167"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="129"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="168"/>
         <source>Ext. Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="170"/>
         <source>Setup paths to external tools, like gdalwarp etc.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="144"/>
         <location filename="../IMainWindow.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="174"/>
         <source>Flip Mouse Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="156"/>
         <location filename="../IMainWindow.ui" line="159"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="178"/>
         <source>Setup Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="168"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="180"/>
         <source>Setup Coord. Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="171"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="182"/>
         <source>Change the format coordinates are displayed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="182"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="184"/>
         <source>Show Tool Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="185"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="194"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="187"/>
         <source>F1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1076,19 +1022,16 @@ or
     <name>IOverlayCutMap</name>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="142"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="144"/>
         <source>Just move the map and zoom.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="58"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="148"/>
         <source>Add point to mask.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1099,42 +1042,31 @@ or
         <location filename="../overlay/IOverlayCutMap.ui" line="137"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="158"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="170"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="152"/>
         <source>Move point of mask.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="156"/>
         <source>Remove point from mask.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="160"/>
         <source>Remove complete cut mask.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="164"/>
         <source>Load cut mask from shape file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="168"/>
         <source>Save cut mask to shape file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1143,13 +1075,11 @@ or
     <name>IOverlayGridTool</name>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="142"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="146"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,19 +1088,16 @@ or
     <name>IOverlayRefMap</name>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="241"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="244"/>
         <source>Just move the map and zoom.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="63"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="248"/>
         <source>Add reference point.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1185,106 +1112,81 @@ or
         <location filename="../overlay/IOverlayRefMap.ui" line="217"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="244"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="326"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="258"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="262"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="266"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="282"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="294"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="86"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="252"/>
         <source>Move reference point.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="256"/>
         <source>Remove single reference point.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="260"/>
         <source>Move reference points with auto mode. This will pickup the next point after you moved a reference point.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="264"/>
         <source>Remove all reference points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="268"/>
         <source>Switch to the Grid Tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="272"/>
         <source>Load reference points from GCP file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="214"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="276"/>
         <source>Save reference points into GCP file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="241"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="280"/>
         <source>Sort list of reference points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="285"/>
         <source>(x, y)[pixel]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="284"/>
         <source>(lat, lon)[°]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="286"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="304"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="287"/>
         <source>Final Map Projection:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="316"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="289"/>
         <source>Enter a valid projection string. Valid strings are &quot;+proj...&quot; or &quot;EPSG:...&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="323"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="292"/>
         <source>Start projection wizard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="343"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="242"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,67 +1195,56 @@ or
     <name>IProjWizard</name>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="191"/>
         <source>PROJ Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="29"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="192"/>
         <source>Mercator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="193"/>
         <source>UTM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="45"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="194"/>
         <source>zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="195"/>
         <source>user defined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="196"/>
         <source>Datum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="197"/>
         <source>World Mercator (OSM)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="124"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="198"/>
         <source>Result:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="138"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="200"/>
         <source>UPS North (North Pole)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="201"/>
         <source>UPS South (South Pole)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="152"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="202"/>
         <source>Projection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1362,7 +1253,6 @@ or
     <name>ISetupExtTools</name>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="244"/>
         <source>Setup Ext. Tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1373,12 +1263,6 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="173"/>
         <location filename="../setup/ISetupExtTools.ui" line="194"/>
         <location filename="../setup/ISetupExtTools.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="245"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="255"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="264"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="276"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="296"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;not found&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1395,42 +1279,26 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="239"/>
         <location filename="../setup/ISetupExtTools.ui" line="264"/>
         <location filename="../setup/ISetupExtTools.ui" line="275"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="249"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="259"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="263"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="280"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="290"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="297"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="298"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="265"/>
         <source>gdal_translate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="43"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="250"/>
         <source>gdalbuildvrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="275"/>
         <source>gdaladdo:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="125"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="266"/>
         <source>gdalwarp:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1440,17 +1308,11 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="180"/>
         <location filename="../setup/ISetupExtTools.ui" line="208"/>
         <location filename="../setup/ISetupExtTools.ui" line="222"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="247"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="268"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="284"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="288"/>
         <source>Setup user defined path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="201"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="282"/>
         <source>qmt_rgb2pct</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1460,23 +1322,16 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="85"/>
         <location filename="../setup/ISetupExtTools.ui" line="146"/>
         <location filename="../setup/ISetupExtTools.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="252"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="261"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="272"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="292"/>
         <source>Reset user defined path setup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="295"/>
         <source>qmt_map2jnx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="288"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="299"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; Usually QMapTool should detect all external tools by itself. If it does not, it&apos;s a bad setup and you should fix the PATH variable of your system. You can setup the paths manually, too, if you know what you are doing. But please keep in mind that GDAL needs a proper environment setup to function properly. If it&apos;s not setup properly you might get results but these can be off grid.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1340,36 @@ or
     <name>ITimeZoneSetup</name>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="150"/>
         <source>Setup Timezone ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="22"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="151"/>
         <source>UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="152"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="153"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="75"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="155"/>
         <source>Print date/time in </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="156"/>
         <source>long format, or</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="157"/>
         <source>short format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1530,97 +1378,81 @@ or
     <name>IToolAddOverview</name>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="204"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="205"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="206"/>
         <source>:2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="126"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="207"/>
         <source>:4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="208"/>
         <source>:8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="209"/>
         <source>:16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="210"/>
         <source>:32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="211"/>
         <source>:64</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="213"/>
         <source>Remove all overview levels from map file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="215"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="174"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="217"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="219"/>
         <source>Overview as external file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="207"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="220"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="221"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="221"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="232"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="222"/>
         <source>For all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1629,67 +1461,56 @@ or
     <name>IToolCutMap</name>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="203"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="204"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="114"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="205"/>
         <source>Output filename suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="206"/>
         <source>_cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="207"/>
         <source>Create overviews for result.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="208"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="183"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="209"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="210"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="208"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="211"/>
         <source>For all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="233"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="212"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="243"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="213"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1698,63 +1519,52 @@ or
     <name>IToolExport</name>
     <message>
         <location filename="../tool/IToolExport.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="173"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="59"/>
         <location filename="../tool/IToolExport.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="176"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="83"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="177"/>
         <source>Garmin BirdsEye (*.jnx)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="178"/>
         <source>TwoNav Raster (*.rmap)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="180"/>
         <source>not implemented yet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="181"/>
         <source>Target File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="130"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="182"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="183"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="173"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="184"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_map2jnx&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="174"/>
         <source>Target Filename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1763,95 +1573,78 @@ or
     <name>IToolExportJnx</name>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="180"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="35"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="181"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="186"/>
         <source>BirdsEye</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="182"/>
         <source>Product ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="183"/>
         <source>Copyright notice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="64"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="95"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="188"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="185"/>
         <source>Product name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="187"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="189"/>
         <source>JPEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="190"/>
         <source>Quality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="191"/>
         <source>Chroma subsampling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="192"/>
         <source>411</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="153"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="193"/>
         <source>422</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="194"/>
         <source>444</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="196"/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="197"/>
         <source>Z-Order</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1860,43 +1653,36 @@ or
     <name>IToolGDALGroupBox</name>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="167"/>
         <source>GroupBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="17"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="168"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="169"/>
         <source>Resampling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="170"/>
         <source>Compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="118"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="171"/>
         <source>Tiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="172"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="188"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="173"/>
         <source>Other:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1905,37 +1691,31 @@ or
     <name>IToolGrid</name>
     <message>
         <location filename="../tool/IToolGrid.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="130"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="56"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="132"/>
         <source>Grid Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="65"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="133"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="134"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="110"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="135"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="136"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1944,55 +1724,46 @@ or
     <name>IToolOverviewGroupBox</name>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="104"/>
         <source>GroupBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="105"/>
         <source>:2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="106"/>
         <source>:4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="85"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="107"/>
         <source>:8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="108"/>
         <source>:16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="109"/>
         <source>:32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="106"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="110"/>
         <source>:64</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="112"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="122"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="114"/>
         <source>Overview as external file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2001,87 +1772,72 @@ or
     <name>IToolPalettize</name>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="221"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="65"/>
         <location filename="../tool/IToolPalettize.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="223"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="224"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="96"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="225"/>
         <source>Single files, filename suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="226"/>
         <source>_8bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="123"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="227"/>
         <source>Combined file, filename:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="135"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="228"/>
         <source>Embed result into *.vrt file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="142"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="229"/>
         <source>Create overviews for result.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="149"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="230"/>
         <source>GDAL Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="231"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="232"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="220"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="233"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="230"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="234"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="240"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="235"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_rgb2pct&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="222"/>
         <source>Select filename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2090,79 +1846,66 @@ or
     <name>IToolRefMap</name>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="212"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="213"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="113"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="214"/>
         <source>Output filename suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="215"/>
         <source>_ref</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="216"/>
         <source>Embed result into *.vrt file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="151"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="217"/>
         <source>Create overviews for result.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="218"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="186"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="219"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="200"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="220"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="211"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="221"/>
         <source>For all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="222"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="246"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="256"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="224"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2190,31 +1933,26 @@ or
     <name>IUnitsSetup</name>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="103"/>
         <source>Setup units...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="104"/>
         <source>Nautical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="105"/>
         <source>Imperial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="106"/>
         <source>Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_de.ts
+++ b/src/qmaptool/locale/qmaptool_de.ts
@@ -300,6 +300,24 @@
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation>Gehe eine Seite zurück</translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation>Gehe eine Seite vor</translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation>Gehe zur Startseite</translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -669,13 +687,11 @@ Durch den Benutzer abgebrochen.</translation>
     <name>IAbout</name>
     <message>
         <location filename="../IAbout.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="162"/>
         <source>About...</source>
         <translation>Über...</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="26"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="163"/>
         <source>&lt;b&gt;QMapTool&lt;/b&gt;, Version</source>
         <translation>&lt;b&gt;QMapTool&lt;/b&gt;, Version</translation>
     </message>
@@ -684,40 +700,31 @@ Durch den Benutzer abgebrochen.</translation>
         <location filename="../IAbout.ui" line="77"/>
         <location filename="../IAbout.ui" line="91"/>
         <location filename="../IAbout.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="171"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="70"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="166"/>
         <source>Qt</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="168"/>
         <source>GDAL</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="98"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="170"/>
         <source>PROJ</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="121"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="172"/>
         <source>This software is licensed under GPL3 or any later version</source>
         <translation>Diese Software steht unter der GPL3 Lizenz, oder einer neueren Version</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="128"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="173"/>
         <source>© 2017 Oliver Eichler (oliver.eichler@gmx.de)</source>
         <translation></translation>
     </message>
@@ -726,31 +733,26 @@ Durch den Benutzer abgebrochen.</translation>
     <name>ICoordFormatSetup</name>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="103"/>
         <source>Coordinate Format...</source>
         <translation>Koordinatenformat...</translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="104"/>
         <source>N48° 53&apos; 39.6&quot; E13° 31&apos; 6.78&quot;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="105"/>
         <source>N48.8943° E013.51855°</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="106"/>
         <source>N48° 53.660 E013° 31.113</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Anmerkung:&lt;/b&gt; Bei einigen GUI Elementen wird die Änderung erst mit einem Neustart von QMapTool übernommen.</translation>
     </message>
@@ -759,37 +761,31 @@ Durch den Benutzer abgebrochen.</translation>
     <name>IDialogRefPoint</name>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="115"/>
         <source>Dialog</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="25"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="116"/>
         <source>Coord. Map File [pixel]</source>
         <translation>Koord. Karte [pixel]</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="117"/>
         <source>x</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="118"/>
         <source>y</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="49"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="119"/>
         <source>Coord. lat/lon WGS84 [°]</source>
         <translation>Koord. lat/lon WGS84 [°]</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="120"/>
         <source>Bad position format. Must be: 
 &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot;
 or
@@ -804,19 +800,16 @@ oder
     <name>IGridPlacer</name>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="190"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="198"/>
         <source>Reset</source>
         <translation>Zurücksetzen</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="224"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="204"/>
         <source>Set Area</source>
         <translation>Abdeckung</translation>
     </message>
@@ -825,13 +818,11 @@ oder
     <name>IGridSelArea</name>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="50"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="51"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
@@ -840,49 +831,41 @@ oder
     <name>IGridSetRef</name>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="135"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="136"/>
         <source>Grid Projection:</source>
         <translation>Gitterprojektion:</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="137"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="60"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="138"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="139"/>
         <source>Easting</source>
         <translation>Ostwert</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="140"/>
         <source>Horiz. Spacing</source>
         <translation>horiz. Abstand</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="141"/>
         <source>Northing</source>
         <translation>Nordwert</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="102"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="142"/>
         <source>Vert. Spacing</source>
         <translation>vert. Abstand</translation>
     </message>
@@ -891,13 +874,11 @@ oder
     <name>IItemListWidget</name>
     <message>
         <location filename="../items/IItemListWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="103"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="105"/>
         <source>Add map files to list</source>
         <translation>Kartendateien zur Liste hinzufügen</translation>
     </message>
@@ -906,28 +887,21 @@ oder
         <location filename="../items/IItemListWidget.ui" line="60"/>
         <location filename="../items/IItemListWidget.ui" line="77"/>
         <location filename="../items/IItemListWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="107"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="111"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="115"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="119"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="109"/>
         <source>Remove selected file from the list.</source>
         <translation>Ausgewählte Dateien aus der Liste entfernen.</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="113"/>
         <source>Clear complete list of map files.</source>
         <translation>Die komplette Kartendateiliste löschen. </translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="117"/>
         <source>Reload the currently selected map.</source>
         <translation>Die aktuell ausgewählte Karte erneut laden.</translation>
     </message>
@@ -936,13 +910,11 @@ oder
     <name>IItemTreeWidget</name>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="108"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="110"/>
         <source>Add map files to list</source>
         <translation>Kartendateien zur Liste hinzufügen</translation>
     </message>
@@ -951,28 +923,21 @@ oder
         <location filename="../items/IItemTreeWidget.ui" line="60"/>
         <location filename="../items/IItemTreeWidget.ui" line="77"/>
         <location filename="../items/IItemTreeWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="116"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="124"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="114"/>
         <source>Remove selected file from the list.</source>
         <translation>Ausgewählte Dateien aus der Liste entfernen.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="118"/>
         <source>Clear complete list of map files.</source>
         <translation>Die komplette Kartendateiliste löschen.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="122"/>
         <source>Reload the currently selected map.</source>
         <translation>Die aktuell ausgewählte Karte erneut laden.</translation>
     </message>
@@ -981,107 +946,88 @@ oder
     <name>IMainWindow</name>
     <message>
         <location filename="../IMainWindow.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="166"/>
         <source>MainWindow</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="189"/>
         <source>Setup</source>
         <translation>Einrichten</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="41"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="190"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="191"/>
         <source>Window</source>
         <translation>Fenster</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="52"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="192"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="68"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="193"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="194"/>
         <source>Shell</source>
         <translation>Shell</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="167"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="129"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="168"/>
         <source>Ext. Tools</source>
         <translation>Ext. Werkzeuge</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="170"/>
         <source>Setup paths to external tools, like gdalwarp etc.</source>
         <translation>Pfade zu den externen Werkzeugen, wie z.B. gdalwarp, einrichten.</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="144"/>
         <location filename="../IMainWindow.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="174"/>
         <source>Flip Mouse Wheel</source>
         <translation>Mausrad umdrehen</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="156"/>
         <location filename="../IMainWindow.ui" line="159"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="178"/>
         <source>Setup Units</source>
         <translation>Einheiten einrichten</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="168"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="180"/>
         <source>Setup Coord. Format</source>
         <translation>Koordinatenformat einrichten</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="171"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="182"/>
         <source>Change the format coordinates are displayed</source>
         <translation>Das Format, in dem die Koordinaten angezeigt werden, ändern</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="182"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="184"/>
         <source>Show Tool Help</source>
         <translation>Hilfstexte anzeigen</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="185"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="194"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="187"/>
         <source>F1</source>
         <translation></translation>
     </message>
@@ -1090,19 +1036,16 @@ oder
     <name>IOverlayCutMap</name>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="142"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="144"/>
         <source>Just move the map and zoom.</source>
         <translation>Die Karte verschieben und zoomen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="58"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="148"/>
         <source>Add point to mask.</source>
         <translation>Punkte zur Maske hinzufügen.</translation>
     </message>
@@ -1113,42 +1056,31 @@ oder
         <location filename="../overlay/IOverlayCutMap.ui" line="137"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="158"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="170"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="152"/>
         <source>Move point of mask.</source>
         <translation>Maskenpunkte verschieben.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="156"/>
         <source>Remove point from mask.</source>
         <translation>Punkte aus der Maske entfernen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="160"/>
         <source>Remove complete cut mask.</source>
         <translation>Die komplette Freistellmaske entfernen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="164"/>
         <source>Load cut mask from shape file.</source>
         <translation>Freistellmaske aus einer Shapedatei laden.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="168"/>
         <source>Save cut mask to shape file.</source>
         <translation>Freistellmaske in einer Shapedatei speichern.</translation>
     </message>
@@ -1157,13 +1089,11 @@ oder
     <name>IOverlayGridTool</name>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="142"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="146"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
@@ -1172,19 +1102,16 @@ oder
     <name>IOverlayRefMap</name>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="241"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="244"/>
         <source>Just move the map and zoom.</source>
         <translation>Die Karte verschieben und zoomen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="63"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="248"/>
         <source>Add reference point.</source>
         <translation>Referenzpunkte hinzufügen.</translation>
     </message>
@@ -1199,106 +1126,81 @@ oder
         <location filename="../overlay/IOverlayRefMap.ui" line="217"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="244"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="326"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="258"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="262"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="266"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="282"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="294"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="86"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="252"/>
         <source>Move reference point.</source>
         <translation>Referenzpunkte verschieben.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="256"/>
         <source>Remove single reference point.</source>
         <translation>Referenzpunkte löschen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="260"/>
         <source>Move reference points with auto mode. This will pickup the next point after you moved a reference point.</source>
         <translation>Referenzpunkte im Automode verschieben. Nachdem der aktuelle Punkt verschoben wurde, wird automatisch der Nächste genommen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="264"/>
         <source>Remove all reference points.</source>
         <translation>Alle Referenzpunkte löschen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="268"/>
         <source>Switch to the Grid Tool.</source>
         <translation>Auf das Gitterwerkzeug umschalten.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="272"/>
         <source>Load reference points from GCP file.</source>
         <translation>Referenzpunkte aus einer GCP Datei lesen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="214"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="276"/>
         <source>Save reference points into GCP file.</source>
         <translation>Referenzpunkte in eine GCP Datei speichern.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="241"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="280"/>
         <source>Sort list of reference points.</source>
         <translation>Die Liste der Referenzpunkte sortieren.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="285"/>
         <source>(x, y)[pixel]</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="284"/>
         <source>(lat, lon)[°]</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="286"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="304"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="287"/>
         <source>Final Map Projection:</source>
         <translation>Endgültige Kartenprojektion:</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="316"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="289"/>
         <source>Enter a valid projection string. Valid strings are &quot;+proj...&quot; or &quot;EPSG:...&quot;.</source>
         <translation>Geben Sie einen gültigen Projektionstext ein. Gültige Formen sind &quot;+proj...&quot; oder &quot;EPSG:...&quot;.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="323"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="292"/>
         <source>Start projection wizard.</source>
         <translation>Den Projektionsassistenten öffnen.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="343"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="242"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
@@ -1307,67 +1209,56 @@ oder
     <name>IProjWizard</name>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="191"/>
         <source>PROJ Wizard</source>
         <translation>PROJ Assistent</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="29"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="192"/>
         <source>Mercator</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="193"/>
         <source>UTM</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="45"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="194"/>
         <source>zone</source>
         <translation>Zone</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="195"/>
         <source>user defined</source>
         <translation>benutzerdefiniert</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="196"/>
         <source>Datum</source>
         <translation>Datum</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="197"/>
         <source>World Mercator (OSM)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="124"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="198"/>
         <source>Result:</source>
         <translation>Ergebnis:</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="138"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="200"/>
         <source>UPS North (North Pole)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="201"/>
         <source>UPS South (South Pole)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="152"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="202"/>
         <source>Projection</source>
         <translation>Projektion</translation>
     </message>
@@ -1376,7 +1267,6 @@ oder
     <name>ISetupExtTools</name>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="244"/>
         <source>Setup Ext. Tools</source>
         <translation>Externe Werkzeuge einstellen</translation>
     </message>
@@ -1387,12 +1277,6 @@ oder
         <location filename="../setup/ISetupExtTools.ui" line="173"/>
         <location filename="../setup/ISetupExtTools.ui" line="194"/>
         <location filename="../setup/ISetupExtTools.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="245"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="255"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="264"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="276"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="296"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;not found&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;nicht gefunden&lt;/b&gt;</translation>
     </message>
@@ -1409,42 +1293,26 @@ oder
         <location filename="../setup/ISetupExtTools.ui" line="239"/>
         <location filename="../setup/ISetupExtTools.ui" line="264"/>
         <location filename="../setup/ISetupExtTools.ui" line="275"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="249"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="259"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="263"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="280"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="290"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="297"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="298"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="265"/>
         <source>gdal_translate:</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="43"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="250"/>
         <source>gdalbuildvrt</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="275"/>
         <source>gdaladdo:</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="125"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="266"/>
         <source>gdalwarp:</source>
         <translation></translation>
     </message>
@@ -1454,17 +1322,11 @@ oder
         <location filename="../setup/ISetupExtTools.ui" line="180"/>
         <location filename="../setup/ISetupExtTools.ui" line="208"/>
         <location filename="../setup/ISetupExtTools.ui" line="222"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="247"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="268"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="284"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="288"/>
         <source>Setup user defined path.</source>
         <translation>Benutzerdefinierten Pfad einstellen.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="201"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="282"/>
         <source>qmt_rgb2pct</source>
         <translation></translation>
     </message>
@@ -1474,23 +1336,16 @@ oder
         <location filename="../setup/ISetupExtTools.ui" line="85"/>
         <location filename="../setup/ISetupExtTools.ui" line="146"/>
         <location filename="../setup/ISetupExtTools.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="252"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="261"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="272"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="292"/>
         <source>Reset user defined path setup.</source>
         <translation>Benutzerdefinierten Pfad zurücksetzen.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="295"/>
         <source>qmt_map2jnx</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="288"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="299"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; Usually QMapTool should detect all external tools by itself. If it does not, it&apos;s a bad setup and you should fix the PATH variable of your system. You can setup the paths manually, too, if you know what you are doing. But please keep in mind that GDAL needs a proper environment setup to function properly. If it&apos;s not setup properly you might get results but these can be off grid.</source>
         <translation>&lt;b&gt;Anmerkung:&lt;/b&gt; Normalerweise sollte QMapTool alle externen Werkzeuge selber finden. Wenn das nicht gelingt, liegt es in der Regel an einer schlechten Einstellung und Sie sollten die PATH Variable ihres Systems überprüfen. Man kann die Werkzeugpfade auch selber setzen. Vorausgesetzt, man weiß was man macht. Bitte bedenken Sie, dass GDAL eine ordentlich aufgesetzte Umgebung benötigt, um fachgerecht zu funktionieren. Wenn dem nicht so ist, können durchaus Ergebnisse erzielt werden, diese können aber verschoben sein.</translation>
     </message>
@@ -1499,43 +1354,36 @@ oder
     <name>ITimeZoneSetup</name>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="150"/>
         <source>Setup Timezone ...</source>
         <translation>Zeitzone einstellen...</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="22"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="151"/>
         <source>UTC</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="152"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="153"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="75"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="155"/>
         <source>Print date/time in </source>
         <translation>Datum/Zeit anzeigen im</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="156"/>
         <source>long format, or</source>
         <translation>langen Format</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="157"/>
         <source>short format</source>
         <translation>kurzen Format</translation>
     </message>
@@ -1544,97 +1392,81 @@ oder
     <name>IToolAddOverview</name>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="204"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="205"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="206"/>
         <source>:2</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="126"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="207"/>
         <source>:4</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="208"/>
         <source>:8</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="209"/>
         <source>:16</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="210"/>
         <source>:32</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="211"/>
         <source>:64</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="213"/>
         <source>Remove all overview levels from map file.</source>
         <translation>Alle Übersichten aus der Kartendatei entfernen.</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="215"/>
         <source>Remove</source>
         <translation>Löschen</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="174"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="217"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation>Die Übersichten nicht in der Datei selbst anlegen. Als extra Datei hinzufügen.</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="219"/>
         <source>Overview as external file</source>
         <translation>Übersichten als externe Datei</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="207"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="220"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="221"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="221"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="232"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="222"/>
         <source>For all files</source>
         <translation>Für alle Dateien</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
@@ -1643,67 +1475,56 @@ oder
     <name>IToolCutMap</name>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="203"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="204"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="114"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="205"/>
         <source>Output filename suffix</source>
         <translation>Suffix der Ausgabedatei</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="206"/>
         <source>_cut</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="207"/>
         <source>Create overviews for result.</source>
         <translation>Übersichten für das Ergebnis erzeugen.</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="208"/>
         <source>GDAL Parameters</source>
         <translation>GDAL Parameter</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="183"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="209"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="210"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="208"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="211"/>
         <source>For all files</source>
         <translation>Für alle Dateien</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="233"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="212"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdalwarp&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="243"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="213"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
@@ -1712,63 +1533,52 @@ oder
     <name>IToolExport</name>
     <message>
         <location filename="../tool/IToolExport.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="173"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="59"/>
         <location filename="../tool/IToolExport.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="176"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="83"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="177"/>
         <source>Garmin BirdsEye (*.jnx)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="178"/>
         <source>TwoNav Raster (*.rmap)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="180"/>
         <source>not implemented yet</source>
         <translation>noch nicht eingebaut</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="181"/>
         <source>Target File</source>
         <translation>Zieldatei</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="130"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="182"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="183"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="173"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="184"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_map2jnx&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;qmt_map2jnx&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="174"/>
         <source>Target Filename</source>
         <translation>Dateiname der Zieldatei</translation>
     </message>
@@ -1777,96 +1587,79 @@ oder
     <name>IToolExportJnx</name>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="180"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="35"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="181"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="186"/>
         <source>BirdsEye</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="182"/>
         <source>Product ID</source>
         <translation>Produkt ID</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="183"/>
         <source>Copyright notice</source>
         <translation>Urheberhinweis</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="64"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="95"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="188"/>
         <source>None</source>
         <translation>Nichts</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="185"/>
         <source>Product name</source>
         <translation>Produktname</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="187"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="189"/>
         <source>JPEG</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="190"/>
         <source>Quality</source>
         <translation>Qualität
 </translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="191"/>
         <source>Chroma subsampling</source>
         <translation>Halbttonunterabtastung</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="192"/>
         <source>411</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="153"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="193"/>
         <source>422</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="194"/>
         <source>444</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="196"/>
         <source>Device</source>
         <translation>Gerät</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="197"/>
         <source>Z-Order</source>
         <translation>Reihenfolge (Z-Achse)</translation>
     </message>
@@ -1875,43 +1668,36 @@ oder
     <name>IToolGDALGroupBox</name>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="167"/>
         <source>GroupBox</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="17"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="168"/>
         <source>GDAL Parameters</source>
         <translation>GDAL Parameter</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="169"/>
         <source>Resampling</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="170"/>
         <source>Compression</source>
         <translation>Kompression</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="118"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="171"/>
         <source>Tiled</source>
         <translation>Kacheln</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="172"/>
         <source>x</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="188"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="173"/>
         <source>Other:</source>
         <translation>Weitere:</translation>
     </message>
@@ -1920,37 +1706,31 @@ oder
     <name>IToolGrid</name>
     <message>
         <location filename="../tool/IToolGrid.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="130"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="56"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="132"/>
         <source>Grid Tool</source>
         <translation>Gitterwerkzeug</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="65"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="133"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="134"/>
         <source>Ok</source>
         <translation>OK</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="110"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="135"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="136"/>
         <source>Reset</source>
         <translation>Zurücksetzen</translation>
     </message>
@@ -1959,55 +1739,46 @@ oder
     <name>IToolOverviewGroupBox</name>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="104"/>
         <source>GroupBox</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="105"/>
         <source>:2</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="106"/>
         <source>:4</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="85"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="107"/>
         <source>:8</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="108"/>
         <source>:16</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="109"/>
         <source>:32</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="106"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="110"/>
         <source>:64</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="112"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation>Die Übersichten nicht in der Datei selber anlegen. Als extra Datei hinzufügen.</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="122"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="114"/>
         <source>Overview as external file</source>
         <translation>Übersichten als externe Datei</translation>
     </message>
@@ -2016,87 +1787,72 @@ oder
     <name>IToolPalettize</name>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="221"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="65"/>
         <location filename="../tool/IToolPalettize.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="223"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="224"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="96"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="225"/>
         <source>Single files, filename suffix</source>
         <translation>Einzelne Dateien, Dateinamensuffix</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="226"/>
         <source>_8bit</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="123"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="227"/>
         <source>Combined file, filename:</source>
         <translation>In einer Datei zusammenfassen, Dateiname:</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="135"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="228"/>
         <source>Embed result into *.vrt file.</source>
         <translation>Ergebnis in eine *.vrt Datei einbetten.</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="142"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="229"/>
         <source>Create overviews for result.</source>
         <translation>Übersichten für das Ergebnis erzeugen.</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="149"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="230"/>
         <source>GDAL Parameter</source>
         <translation>GDAL Parameter</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="231"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="232"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="220"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="233"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="230"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="234"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdal_translate&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="240"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="235"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_rgb2pct&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;qmt_rgb2pct&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="222"/>
         <source>Select filename</source>
         <translation>Dateinamen auswählen</translation>
     </message>
@@ -2105,79 +1861,66 @@ oder
     <name>IToolRefMap</name>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="212"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="213"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="113"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="214"/>
         <source>Output filename suffix</source>
         <translation>Suffix der Ausgabedatei</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="215"/>
         <source>_ref</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="216"/>
         <source>Embed result into *.vrt file.</source>
         <translation>Ergebnis in eine *.vrt Datei einbetten.</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="151"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="217"/>
         <source>Create overviews for result.</source>
         <translation>Übersichten für das Ergebnis erzeugen.</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="218"/>
         <source>GDAL Parameters</source>
         <translation>GDAL Parameter</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="186"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="219"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="200"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="220"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="211"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="221"/>
         <source>For all files</source>
         <translation>Für alle Dateien</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="222"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdalwarp&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="246"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdal_translate&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="256"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="224"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot;nicht gefunden. Bitte überprüfen Sie die Einstellungen!&lt;/b&gt;</translation>
     </message>
@@ -2208,31 +1951,26 @@ oder
     <name>IUnitsSetup</name>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="103"/>
         <source>Setup units...</source>
         <translation>Einheiten einrichten...</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="104"/>
         <source>Nautical</source>
         <translation>nautisch</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="105"/>
         <source>Imperial</source>
         <translation>imperial</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="106"/>
         <source>Metric</source>
         <translation>metrisch</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Anmerkung:&lt;/b&gt; Bei einigen GUI Elementen wird die Änderung erst mit einem Neustart von QMapTool übernommen.</translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_es.ts
+++ b/src/qmaptool/locale/qmaptool_es.ts
@@ -299,6 +299,24 @@
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -667,13 +685,11 @@ Canceled by user&apos;s request.
     <name>IAbout</name>
     <message>
         <location filename="../IAbout.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="162"/>
         <source>About...</source>
         <translation>Acerca de...</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="26"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="163"/>
         <source>&lt;b&gt;QMapTool&lt;/b&gt;, Version</source>
         <translation>&lt;b&gt;QMapTool&lt;/b&gt;, Versión</translation>
     </message>
@@ -682,40 +698,31 @@ Canceled by user&apos;s request.
         <location filename="../IAbout.ui" line="77"/>
         <location filename="../IAbout.ui" line="91"/>
         <location filename="../IAbout.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="171"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="70"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="166"/>
         <source>Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="168"/>
         <source>GDAL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="98"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="170"/>
         <source>PROJ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="121"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="172"/>
         <source>This software is licensed under GPL3 or any later version</source>
         <translation>Este programa está bajo licencia GPL3 o posterior</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="128"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="173"/>
         <source>© 2017 Oliver Eichler (oliver.eichler@gmx.de)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -724,31 +731,26 @@ Canceled by user&apos;s request.
     <name>ICoordFormatSetup</name>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="103"/>
         <source>Coordinate Format...</source>
         <translation>Formato de Coordenadas...</translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="104"/>
         <source>N48° 53&apos; 39.6&quot; E13° 31&apos; 6.78&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="105"/>
         <source>N48.8943° E013.51855°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="106"/>
         <source>N48° 53.660 E013° 31.113</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Nota:&lt;/b&gt; El cambio de las unidades de algunos elementos no se producirá hasta el reinicio de QMapTool.</translation>
     </message>
@@ -757,37 +759,31 @@ Canceled by user&apos;s request.
     <name>IDialogRefPoint</name>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="115"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="25"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="116"/>
         <source>Coord. Map File [pixel]</source>
         <translation>Coord. archivo Map [pixel]</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="117"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="118"/>
         <source>y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="49"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="119"/>
         <source>Coord. lat/lon WGS84 [°]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="120"/>
         <source>Bad position format. Must be: 
 &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot;
 or
@@ -802,19 +798,16 @@ o
     <name>IGridPlacer</name>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="190"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="198"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="224"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="204"/>
         <source>Set Area</source>
         <translation>Establecer área</translation>
     </message>
@@ -823,13 +816,11 @@ o
     <name>IGridSelArea</name>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="50"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="51"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -838,49 +829,41 @@ o
     <name>IGridSetRef</name>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="135"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="136"/>
         <source>Grid Projection:</source>
         <translation>Proyección de la Cuadrícula:</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="137"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="60"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="138"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="139"/>
         <source>Easting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="140"/>
         <source>Horiz. Spacing</source>
         <translation>Espaciado horizontal</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="141"/>
         <source>Northing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="102"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="142"/>
         <source>Vert. Spacing</source>
         <translation>Espaciado vertical</translation>
     </message>
@@ -889,13 +872,11 @@ o
     <name>IItemListWidget</name>
     <message>
         <location filename="../items/IItemListWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="103"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="105"/>
         <source>Add map files to list</source>
         <translation>Añadir archivos de mapa a la lista</translation>
     </message>
@@ -904,28 +885,21 @@ o
         <location filename="../items/IItemListWidget.ui" line="60"/>
         <location filename="../items/IItemListWidget.ui" line="77"/>
         <location filename="../items/IItemListWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="107"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="111"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="115"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="119"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="109"/>
         <source>Remove selected file from the list.</source>
         <translation>Borrar archivo seleccionado de la lista.</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="113"/>
         <source>Clear complete list of map files.</source>
         <translation>Borrar lista completa de archivos de mapa.</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="117"/>
         <source>Reload the currently selected map.</source>
         <translation>Recargar mapa seleccionado.</translation>
     </message>
@@ -934,13 +908,11 @@ o
     <name>IItemTreeWidget</name>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="108"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="110"/>
         <source>Add map files to list</source>
         <translation type="unfinished">Añadir archivos de mapa a la lista</translation>
     </message>
@@ -949,28 +921,21 @@ o
         <location filename="../items/IItemTreeWidget.ui" line="60"/>
         <location filename="../items/IItemTreeWidget.ui" line="77"/>
         <location filename="../items/IItemTreeWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="116"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="124"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="114"/>
         <source>Remove selected file from the list.</source>
         <translation type="unfinished">Borrar archivo seleccionado de la lista.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="118"/>
         <source>Clear complete list of map files.</source>
         <translation type="unfinished">Borrar lista completa de archivos de mapa.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="122"/>
         <source>Reload the currently selected map.</source>
         <translation type="unfinished">Recargar mapa seleccionado.</translation>
     </message>
@@ -979,107 +944,88 @@ o
     <name>IMainWindow</name>
     <message>
         <location filename="../IMainWindow.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="166"/>
         <source>MainWindow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="189"/>
         <source>Setup</source>
         <translation>Configuración</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="41"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="190"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="191"/>
         <source>Window</source>
         <translation>Ventana</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="52"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="192"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="68"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="193"/>
         <source>Tools</source>
         <translation>Herramientas</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="194"/>
         <source>Shell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="167"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="129"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="168"/>
         <source>Ext. Tools</source>
         <translation>Herramientas ext.</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="170"/>
         <source>Setup paths to external tools, like gdalwarp etc.</source>
         <translation>Configurar rutas de las herramientas ext.</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="144"/>
         <location filename="../IMainWindow.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="174"/>
         <source>Flip Mouse Wheel</source>
         <translation>Invertir rueda del ratón</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="156"/>
         <location filename="../IMainWindow.ui" line="159"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="178"/>
         <source>Setup Units</source>
         <translation>Configurar unidades</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="168"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="180"/>
         <source>Setup Coord. Format</source>
         <translation>Configurar formato de coordenadas</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="171"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="182"/>
         <source>Change the format coordinates are displayed</source>
         <translation>Cambiar formato de coordenadas mostrado.</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="182"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="184"/>
         <source>Show Tool Help</source>
         <translation>Mostrar ayuda de la herramienta</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="185"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="194"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="187"/>
         <source>F1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1088,19 +1034,16 @@ o
     <name>IOverlayCutMap</name>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="142"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="144"/>
         <source>Just move the map and zoom.</source>
         <translation>Solo mueve el mapa y zoom</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="58"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="148"/>
         <source>Add point to mask.</source>
         <translation>Añadir punto a la máscara.</translation>
     </message>
@@ -1111,42 +1054,31 @@ o
         <location filename="../overlay/IOverlayCutMap.ui" line="137"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="158"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="170"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="152"/>
         <source>Move point of mask.</source>
         <translation>Mover punto de la máscara.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="156"/>
         <source>Remove point from mask.</source>
         <translation>Borrar punto de la máscara.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="160"/>
         <source>Remove complete cut mask.</source>
         <translation>Borrar máscara de corte completa.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="164"/>
         <source>Load cut mask from shape file.</source>
         <translation>Cargar máscara de corte desde archivo Shape.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="168"/>
         <source>Save cut mask to shape file.</source>
         <translation>Guardar máscara de corte en archivo Shape.</translation>
     </message>
@@ -1155,13 +1087,11 @@ o
     <name>IOverlayGridTool</name>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="142"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="146"/>
         <source>do not translate</source>
         <translation>No traducir</translation>
     </message>
@@ -1170,19 +1100,16 @@ o
     <name>IOverlayRefMap</name>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="241"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="244"/>
         <source>Just move the map and zoom.</source>
         <translation>Solo mover mapa y zoom.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="63"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="248"/>
         <source>Add reference point.</source>
         <translation>Añadir punto de referencia.</translation>
     </message>
@@ -1197,106 +1124,81 @@ o
         <location filename="../overlay/IOverlayRefMap.ui" line="217"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="244"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="326"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="258"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="262"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="266"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="282"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="294"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="86"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="252"/>
         <source>Move reference point.</source>
         <translation>Mover punto de referencia.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="256"/>
         <source>Remove single reference point.</source>
         <translation>Borrar un punto de referencia.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="260"/>
         <source>Move reference points with auto mode. This will pickup the next point after you moved a reference point.</source>
         <translation>Mover puntos de referencia con modo auto, captará el siguiente tras el desplazamiento del anterior.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="264"/>
         <source>Remove all reference points.</source>
         <translation>Borrar todos los puntos de referencia.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="268"/>
         <source>Switch to the Grid Tool.</source>
         <translation>Cambiar a la Herramienta de cuadrícula.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="272"/>
         <source>Load reference points from GCP file.</source>
         <translation>Cargar puntos de referencia desde archivo GCP.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="214"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="276"/>
         <source>Save reference points into GCP file.</source>
         <translation>Guardar puntos de referencia en archivo GCP.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="241"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="280"/>
         <source>Sort list of reference points.</source>
         <translation>Ordenar lista de puntos de referencia</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="285"/>
         <source>(x, y)[pixel]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="284"/>
         <source>(lat, lon)[°]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="286"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="304"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="287"/>
         <source>Final Map Projection:</source>
         <translation>Proyección final del mapa:</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="316"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="289"/>
         <source>Enter a valid projection string. Valid strings are &quot;+proj...&quot; or &quot;EPSG:...&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="323"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="292"/>
         <source>Start projection wizard.</source>
         <translation>Iniciar asistente de proyección.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="343"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="242"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
@@ -1305,67 +1207,56 @@ o
     <name>IProjWizard</name>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="191"/>
         <source>PROJ Wizard</source>
         <translation>Asistente de PROJ</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="29"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="192"/>
         <source>Mercator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="193"/>
         <source>UTM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="45"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="194"/>
         <source>zone</source>
         <translation>zona</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="195"/>
         <source>user defined</source>
         <translation>definida por el usuario</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="196"/>
         <source>Datum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="197"/>
         <source>World Mercator (OSM)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="124"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="198"/>
         <source>Result:</source>
         <translation>Resultado:</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="138"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="200"/>
         <source>UPS North (North Pole)</source>
         <translation>UPS Norte (Polo Norte)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="201"/>
         <source>UPS South (South Pole)</source>
         <translation>UPS Sur (Polo Sur)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="152"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="202"/>
         <source>Projection</source>
         <translation>Proyección</translation>
     </message>
@@ -1374,7 +1265,6 @@ o
     <name>ISetupExtTools</name>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="244"/>
         <source>Setup Ext. Tools</source>
         <translation>Configurar Herramientas Ext.</translation>
     </message>
@@ -1385,12 +1275,6 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="173"/>
         <location filename="../setup/ISetupExtTools.ui" line="194"/>
         <location filename="../setup/ISetupExtTools.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="245"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="255"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="264"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="276"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="296"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;not found&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;no encontrado&lt;/b&gt;</translation>
     </message>
@@ -1407,42 +1291,26 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="239"/>
         <location filename="../setup/ISetupExtTools.ui" line="264"/>
         <location filename="../setup/ISetupExtTools.ui" line="275"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="249"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="259"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="263"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="280"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="290"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="297"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="298"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="265"/>
         <source>gdal_translate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="43"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="250"/>
         <source>gdalbuildvrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="275"/>
         <source>gdaladdo:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="125"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="266"/>
         <source>gdalwarp:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,17 +1320,11 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="180"/>
         <location filename="../setup/ISetupExtTools.ui" line="208"/>
         <location filename="../setup/ISetupExtTools.ui" line="222"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="247"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="268"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="284"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="288"/>
         <source>Setup user defined path.</source>
         <translation>Configurar ruta definida por el usuario.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="201"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="282"/>
         <source>qmt_rgb2pct</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1472,23 +1334,16 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="85"/>
         <location filename="../setup/ISetupExtTools.ui" line="146"/>
         <location filename="../setup/ISetupExtTools.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="252"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="261"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="272"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="292"/>
         <source>Reset user defined path setup.</source>
         <translation>Reiniciar la configuración de la ruta definida por el usuario.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="295"/>
         <source>qmt_map2jnx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="288"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="299"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; Usually QMapTool should detect all external tools by itself. If it does not, it&apos;s a bad setup and you should fix the PATH variable of your system. You can setup the paths manually, too, if you know what you are doing. But please keep in mind that GDAL needs a proper environment setup to function properly. If it&apos;s not setup properly you might get results but these can be off grid.</source>
         <translation>&lt;b&gt;Nota:&lt;/b&gt; QMapTool debería detectar todas las herramientas externas automáticamente, si no es así, es debido a una configuración errónea y hay que corregir la variable PATH del sistema. También se  pueden configurar las rutas manualmente, si se sabe lo que se está haciendo, pero ten en cuenta que GDAL necesita una configuración del entorno adecuada para funcionar correctamente. Si no es correcta se pueden obtener resultados, pero pueden ser incorrectos.</translation>
     </message>
@@ -1497,43 +1352,36 @@ o
     <name>ITimeZoneSetup</name>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="150"/>
         <source>Setup Timezone ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="22"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="151"/>
         <source>UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="152"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="153"/>
         <source>Automatic</source>
         <translation>Automática</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="75"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="155"/>
         <source>Print date/time in </source>
         <translation>Mostrar fecha y hora en </translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="156"/>
         <source>long format, or</source>
         <translation>formato largo o</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="157"/>
         <source>short format</source>
         <translation>formato corto</translation>
     </message>
@@ -1542,97 +1390,81 @@ o
     <name>IToolAddOverview</name>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="204"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="205"/>
         <source>do not translate</source>
         <translation>no traducir</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="206"/>
         <source>:2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="126"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="207"/>
         <source>:4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="208"/>
         <source>:8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="209"/>
         <source>:16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="210"/>
         <source>:32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="211"/>
         <source>:64</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="213"/>
         <source>Remove all overview levels from map file.</source>
         <translation>Borrar los niveles de zoom del archivo del mapa.</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="215"/>
         <source>Remove</source>
         <translation>Borrar</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="174"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="217"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation>No copiar los niveles de zoom en el mismo archivo, hacerlo en uno externo.</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="219"/>
         <source>Overview as external file</source>
         <translation>Niveles de zoom en archivo externo</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="207"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="220"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="221"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="221"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="232"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="222"/>
         <source>For all files</source>
         <translation>Para todos los archivos</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;Gdaladdo&quot; no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
@@ -1641,67 +1473,56 @@ o
     <name>IToolCutMap</name>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="203"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="204"/>
         <source>do not translate</source>
         <translation>no traducir</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="114"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="205"/>
         <source>Output filename suffix</source>
         <translation>Sufijo del nombre de archivo resultante</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="206"/>
         <source>_cut</source>
         <translation>_cortar</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="207"/>
         <source>Create overviews for result.</source>
         <translation>Crear niveles de zoom.</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="208"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="183"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="209"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="210"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="208"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="211"/>
         <source>For all files</source>
         <translation>Para todos los archivos</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="233"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="212"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>lt;b style=&apos;color: red;&apos;&gt; &quot;Gdalwarp&quot;no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="243"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="213"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt; &quot;Gdaladdo&quot;no encontrado ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
@@ -1710,63 +1531,52 @@ o
     <name>IToolExport</name>
     <message>
         <location filename="../tool/IToolExport.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="173"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="59"/>
         <location filename="../tool/IToolExport.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="176"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="83"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="177"/>
         <source>Garmin BirdsEye (*.jnx)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="178"/>
         <source>TwoNav Raster (*.rmap)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="180"/>
         <source>not implemented yet</source>
         <translation>Todavía no implementado</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="181"/>
         <source>Target File</source>
         <translation>Archivo de destino</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="130"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="182"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="183"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="173"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="184"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_map2jnx&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;qmt_map2jnx&quot; No encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="174"/>
         <source>Target Filename</source>
         <translation>Nombre del archivo de destino</translation>
     </message>
@@ -1775,95 +1585,78 @@ o
     <name>IToolExportJnx</name>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="180"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="35"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="181"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="186"/>
         <source>BirdsEye</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="182"/>
         <source>Product ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="183"/>
         <source>Copyright notice</source>
         <translation>Aviso de copyright</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="64"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="95"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="188"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="185"/>
         <source>Product name</source>
         <translation>Nombre del producto</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="187"/>
         <source>Description</source>
         <translation type="unfinished">Descripción</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="189"/>
         <source>JPEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="190"/>
         <source>Quality</source>
         <translation>Calidad</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="191"/>
         <source>Chroma subsampling</source>
         <translation>Submuestreo de Chroma</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="192"/>
         <source>411</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="153"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="193"/>
         <source>422</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="194"/>
         <source>444</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="196"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="197"/>
         <source>Z-Order</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1872,43 +1665,36 @@ o
     <name>IToolGDALGroupBox</name>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="167"/>
         <source>GroupBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="17"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="168"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="169"/>
         <source>Resampling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="170"/>
         <source>Compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="118"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="171"/>
         <source>Tiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="172"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="188"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="173"/>
         <source>Other:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1917,37 +1703,31 @@ o
     <name>IToolGrid</name>
     <message>
         <location filename="../tool/IToolGrid.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="130"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="56"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="132"/>
         <source>Grid Tool</source>
         <translation>Herramienta Cuadrícula</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="65"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="133"/>
         <source>do not translate</source>
         <translation>no traducir</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="134"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="110"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="135"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="136"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
@@ -1956,55 +1736,46 @@ o
     <name>IToolOverviewGroupBox</name>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="104"/>
         <source>GroupBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="105"/>
         <source>:2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="106"/>
         <source>:4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="85"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="107"/>
         <source>:8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="108"/>
         <source>:16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="109"/>
         <source>:32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="106"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="110"/>
         <source>:64</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="112"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation>No copiar los niveles de zoom en el mismo archivo, hacerlo en uno externo.</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="122"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="114"/>
         <source>Overview as external file</source>
         <translation>Niveles de zoom en archivo externo</translation>
     </message>
@@ -2013,87 +1784,72 @@ o
     <name>IToolPalettize</name>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="221"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="65"/>
         <location filename="../tool/IToolPalettize.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="223"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="224"/>
         <source>do not translate</source>
         <translation>no traducir</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="96"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="225"/>
         <source>Single files, filename suffix</source>
         <translation>Archivos individuales, sufijo del nombre</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="226"/>
         <source>_8bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="123"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="227"/>
         <source>Combined file, filename:</source>
         <translation>Archivo combinado, nombre:</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="135"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="228"/>
         <source>Embed result into *.vrt file.</source>
         <translation>Insertar el resultado en un archivo *.vrt.</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="142"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="229"/>
         <source>Create overviews for result.</source>
         <translation>Crear niveles de zoom.</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="149"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="230"/>
         <source>GDAL Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="231"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="232"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="220"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="233"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;Gdaladdo&quot; no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="230"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="234"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;Gdal_translate&quot; no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="240"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="235"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_rgb2pct&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;Qmt_rgb2pct&quot; no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="222"/>
         <source>Select filename</source>
         <translation>Seleccionar nombre de archivo</translation>
     </message>
@@ -2102,79 +1858,66 @@ o
     <name>IToolRefMap</name>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="212"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="213"/>
         <source>do not translate</source>
         <translation>no traducir</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="113"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="214"/>
         <source>Output filename suffix</source>
         <translation>Sufijo del nombre de archivo</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="215"/>
         <source>_ref</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="216"/>
         <source>Embed result into *.vrt file.</source>
         <translation>Insertar resultado en archivo *.vrt.</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="151"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="217"/>
         <source>Create overviews for result.</source>
         <translation>Crear niveles de zoom.</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="218"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="186"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="219"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="200"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="220"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="211"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="221"/>
         <source>For all files</source>
         <translation>Para todos los archivos</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="222"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;Gdalwarp&quot; no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="246"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;Gdal_translate&quot; no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="256"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="224"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;Gdaladdo&quot; no encontrado. ¡Comprobar la configuración!&lt;/b&gt;</translation>
     </message>
@@ -2202,31 +1945,26 @@ o
     <name>IUnitsSetup</name>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="103"/>
         <source>Setup units...</source>
         <translation>Configurar unidades...</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="104"/>
         <source>Nautical</source>
         <translation>Náutico</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="105"/>
         <source>Imperial</source>
         <translation>Imperial</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="106"/>
         <source>Metric</source>
         <translation>Métrico</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Nota:&lt;/b&gt; El cambio de las unidades de algunos elementos no se producirá hasta el reinicio de QMapTool.</translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_hr.ts
+++ b/src/qmaptool/locale/qmaptool_hr.ts
@@ -299,6 +299,24 @@
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -658,13 +676,11 @@ Canceled by user&apos;s request.
     <name>IAbout</name>
     <message>
         <location filename="../IAbout.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="162"/>
         <source>About...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="26"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="163"/>
         <source>&lt;b&gt;QMapTool&lt;/b&gt;, Version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,40 +689,31 @@ Canceled by user&apos;s request.
         <location filename="../IAbout.ui" line="77"/>
         <location filename="../IAbout.ui" line="91"/>
         <location filename="../IAbout.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="171"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="70"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="166"/>
         <source>Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="168"/>
         <source>GDAL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="98"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="170"/>
         <source>PROJ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="121"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="172"/>
         <source>This software is licensed under GPL3 or any later version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="128"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="173"/>
         <source>© 2017 Oliver Eichler (oliver.eichler@gmx.de)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -715,31 +722,26 @@ Canceled by user&apos;s request.
     <name>ICoordFormatSetup</name>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="103"/>
         <source>Coordinate Format...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="104"/>
         <source>N48° 53&apos; 39.6&quot; E13° 31&apos; 6.78&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="105"/>
         <source>N48.8943° E013.51855°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="106"/>
         <source>N48° 53.660 E013° 31.113</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -748,37 +750,31 @@ Canceled by user&apos;s request.
     <name>IDialogRefPoint</name>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="115"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="25"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="116"/>
         <source>Coord. Map File [pixel]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="117"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="118"/>
         <source>y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="49"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="119"/>
         <source>Coord. lat/lon WGS84 [°]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="120"/>
         <source>Bad position format. Must be: 
 &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot;
 or
@@ -790,19 +786,16 @@ or
     <name>IGridPlacer</name>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="190"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="198"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="224"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="204"/>
         <source>Set Area</source>
         <translation type="unfinished"></translation>
     </message>
@@ -811,13 +804,11 @@ or
     <name>IGridSelArea</name>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="50"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="51"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,49 +817,41 @@ or
     <name>IGridSetRef</name>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="135"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="136"/>
         <source>Grid Projection:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="137"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="60"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="138"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="139"/>
         <source>Easting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="140"/>
         <source>Horiz. Spacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="141"/>
         <source>Northing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="102"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="142"/>
         <source>Vert. Spacing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -877,13 +860,11 @@ or
     <name>IItemListWidget</name>
     <message>
         <location filename="../items/IItemListWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="103"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="105"/>
         <source>Add map files to list</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,28 +873,21 @@ or
         <location filename="../items/IItemListWidget.ui" line="60"/>
         <location filename="../items/IItemListWidget.ui" line="77"/>
         <location filename="../items/IItemListWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="107"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="111"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="115"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="119"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="109"/>
         <source>Remove selected file from the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="113"/>
         <source>Clear complete list of map files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="117"/>
         <source>Reload the currently selected map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -922,13 +896,11 @@ or
     <name>IItemTreeWidget</name>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="108"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="110"/>
         <source>Add map files to list</source>
         <translation type="unfinished"></translation>
     </message>
@@ -937,28 +909,21 @@ or
         <location filename="../items/IItemTreeWidget.ui" line="60"/>
         <location filename="../items/IItemTreeWidget.ui" line="77"/>
         <location filename="../items/IItemTreeWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="116"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="124"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="114"/>
         <source>Remove selected file from the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="118"/>
         <source>Clear complete list of map files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="122"/>
         <source>Reload the currently selected map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -967,107 +932,88 @@ or
     <name>IMainWindow</name>
     <message>
         <location filename="../IMainWindow.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="166"/>
         <source>MainWindow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="189"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="41"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="190"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="191"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="52"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="192"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="68"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="193"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="194"/>
         <source>Shell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="167"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="129"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="168"/>
         <source>Ext. Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="170"/>
         <source>Setup paths to external tools, like gdalwarp etc.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="144"/>
         <location filename="../IMainWindow.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="174"/>
         <source>Flip Mouse Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="156"/>
         <location filename="../IMainWindow.ui" line="159"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="178"/>
         <source>Setup Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="168"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="180"/>
         <source>Setup Coord. Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="171"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="182"/>
         <source>Change the format coordinates are displayed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="182"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="184"/>
         <source>Show Tool Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="185"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="194"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="187"/>
         <source>F1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1076,19 +1022,16 @@ or
     <name>IOverlayCutMap</name>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="142"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="144"/>
         <source>Just move the map and zoom.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="58"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="148"/>
         <source>Add point to mask.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1099,42 +1042,31 @@ or
         <location filename="../overlay/IOverlayCutMap.ui" line="137"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="158"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="170"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="152"/>
         <source>Move point of mask.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="156"/>
         <source>Remove point from mask.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="160"/>
         <source>Remove complete cut mask.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="164"/>
         <source>Load cut mask from shape file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="168"/>
         <source>Save cut mask to shape file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1143,13 +1075,11 @@ or
     <name>IOverlayGridTool</name>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="142"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="146"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,19 +1088,16 @@ or
     <name>IOverlayRefMap</name>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="241"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="244"/>
         <source>Just move the map and zoom.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="63"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="248"/>
         <source>Add reference point.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1185,106 +1112,81 @@ or
         <location filename="../overlay/IOverlayRefMap.ui" line="217"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="244"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="326"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="258"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="262"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="266"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="282"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="294"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="86"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="252"/>
         <source>Move reference point.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="256"/>
         <source>Remove single reference point.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="260"/>
         <source>Move reference points with auto mode. This will pickup the next point after you moved a reference point.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="264"/>
         <source>Remove all reference points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="268"/>
         <source>Switch to the Grid Tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="272"/>
         <source>Load reference points from GCP file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="214"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="276"/>
         <source>Save reference points into GCP file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="241"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="280"/>
         <source>Sort list of reference points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="285"/>
         <source>(x, y)[pixel]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="284"/>
         <source>(lat, lon)[°]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="286"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="304"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="287"/>
         <source>Final Map Projection:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="316"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="289"/>
         <source>Enter a valid projection string. Valid strings are &quot;+proj...&quot; or &quot;EPSG:...&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="323"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="292"/>
         <source>Start projection wizard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="343"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="242"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,67 +1195,56 @@ or
     <name>IProjWizard</name>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="191"/>
         <source>PROJ Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="29"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="192"/>
         <source>Mercator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="193"/>
         <source>UTM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="45"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="194"/>
         <source>zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="195"/>
         <source>user defined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="196"/>
         <source>Datum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="197"/>
         <source>World Mercator (OSM)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="124"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="198"/>
         <source>Result:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="138"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="200"/>
         <source>UPS North (North Pole)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="201"/>
         <source>UPS South (South Pole)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="152"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="202"/>
         <source>Projection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1362,7 +1253,6 @@ or
     <name>ISetupExtTools</name>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="244"/>
         <source>Setup Ext. Tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1373,12 +1263,6 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="173"/>
         <location filename="../setup/ISetupExtTools.ui" line="194"/>
         <location filename="../setup/ISetupExtTools.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="245"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="255"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="264"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="276"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="296"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;not found&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,11 +1272,6 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="180"/>
         <location filename="../setup/ISetupExtTools.ui" line="208"/>
         <location filename="../setup/ISetupExtTools.ui" line="222"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="247"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="268"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="284"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="288"/>
         <source>Setup user defined path.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1409,24 +1288,11 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="239"/>
         <location filename="../setup/ISetupExtTools.ui" line="264"/>
         <location filename="../setup/ISetupExtTools.ui" line="275"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="249"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="259"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="263"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="280"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="290"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="297"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="298"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="43"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="250"/>
         <source>gdalbuildvrt</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,47 +1302,36 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="85"/>
         <location filename="../setup/ISetupExtTools.ui" line="146"/>
         <location filename="../setup/ISetupExtTools.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="252"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="261"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="272"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="292"/>
         <source>Reset user defined path setup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="265"/>
         <source>gdal_translate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="125"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="266"/>
         <source>gdalwarp:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="275"/>
         <source>gdaladdo:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="201"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="282"/>
         <source>qmt_rgb2pct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="295"/>
         <source>qmt_map2jnx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="288"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="299"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; Usually QMapTool should detect all external tools by itself. If it does not, it&apos;s a bad setup and you should fix the PATH variable of your system. You can setup the paths manually, too, if you know what you are doing. But please keep in mind that GDAL needs a proper environment setup to function properly. If it&apos;s not setup properly you might get results but these can be off grid.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1340,36 @@ or
     <name>ITimeZoneSetup</name>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="150"/>
         <source>Setup Timezone ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="22"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="151"/>
         <source>UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="152"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="153"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="75"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="155"/>
         <source>Print date/time in </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="156"/>
         <source>long format, or</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="157"/>
         <source>short format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1530,97 +1378,81 @@ or
     <name>IToolAddOverview</name>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="204"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="205"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="206"/>
         <source>:2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="126"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="207"/>
         <source>:4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="208"/>
         <source>:8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="209"/>
         <source>:16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="210"/>
         <source>:32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="211"/>
         <source>:64</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="213"/>
         <source>Remove all overview levels from map file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="215"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="174"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="217"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="219"/>
         <source>Overview as external file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="207"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="220"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="221"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="221"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="232"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="222"/>
         <source>For all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1629,67 +1461,56 @@ or
     <name>IToolCutMap</name>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="203"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="204"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="114"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="205"/>
         <source>Output filename suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="206"/>
         <source>_cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="207"/>
         <source>Create overviews for result.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="208"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="183"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="209"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="210"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="208"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="211"/>
         <source>For all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="233"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="212"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="243"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="213"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1698,63 +1519,52 @@ or
     <name>IToolExport</name>
     <message>
         <location filename="../tool/IToolExport.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="173"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="59"/>
         <location filename="../tool/IToolExport.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="176"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="83"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="177"/>
         <source>Garmin BirdsEye (*.jnx)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="178"/>
         <source>TwoNav Raster (*.rmap)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="180"/>
         <source>not implemented yet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="181"/>
         <source>Target File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="130"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="182"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="183"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="173"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="184"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_map2jnx&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="174"/>
         <source>Target Filename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1763,95 +1573,78 @@ or
     <name>IToolExportJnx</name>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="180"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="35"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="181"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="186"/>
         <source>BirdsEye</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="182"/>
         <source>Product ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="183"/>
         <source>Copyright notice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="64"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="95"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="188"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="185"/>
         <source>Product name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="187"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="189"/>
         <source>JPEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="190"/>
         <source>Quality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="191"/>
         <source>Chroma subsampling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="192"/>
         <source>411</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="153"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="193"/>
         <source>422</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="194"/>
         <source>444</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="196"/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="197"/>
         <source>Z-Order</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1860,43 +1653,36 @@ or
     <name>IToolGDALGroupBox</name>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="167"/>
         <source>GroupBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="17"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="168"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="169"/>
         <source>Resampling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="170"/>
         <source>Compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="118"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="171"/>
         <source>Tiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="172"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="188"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="173"/>
         <source>Other:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1905,37 +1691,31 @@ or
     <name>IToolGrid</name>
     <message>
         <location filename="../tool/IToolGrid.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="130"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="56"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="132"/>
         <source>Grid Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="65"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="133"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="134"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="110"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="135"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="136"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1944,55 +1724,46 @@ or
     <name>IToolOverviewGroupBox</name>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="104"/>
         <source>GroupBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="105"/>
         <source>:2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="106"/>
         <source>:4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="85"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="107"/>
         <source>:8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="108"/>
         <source>:16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="109"/>
         <source>:32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="106"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="110"/>
         <source>:64</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="112"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="122"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="114"/>
         <source>Overview as external file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2001,87 +1772,72 @@ or
     <name>IToolPalettize</name>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="221"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="65"/>
         <location filename="../tool/IToolPalettize.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="223"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="224"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="96"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="225"/>
         <source>Single files, filename suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="226"/>
         <source>_8bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="123"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="227"/>
         <source>Combined file, filename:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="135"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="228"/>
         <source>Embed result into *.vrt file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="142"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="229"/>
         <source>Create overviews for result.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="149"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="230"/>
         <source>GDAL Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="231"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="232"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="220"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="233"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="230"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="234"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="240"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="235"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_rgb2pct&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="222"/>
         <source>Select filename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2090,79 +1846,66 @@ or
     <name>IToolRefMap</name>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="212"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="213"/>
         <source>do not translate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="113"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="214"/>
         <source>Output filename suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="215"/>
         <source>_ref</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="216"/>
         <source>Embed result into *.vrt file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="151"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="217"/>
         <source>Create overviews for result.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="218"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="186"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="219"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="200"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="220"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="211"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="221"/>
         <source>For all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="222"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="246"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="256"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="224"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2190,31 +1933,26 @@ or
     <name>IUnitsSetup</name>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="103"/>
         <source>Setup units...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="104"/>
         <source>Nautical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="105"/>
         <source>Imperial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="106"/>
         <source>Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_it.ts
+++ b/src/qmaptool/locale/qmaptool_it.ts
@@ -299,6 +299,24 @@
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -674,13 +692,11 @@ Annullato su richiesta dell&apos;utente.
     <name>IAbout</name>
     <message>
         <location filename="../IAbout.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="162"/>
         <source>About...</source>
         <translation>Ringraziamenti...</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="26"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="163"/>
         <source>&lt;b&gt;QMapTool&lt;/b&gt;, Version</source>
         <translation>&lt;b&gt;QMapTool&lt;/b&gt;, Versione</translation>
     </message>
@@ -689,40 +705,31 @@ Annullato su richiesta dell&apos;utente.
         <location filename="../IAbout.ui" line="77"/>
         <location filename="../IAbout.ui" line="91"/>
         <location filename="../IAbout.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="171"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="70"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="166"/>
         <source>Qt</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="168"/>
         <source>GDAL</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="98"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="170"/>
         <source>PROJ</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="121"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="172"/>
         <source>This software is licensed under GPL3 or any later version</source>
         <translation>Questo software è concesso in licenza in GPL3 o versioni successive</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="128"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="173"/>
         <source>© 2017 Oliver Eichler (oliver.eichler@gmx.de)</source>
         <translation></translation>
     </message>
@@ -731,31 +738,26 @@ Annullato su richiesta dell&apos;utente.
     <name>ICoordFormatSetup</name>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="103"/>
         <source>Coordinate Format...</source>
         <translation>Formato coordinate...</translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="104"/>
         <source>N48° 53&apos; 39.6&quot; E13° 31&apos; 6.78&quot;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="105"/>
         <source>N48.8943° E013.51855°</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="106"/>
         <source>N48° 53.660 E013° 31.113</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Nota:&lt;/b&gt; Per alcuni elementi della GUI la modifica delle unità non avrà effetto fino al riavvio di QMapTool.</translation>
     </message>
@@ -764,37 +766,31 @@ Annullato su richiesta dell&apos;utente.
     <name>IDialogRefPoint</name>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="115"/>
         <source>Dialog</source>
         <translation>Dialogo</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="25"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="116"/>
         <source>Coord. Map File [pixel]</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="117"/>
         <source>x</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="118"/>
         <source>y</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="49"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="119"/>
         <source>Coord. lat/lon WGS84 [°]</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="120"/>
         <source>Bad position format. Must be: 
 &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot;
 or
@@ -809,19 +805,16 @@ o
     <name>IGridPlacer</name>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="190"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="198"/>
         <source>Reset</source>
         <translation>Reset</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="224"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="204"/>
         <source>Set Area</source>
         <translation>Imposta area</translation>
     </message>
@@ -830,13 +823,11 @@ o
     <name>IGridSelArea</name>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="50"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="51"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
@@ -845,49 +836,41 @@ o
     <name>IGridSetRef</name>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="135"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="136"/>
         <source>Grid Projection:</source>
         <translation>Proiezione della griglia:</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="137"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="60"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="138"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="139"/>
         <source>Easting</source>
         <translation>Verso est</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="140"/>
         <source>Horiz. Spacing</source>
         <translation>Spazio orizzontale</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="141"/>
         <source>Northing</source>
         <translation>Verso nord</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="102"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="142"/>
         <source>Vert. Spacing</source>
         <translation>Spazio verticale</translation>
     </message>
@@ -896,13 +879,11 @@ o
     <name>IItemListWidget</name>
     <message>
         <location filename="../items/IItemListWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="103"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="105"/>
         <source>Add map files to list</source>
         <translation>Aggiungi i file della mappa all&apos;elenco</translation>
     </message>
@@ -911,28 +892,21 @@ o
         <location filename="../items/IItemListWidget.ui" line="60"/>
         <location filename="../items/IItemListWidget.ui" line="77"/>
         <location filename="../items/IItemListWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="107"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="111"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="115"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="119"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="109"/>
         <source>Remove selected file from the list.</source>
         <translation>Rimuovi il file selezionato dall&apos;elenco.</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="113"/>
         <source>Clear complete list of map files.</source>
         <translation>Cancella l&apos;elenco completo dei file della mappa.</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="117"/>
         <source>Reload the currently selected map.</source>
         <translation>Ricarica la mappa attualmente selezionata.</translation>
     </message>
@@ -941,13 +915,11 @@ o
     <name>IItemTreeWidget</name>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="108"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="110"/>
         <source>Add map files to list</source>
         <translation>Aggiungi i file della mappa all&apos;elenco</translation>
     </message>
@@ -956,28 +928,21 @@ o
         <location filename="../items/IItemTreeWidget.ui" line="60"/>
         <location filename="../items/IItemTreeWidget.ui" line="77"/>
         <location filename="../items/IItemTreeWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="116"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="124"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="114"/>
         <source>Remove selected file from the list.</source>
         <translation>Rimuovi il file selezionato dall&apos;elenco.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="118"/>
         <source>Clear complete list of map files.</source>
         <translation>Cancella l&apos;elenco completo dei file della mappa.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="122"/>
         <source>Reload the currently selected map.</source>
         <translation>Ricarica la mappa attualmente selezionata.</translation>
     </message>
@@ -986,107 +951,88 @@ o
     <name>IMainWindow</name>
     <message>
         <location filename="../IMainWindow.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="166"/>
         <source>MainWindow</source>
         <translation>MainWindow</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="189"/>
         <source>Setup</source>
         <translation>Setup</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="41"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="190"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="191"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="52"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="192"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="68"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="193"/>
         <source>Tools</source>
         <translation>Strumenti</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="194"/>
         <source>Shell</source>
         <translation>Shell</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="167"/>
         <source>About</source>
         <translation>About</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="129"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="168"/>
         <source>Ext. Tools</source>
         <translation>Strum. esterni</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="170"/>
         <source>Setup paths to external tools, like gdalwarp etc.</source>
         <translation>Percorsi di installazione per strumenti esterni, come gdalwarp ecc.</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="144"/>
         <location filename="../IMainWindow.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="174"/>
         <source>Flip Mouse Wheel</source>
         <translation>Gira la rotellina del mouse</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="156"/>
         <location filename="../IMainWindow.ui" line="159"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="178"/>
         <source>Setup Units</source>
         <translation>Unità di installazione</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="168"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="180"/>
         <source>Setup Coord. Format</source>
         <translation>Imposta formato coordinate</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="171"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="182"/>
         <source>Change the format coordinates are displayed</source>
         <translation>Modifica le coordinate nel formato come vengono visualizzate</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="182"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="184"/>
         <source>Show Tool Help</source>
         <translation>Mostra l&apos;aiuto</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="185"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="194"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="187"/>
         <source>F1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1095,19 +1041,16 @@ o
     <name>IOverlayCutMap</name>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="142"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="144"/>
         <source>Just move the map and zoom.</source>
         <translation>Basta spostare la mappa e ingrandire.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="58"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="148"/>
         <source>Add point to mask.</source>
         <translation>Aggiungi un punto alla maschera.</translation>
     </message>
@@ -1118,42 +1061,31 @@ o
         <location filename="../overlay/IOverlayCutMap.ui" line="137"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="158"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="170"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="152"/>
         <source>Move point of mask.</source>
         <translation>Sposta il punto della maschera.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="156"/>
         <source>Remove point from mask.</source>
         <translation>Rimuovere il punto dalla maschera.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="160"/>
         <source>Remove complete cut mask.</source>
         <translation>Rimuovere la maschera di taglio completa.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="164"/>
         <source>Load cut mask from shape file.</source>
         <translation>Carica la maschera tagliata da un shape file.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="168"/>
         <source>Save cut mask to shape file.</source>
         <translation>Salva la maschera come shape file.</translation>
     </message>
@@ -1162,13 +1094,11 @@ o
     <name>IOverlayGridTool</name>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="142"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="146"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
@@ -1177,19 +1107,16 @@ o
     <name>IOverlayRefMap</name>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="241"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="244"/>
         <source>Just move the map and zoom.</source>
         <translation>Basta spostare la mappa e ingrandire.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="63"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="248"/>
         <source>Add reference point.</source>
         <translation>Aggiungi punto di riferimento.</translation>
     </message>
@@ -1204,106 +1131,81 @@ o
         <location filename="../overlay/IOverlayRefMap.ui" line="217"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="244"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="326"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="258"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="262"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="266"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="282"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="294"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="86"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="252"/>
         <source>Move reference point.</source>
         <translation>Muovi il punto di riferimento.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="256"/>
         <source>Remove single reference point.</source>
         <translation>Rimuovi singolo punto di riferimento.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="260"/>
         <source>Move reference points with auto mode. This will pickup the next point after you moved a reference point.</source>
         <translation>Sposta i punti di riferimento con la modalità automatica. Questo riprenderà il punto successivo dopo aver spostato un punto di riferimento.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="264"/>
         <source>Remove all reference points.</source>
         <translation>Cancella tutti i punti di riferimento.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="268"/>
         <source>Switch to the Grid Tool.</source>
         <translation>Passa allo strumento griglia.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="272"/>
         <source>Load reference points from GCP file.</source>
         <translation>Carica punti di riferimento dal file GCP.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="214"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="276"/>
         <source>Save reference points into GCP file.</source>
         <translation>Salva i punti di riferimento nel file GCP.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="241"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="280"/>
         <source>Sort list of reference points.</source>
         <translation>Ordina l&apos;elenco dei punti di riferimento.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="285"/>
         <source>(x, y)[pixel]</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="284"/>
         <source>(lat, lon)[°]</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="286"/>
         <source>TextLabel</source>
         <translation>Testo</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="304"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="287"/>
         <source>Final Map Projection:</source>
         <translation>Proiezione finale della mappa:</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="316"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="289"/>
         <source>Enter a valid projection string. Valid strings are &quot;+proj...&quot; or &quot;EPSG:...&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="323"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="292"/>
         <source>Start projection wizard.</source>
         <translation>Avvia la procedura guidata di proiezione.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="343"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="242"/>
         <source>Delete</source>
         <translation>Cancella</translation>
     </message>
@@ -1312,67 +1214,56 @@ o
     <name>IProjWizard</name>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="191"/>
         <source>PROJ Wizard</source>
         <translation>Procedura guidata PROJ</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="29"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="192"/>
         <source>Mercator</source>
         <translation>Mercatore</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="193"/>
         <source>UTM</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="45"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="194"/>
         <source>zone</source>
         <translation>zona</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="195"/>
         <source>user defined</source>
         <translation>Definito dall&apos;utente</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="196"/>
         <source>Datum</source>
         <translation>Datum</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="197"/>
         <source>World Mercator (OSM)</source>
         <translation>World Mercator (OSM)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="124"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="198"/>
         <source>Result:</source>
         <translation>Risultato:</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="138"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="200"/>
         <source>UPS North (North Pole)</source>
         <translation>UPS Nord (Polo Nord)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="201"/>
         <source>UPS South (South Pole)</source>
         <translation>UPS Sud (Polo Sud)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="152"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="202"/>
         <source>Projection</source>
         <translation>Proiezione</translation>
     </message>
@@ -1381,7 +1272,6 @@ o
     <name>ISetupExtTools</name>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="244"/>
         <source>Setup Ext. Tools</source>
         <translation>Setup strumenti esterni</translation>
     </message>
@@ -1392,12 +1282,6 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="173"/>
         <location filename="../setup/ISetupExtTools.ui" line="194"/>
         <location filename="../setup/ISetupExtTools.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="245"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="255"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="264"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="276"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="296"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;not found&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;non trovato&lt;/b&gt;</translation>
     </message>
@@ -1414,42 +1298,26 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="239"/>
         <location filename="../setup/ISetupExtTools.ui" line="264"/>
         <location filename="../setup/ISetupExtTools.ui" line="275"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="249"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="259"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="263"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="280"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="290"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="297"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="298"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="265"/>
         <source>gdal_translate:</source>
         <translation>gdal_translate:</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="43"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="250"/>
         <source>gdalbuildvrt</source>
         <translation>gdalbuildvrt:</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="275"/>
         <source>gdaladdo:</source>
         <translation>gdaladdo:</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="125"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="266"/>
         <source>gdalwarp:</source>
         <translation></translation>
     </message>
@@ -1459,17 +1327,11 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="180"/>
         <location filename="../setup/ISetupExtTools.ui" line="208"/>
         <location filename="../setup/ISetupExtTools.ui" line="222"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="247"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="268"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="284"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="288"/>
         <source>Setup user defined path.</source>
         <translation>Imposta il percorso.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="201"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="282"/>
         <source>qmt_rgb2pct</source>
         <translation>qmt_rgb2pct:</translation>
     </message>
@@ -1479,23 +1341,16 @@ o
         <location filename="../setup/ISetupExtTools.ui" line="85"/>
         <location filename="../setup/ISetupExtTools.ui" line="146"/>
         <location filename="../setup/ISetupExtTools.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="252"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="261"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="272"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="292"/>
         <source>Reset user defined path setup.</source>
         <translation>Reset percorso.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="295"/>
         <source>qmt_map2jnx</source>
         <translation>qmt_map2jnx:</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="288"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="299"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; Usually QMapTool should detect all external tools by itself. If it does not, it&apos;s a bad setup and you should fix the PATH variable of your system. You can setup the paths manually, too, if you know what you are doing. But please keep in mind that GDAL needs a proper environment setup to function properly. If it&apos;s not setup properly you might get results but these can be off grid.</source>
         <translation>&lt;b&gt;Nota:&lt;/b&gt; Di solito QMapTool dovrebbe rilevare tutti gli strumenti esterni da solo. In caso contrario, è una configurazione errata e dovresti correggere la variabile PATH del tuo sistema. Puoi anche impostare i percorsi manualmente, se sai cosa stai facendo. Ma tieni presente che GDAL ha bisogno di una corretta configurazione dell&apos;ambiente per funzionare correttamente. Se non è configurato correttamente, potresti ottenere dei risultati ma questi possono essere inutili.</translation>
     </message>
@@ -1504,43 +1359,36 @@ o
     <name>ITimeZoneSetup</name>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="150"/>
         <source>Setup Timezone ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="22"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="151"/>
         <source>UTC</source>
         <translation>UTC</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="152"/>
         <source>Local</source>
         <translation>Locale</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="153"/>
         <source>Automatic</source>
         <translation>Automatico</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="75"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="155"/>
         <source>Print date/time in </source>
         <translation>Stampo data/ora in </translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="156"/>
         <source>long format, or</source>
         <translation>Formato lungo</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="157"/>
         <source>short format</source>
         <translation>Formato breve</translation>
     </message>
@@ -1549,97 +1397,81 @@ o
     <name>IToolAddOverview</name>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="204"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="205"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="206"/>
         <source>:2</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="126"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="207"/>
         <source>:4</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="208"/>
         <source>:8</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="209"/>
         <source>:16</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="210"/>
         <source>:32</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="211"/>
         <source>:64</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="213"/>
         <source>Remove all overview levels from map file.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="215"/>
         <source>Remove</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="174"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="217"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="219"/>
         <source>Overview as external file</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="207"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="220"/>
         <source>Start</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="221"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="221"/>
         <source>Cancel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="232"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="222"/>
         <source>For all files</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
@@ -1648,67 +1480,56 @@ o
     <name>IToolCutMap</name>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="203"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="204"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="114"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="205"/>
         <source>Output filename suffix</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="206"/>
         <source>_cut</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="207"/>
         <source>Create overviews for result.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="208"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="183"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="209"/>
         <source>Start</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="210"/>
         <source>Cancel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="208"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="211"/>
         <source>For all files</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="233"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="212"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="243"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="213"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
@@ -1717,63 +1538,52 @@ o
     <name>IToolExport</name>
     <message>
         <location filename="../tool/IToolExport.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="173"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="59"/>
         <location filename="../tool/IToolExport.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="176"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="83"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="177"/>
         <source>Garmin BirdsEye (*.jnx)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="178"/>
         <source>TwoNav Raster (*.rmap)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="180"/>
         <source>not implemented yet</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="181"/>
         <source>Target File</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="130"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="182"/>
         <source>Start</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="183"/>
         <source>Cancel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="173"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="184"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_map2jnx&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="174"/>
         <source>Target Filename</source>
         <translation></translation>
     </message>
@@ -1782,95 +1592,78 @@ o
     <name>IToolExportJnx</name>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="180"/>
         <source>Form</source>
         <translation>Scheda</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="35"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="181"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="186"/>
         <source>BirdsEye</source>
         <translation>BirdsEye</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="182"/>
         <source>Product ID</source>
         <translation>Product ID</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="183"/>
         <source>Copyright notice</source>
         <translation>Copyright notice</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="64"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="95"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="188"/>
         <source>None</source>
         <translation>None</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="185"/>
         <source>Product name</source>
         <translation>Product name</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="187"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="189"/>
         <source>JPEG</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="190"/>
         <source>Quality</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="191"/>
         <source>Chroma subsampling</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="192"/>
         <source>411</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="153"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="193"/>
         <source>422</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="194"/>
         <source>444</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="196"/>
         <source>Device</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="197"/>
         <source>Z-Order</source>
         <translation></translation>
     </message>
@@ -1879,43 +1672,36 @@ o
     <name>IToolGDALGroupBox</name>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="167"/>
         <source>GroupBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="17"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="168"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="169"/>
         <source>Resampling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="170"/>
         <source>Compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="118"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="171"/>
         <source>Tiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="172"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="188"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="173"/>
         <source>Other:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1924,37 +1710,31 @@ o
     <name>IToolGrid</name>
     <message>
         <location filename="../tool/IToolGrid.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="130"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="56"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="132"/>
         <source>Grid Tool</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="65"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="133"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="134"/>
         <source>Ok</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="110"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="135"/>
         <source>Cancel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="136"/>
         <source>Reset</source>
         <translation></translation>
     </message>
@@ -1963,55 +1743,46 @@ o
     <name>IToolOverviewGroupBox</name>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="104"/>
         <source>GroupBox</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="105"/>
         <source>:2</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="106"/>
         <source>:4</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="85"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="107"/>
         <source>:8</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="108"/>
         <source>:16</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="109"/>
         <source>:32</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="106"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="110"/>
         <source>:64</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="112"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="122"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="114"/>
         <source>Overview as external file</source>
         <translation></translation>
     </message>
@@ -2020,87 +1791,72 @@ o
     <name>IToolPalettize</name>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="221"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="65"/>
         <location filename="../tool/IToolPalettize.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="223"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="224"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="96"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="225"/>
         <source>Single files, filename suffix</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="226"/>
         <source>_8bit</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="123"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="227"/>
         <source>Combined file, filename:</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="135"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="228"/>
         <source>Embed result into *.vrt file.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="142"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="229"/>
         <source>Create overviews for result.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="149"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="230"/>
         <source>GDAL Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="231"/>
         <source>Start</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="232"/>
         <source>Cancel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="220"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="233"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="230"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="234"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="240"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="235"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_rgb2pct&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="222"/>
         <source>Select filename</source>
         <translation></translation>
     </message>
@@ -2109,79 +1865,66 @@ o
     <name>IToolRefMap</name>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="212"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="213"/>
         <source>do not translate</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="113"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="214"/>
         <source>Output filename suffix</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="215"/>
         <source>_ref</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="216"/>
         <source>Embed result into *.vrt file.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="151"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="217"/>
         <source>Create overviews for result.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="218"/>
         <source>GDAL Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="186"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="219"/>
         <source>Start</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="200"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="220"/>
         <source>Cancel</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="211"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="221"/>
         <source>For all files</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="222"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="246"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="256"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="224"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation></translation>
     </message>
@@ -2209,31 +1952,26 @@ o
     <name>IUnitsSetup</name>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="103"/>
         <source>Setup units...</source>
         <translation>Imposta unità...</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="104"/>
         <source>Nautical</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="105"/>
         <source>Imperial</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="106"/>
         <source>Metric</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Nota:&lt;/b&gt; Per alcuni elementi della GUI la modifica delle unità non avrà effetto fino al riavvio di QMapTool.</translation>
     </message>

--- a/src/qmaptool/locale/qmaptool_ru.ts
+++ b/src/qmaptool/locale/qmaptool_ru.ts
@@ -299,6 +299,24 @@
     </message>
 </context>
 <context>
+    <name>CHelpBrowser</name>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="55"/>
+        <source>Go back one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="59"/>
+        <source>Go forward one page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../common/help/CHelpBrowser.cpp" line="63"/>
+        <source>Go to initial page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CHelpIndex</name>
     <message>
         <location filename="../../common/help/CHelpIndex.cpp" line="26"/>
@@ -675,13 +693,11 @@ Canceled by user&apos;s request.
     <name>IAbout</name>
     <message>
         <location filename="../IAbout.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="162"/>
         <source>About...</source>
         <translation>О программе....</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="26"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="163"/>
         <source>&lt;b&gt;QMapTool&lt;/b&gt;, Version</source>
         <translation>&lt;b&gt;QMapTool&lt;/b&gt;, версия</translation>
     </message>
@@ -690,40 +706,31 @@ Canceled by user&apos;s request.
         <location filename="../IAbout.ui" line="77"/>
         <location filename="../IAbout.ui" line="91"/>
         <location filename="../IAbout.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="171"/>
         <source>TextLabel</source>
         <translation>Метка текста</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="70"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="166"/>
         <source>Qt</source>
         <translation>Qt</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="168"/>
         <source>GDAL</source>
         <translation>GDAL</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="98"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="170"/>
         <source>PROJ</source>
         <translation>PROJ</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="121"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="172"/>
         <source>This software is licensed under GPL3 or any later version</source>
         <translation>Это программное обеспечение лицензировано под GPL3 или любой более поздней версией</translation>
     </message>
     <message>
         <location filename="../IAbout.ui" line="128"/>
-        <location filename="../../../build/src/qmaptool/ui_IAbout.h" line="173"/>
         <source>© 2017 Oliver Eichler (oliver.eichler@gmx.de)</source>
         <translation>© 2017 Oliver Eichler (oliver.eichler@gmx.de)</translation>
     </message>
@@ -732,31 +739,26 @@ Canceled by user&apos;s request.
     <name>ICoordFormatSetup</name>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="103"/>
         <source>Coordinate Format...</source>
         <translation>Формат координат ...</translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="104"/>
         <source>N48° 53&apos; 39.6&quot; E13° 31&apos; 6.78&quot;</source>
         <translation>N48° 53&apos; 39.6&quot; E13° 31&apos; 6.78&quot;</translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="105"/>
         <source>N48.8943° E013.51855°</source>
         <translation>N48.8943° E013.51855°</translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="106"/>
         <source>N48° 53.660 E013° 31.113</source>
         <translation>N48° 53.660 E013° 31.113</translation>
     </message>
     <message>
         <location filename="../units/ICoordFormatSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_ICoordFormatSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Примечание:&lt;/b&gt; Изменение единиц для некоторых элементов графического пользовательского интерфейса вступят в силу только после перезапуска QMapTool.</translation>
     </message>
@@ -765,37 +767,31 @@ Canceled by user&apos;s request.
     <name>IDialogRefPoint</name>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="115"/>
         <source>Dialog</source>
         <translation>Диалог</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="25"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="116"/>
         <source>Coord. Map File [pixel]</source>
         <translation>Координаты файла карты [пиксель]</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="117"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="118"/>
         <source>y</source>
         <translation>y</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="49"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="119"/>
         <source>Coord. lat/lon WGS84 [°]</source>
         <translation>Координаты широта / долгота WGS84 [°]</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IDialogRefPoint.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IDialogRefPoint.h" line="120"/>
         <source>Bad position format. Must be: 
 &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot;
 or
@@ -810,19 +806,16 @@ or
     <name>IGridPlacer</name>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="190"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="198"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridPlacer.ui" line="224"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridPlacer.h" line="204"/>
         <source>Set Area</source>
         <translation>Установка области</translation>
     </message>
@@ -831,13 +824,11 @@ or
     <name>IGridSelArea</name>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="50"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSelArea.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSelArea.h" line="51"/>
         <source>TextLabel</source>
         <translation>Метка текста</translation>
     </message>
@@ -846,49 +837,41 @@ or
     <name>IGridSetRef</name>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="135"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="136"/>
         <source>Grid Projection:</source>
         <translation>Проекция сетки:</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="137"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="60"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="138"/>
         <source>TextLabel</source>
         <translation>Метка текста</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="139"/>
         <source>Easting</source>
         <translation>Восточная координата</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="140"/>
         <source>Horiz. Spacing</source>
         <translation>Горизонтальное расстояние</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="141"/>
         <source>Northing</source>
         <translation>Северная координата</translation>
     </message>
     <message>
         <location filename="../overlay/gridtool/IGridSetRef.ui" line="102"/>
-        <location filename="../../../build/src/qmaptool/ui_IGridSetRef.h" line="142"/>
         <source>Vert. Spacing</source>
         <translation>Вертикальное расстояние</translation>
     </message>
@@ -897,13 +880,11 @@ or
     <name>IItemListWidget</name>
     <message>
         <location filename="../items/IItemListWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="103"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="105"/>
         <source>Add map files to list</source>
         <translation>Добавить файлы карт в список</translation>
     </message>
@@ -912,28 +893,21 @@ or
         <location filename="../items/IItemListWidget.ui" line="60"/>
         <location filename="../items/IItemListWidget.ui" line="77"/>
         <location filename="../items/IItemListWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="107"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="111"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="115"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="119"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="109"/>
         <source>Remove selected file from the list.</source>
         <translation>Удалить выбранный файл из списка.</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="113"/>
         <source>Clear complete list of map files.</source>
         <translation>Удалить все файлы карты.</translation>
     </message>
     <message>
         <location filename="../items/IItemListWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemListWidget.h" line="117"/>
         <source>Reload the currently selected map.</source>
         <translation>Перезагрузить выбранную карту.</translation>
     </message>
@@ -942,13 +916,11 @@ or
     <name>IItemTreeWidget</name>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="108"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="110"/>
         <source>Add map files to list</source>
         <translation>Добавить файлы карт в список</translation>
     </message>
@@ -957,28 +929,21 @@ or
         <location filename="../items/IItemTreeWidget.ui" line="60"/>
         <location filename="../items/IItemTreeWidget.ui" line="77"/>
         <location filename="../items/IItemTreeWidget.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="116"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="124"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="114"/>
         <source>Remove selected file from the list.</source>
         <translation>Удалить выбранный файл из списка.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="74"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="118"/>
         <source>Clear complete list of map files.</source>
         <translation>Удалить все файлы карты.</translation>
     </message>
     <message>
         <location filename="../items/IItemTreeWidget.ui" line="91"/>
-        <location filename="../../../build/src/qmaptool/ui_IItemTreeWidget.h" line="122"/>
         <source>Reload the currently selected map.</source>
         <translation>Перезагрузить выбранную карту.</translation>
     </message>
@@ -987,107 +952,88 @@ or
     <name>IMainWindow</name>
     <message>
         <location filename="../IMainWindow.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="166"/>
         <source>MainWindow</source>
         <translation>MainWindow</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="189"/>
         <source>Setup</source>
         <translation>Настройка</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="41"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="190"/>
         <source>View</source>
         <translation>Вид</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="47"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="191"/>
         <source>Window</source>
         <translation>Окно</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="52"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="192"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="68"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="193"/>
         <source>Tools</source>
         <translation>Инструменты</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="194"/>
         <source>Shell</source>
         <translation>Оболочка</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="120"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="167"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="129"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="168"/>
         <source>Ext. Tools</source>
         <translation>Настройка внешних инструментов</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="170"/>
         <source>Setup paths to external tools, like gdalwarp etc.</source>
         <translation>Настройка путей к внешним инструментам, таким как gdalwarp и т.д.</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="144"/>
         <location filename="../IMainWindow.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="174"/>
         <source>Flip Mouse Wheel</source>
         <translation>Флип колесо мышки</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="156"/>
         <location filename="../IMainWindow.ui" line="159"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="178"/>
         <source>Setup Units</source>
         <translation>Настройка единиц</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="168"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="180"/>
         <source>Setup Coord. Format</source>
         <translation>Настройка формата координат</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="171"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="182"/>
         <source>Change the format coordinates are displayed</source>
         <translation>Изменить формат отображения координат</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="182"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="184"/>
         <source>Show Tool Help</source>
         <translation>Показать справку по инструменту</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="185"/>
         <source>Help</source>
         <translation>Справки</translation>
     </message>
     <message>
         <location filename="../IMainWindow.ui" line="194"/>
-        <location filename="../../../build/src/qmaptool/ui_IMainWindow.h" line="187"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
@@ -1096,19 +1042,16 @@ or
     <name>IOverlayCutMap</name>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="142"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="35"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="144"/>
         <source>Just move the map and zoom.</source>
         <translation>Переместить карту и увеличить масштаб.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="58"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="148"/>
         <source>Add point to mask.</source>
         <translation>Добавить точку к маске.</translation>
     </message>
@@ -1119,42 +1062,31 @@ or
         <location filename="../overlay/IOverlayCutMap.ui" line="137"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="158"/>
         <location filename="../overlay/IOverlayCutMap.ui" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="150"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="170"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="152"/>
         <source>Move point of mask.</source>
         <translation>Переместить точку маски.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="156"/>
         <source>Remove point from mask.</source>
         <translation>Удалить точку из маски.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="160"/>
         <source>Remove complete cut mask.</source>
         <translation>Удалить полностью вырезанную маску.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="164"/>
         <source>Load cut mask from shape file.</source>
         <translation>Загрузить маску вырезания из файла фигуры.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayCutMap.ui" line="172"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayCutMap.h" line="168"/>
         <source>Save cut mask to shape file.</source>
         <translation>Сохранить маску вырезания файл фигуры.</translation>
     </message>
@@ -1163,13 +1095,11 @@ or
     <name>IOverlayGridTool</name>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="142"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayGridTool.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayGridTool.h" line="146"/>
         <source>do not translate</source>
         <translation>do not translate</translation>
     </message>
@@ -1178,19 +1108,16 @@ or
     <name>IOverlayRefMap</name>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="241"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="40"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="244"/>
         <source>Just move the map and zoom.</source>
         <translation>Переместить карту и увеличить масштаб.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="63"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="248"/>
         <source>Add reference point.</source>
         <translation>Добавить опорную точку.</translation>
     </message>
@@ -1205,106 +1132,81 @@ or
         <location filename="../overlay/IOverlayRefMap.ui" line="217"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="244"/>
         <location filename="../overlay/IOverlayRefMap.ui" line="326"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="258"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="262"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="266"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="282"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="294"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="86"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="252"/>
         <source>Move reference point.</source>
         <translation>Переместить опорную точку.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="256"/>
         <source>Remove single reference point.</source>
         <translation>Удалить опорную точку.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="260"/>
         <source>Move reference points with auto mode. This will pickup the next point after you moved a reference point.</source>
         <translation>Переместить опорные точки в автоматическом режиме. Это заберет следующую точку после перемещения опорной точки.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="162"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="264"/>
         <source>Remove all reference points.</source>
         <translation>Удалить все опорные точки.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="176"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="268"/>
         <source>Switch to the Grid Tool.</source>
         <translation>Переключить на инструмент сетки.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="272"/>
         <source>Load reference points from GCP file.</source>
         <translation>Загрузить опорные точки из файла GCP.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="214"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="276"/>
         <source>Save reference points into GCP file.</source>
         <translation>Сохранить опорные точки в файл GCP.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="241"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="280"/>
         <source>Sort list of reference points.</source>
         <translation>Сортировать список опорных точек.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="285"/>
         <source>(x, y)[pixel]</source>
         <translation>(х, у) [пиксель]</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="284"/>
         <source>(lat, lon)[°]</source>
         <translation>(широта, долгота) [°]</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="286"/>
         <source>TextLabel</source>
         <translation>Метка текста</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="304"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="287"/>
         <source>Final Map Projection:</source>
         <translation>Окончательная проекция карты:</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="316"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="289"/>
         <source>Enter a valid projection string. Valid strings are &quot;+proj...&quot; or &quot;EPSG:...&quot;.</source>
         <translation>Введите допустимую строку проекции. Допустимыми строками являются &quot;+proj...&quot; или &quot;EPSG:...&quot;.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="323"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="292"/>
         <source>Start projection wizard.</source>
         <translation>Запустите мастер проецирования.</translation>
     </message>
     <message>
         <location filename="../overlay/IOverlayRefMap.ui" line="343"/>
-        <location filename="../../../build/src/qmaptool/ui_IOverlayRefMap.h" line="242"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -1313,67 +1215,56 @@ or
     <name>IProjWizard</name>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="191"/>
         <source>PROJ Wizard</source>
         <translation>PROJ мастер</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="29"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="192"/>
         <source>Mercator</source>
         <translation>Меркатор</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="193"/>
         <source>UTM</source>
         <translation>UTM</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="45"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="194"/>
         <source>zone</source>
         <translation>Зона</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="195"/>
         <source>user defined</source>
         <translation>Задание пользователя</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="94"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="196"/>
         <source>Datum</source>
         <translation>Датум</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="104"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="197"/>
         <source>World Mercator (OSM)</source>
         <translation>World Mercator(OSM)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="124"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="198"/>
         <source>Result:</source>
         <translation>Результат:</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="138"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="200"/>
         <source>UPS North (North Pole)</source>
         <translation>UPS Север (Северный полюс)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="145"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="201"/>
         <source>UPS South (South Pole)</source>
         <translation>UPS Юг (Южный полюс)</translation>
     </message>
     <message>
         <location filename="../overlay/refmap/IProjWizard.ui" line="152"/>
-        <location filename="../../../build/src/qmaptool/ui_IProjWizard.h" line="202"/>
         <source>Projection</source>
         <translation>Проекция</translation>
     </message>
@@ -1382,7 +1273,6 @@ or
     <name>ISetupExtTools</name>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="244"/>
         <source>Setup Ext. Tools</source>
         <translation>Настройка внешних инструментов</translation>
     </message>
@@ -1393,12 +1283,6 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="173"/>
         <location filename="../setup/ISetupExtTools.ui" line="194"/>
         <location filename="../setup/ISetupExtTools.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="245"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="255"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="264"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="276"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="281"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="296"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;not found&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;не найдено&lt;/b&gt;</translation>
     </message>
@@ -1415,42 +1299,26 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="239"/>
         <location filename="../setup/ISetupExtTools.ui" line="264"/>
         <location filename="../setup/ISetupExtTools.ui" line="275"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="249"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="259"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="263"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="270"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="274"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="280"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="286"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="290"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="294"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="297"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="298"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="265"/>
         <source>gdal_translate:</source>
         <translation>gdal_translate:</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="43"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="250"/>
         <source>gdalbuildvrt</source>
         <translation>gdalbuildvrt</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="166"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="275"/>
         <source>gdaladdo:</source>
         <translation>gdaladdo:</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="125"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="266"/>
         <source>gdalwarp:</source>
         <translation>gdalwarp:</translation>
     </message>
@@ -1460,17 +1328,11 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="180"/>
         <location filename="../setup/ISetupExtTools.ui" line="208"/>
         <location filename="../setup/ISetupExtTools.ui" line="222"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="247"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="268"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="278"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="284"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="288"/>
         <source>Setup user defined path.</source>
         <translation>Настроить пользовательский путь.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="201"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="282"/>
         <source>qmt_rgb2pct</source>
         <translation>qmt_rgb2pct</translation>
     </message>
@@ -1480,23 +1342,16 @@ or
         <location filename="../setup/ISetupExtTools.ui" line="85"/>
         <location filename="../setup/ISetupExtTools.ui" line="146"/>
         <location filename="../setup/ISetupExtTools.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="252"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="261"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="272"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="292"/>
         <source>Reset user defined path setup.</source>
         <translation>Сбросить настройку пользовательского пути.</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="250"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="295"/>
         <source>qmt_map2jnx</source>
         <translation>qmt_map2jnx</translation>
     </message>
     <message>
         <location filename="../setup/ISetupExtTools.ui" line="288"/>
-        <location filename="../../../build/src/qmaptool/ui_ISetupExtTools.h" line="299"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; Usually QMapTool should detect all external tools by itself. If it does not, it&apos;s a bad setup and you should fix the PATH variable of your system. You can setup the paths manually, too, if you know what you are doing. But please keep in mind that GDAL needs a proper environment setup to function properly. If it&apos;s not setup properly you might get results but these can be off grid.</source>
         <translation>&lt;b&gt;Примечание:&lt;/b&gt; Обычно QMapTool должен находить все внешние инструменты самостоятельно. Если нет,, то обычно это связано с плохой настройкой, и вы должны проверить переменную PATH вашей системы. Вы также можете установить пути инструментов самостоятельно, при условии, что вы знаете, что делаете. Пожалуйста, имейте в виду, что GDAL нуждается в правильно настроенной среде для корректной работы. Если это не так, результаты могут быть достигнуты, но они могут быть смещены.</translation>
     </message>
@@ -1505,43 +1360,36 @@ or
     <name>ITimeZoneSetup</name>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="150"/>
         <source>Setup Timezone ...</source>
         <translation>Настройка часового пояса...</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="22"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="151"/>
         <source>UTC</source>
         <translation>UTC</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="32"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="152"/>
         <source>Local</source>
         <translation>Местный</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="42"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="153"/>
         <source>Automatic</source>
         <translation>Автоматический</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="75"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="155"/>
         <source>Print date/time in </source>
         <translation>Печатать дату/время в </translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="82"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="156"/>
         <source>long format, or</source>
         <translation>длинном формате, или в</translation>
     </message>
     <message>
         <location filename="../units/ITimeZoneSetup.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_ITimeZoneSetup.h" line="157"/>
         <source>short format</source>
         <translation>сокращённом формате</translation>
     </message>
@@ -1550,97 +1398,81 @@ or
     <name>IToolAddOverview</name>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="204"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="205"/>
         <source>do not translate</source>
         <translation>do not translate</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="206"/>
         <source>:2</source>
         <translation>:2</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="126"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="207"/>
         <source>:4</source>
         <translation>:4</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="208"/>
         <source>:8</source>
         <translation>:8</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="209"/>
         <source>:16</source>
         <translation>16</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="147"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="210"/>
         <source>:32</source>
         <translation>:32</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="154"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="211"/>
         <source>:64</source>
         <translation>:64</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="164"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="213"/>
         <source>Remove all overview levels from map file.</source>
         <translation>Удалить все обзоры из файла карты.</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="167"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="215"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="174"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="217"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation>Не копировать обзоры в файл. Добавить их как внешний файл.</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="219"/>
         <source>Overview as external file</source>
         <translation>Обзор как внешний файл</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="207"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="220"/>
         <source>Start</source>
         <translation>Запуск</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="221"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="221"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="232"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="222"/>
         <source>For all files</source>
         <translation>все файлы</translation>
     </message>
     <message>
         <location filename="../tool/IToolAddOverview.ui" line="257"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolAddOverview.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
@@ -1649,67 +1481,56 @@ or
     <name>IToolCutMap</name>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="203"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="204"/>
         <source>do not translate</source>
         <translation>do not translate</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="114"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="205"/>
         <source>Output filename suffix</source>
         <translation>Суффикс имени выходного файла</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="206"/>
         <source>_cut</source>
         <translation>_cut</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="207"/>
         <source>Create overviews for result.</source>
         <translation>Создать обзоры для результата.</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="155"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="208"/>
         <source>GDAL Parameters</source>
         <translation>Параметры GDAL</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="183"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="209"/>
         <source>Start</source>
         <translation>Запуск</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="197"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="210"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="208"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="211"/>
         <source>For all files</source>
         <translation>все файлы</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="233"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="212"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdalwarp&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolCutMap.ui" line="243"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolCutMap.h" line="213"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
@@ -1718,63 +1539,52 @@ or
     <name>IToolExport</name>
     <message>
         <location filename="../tool/IToolExport.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="173"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="59"/>
         <location filename="../tool/IToolExport.ui" line="72"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="175"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="176"/>
         <source>do not translate</source>
         <translation>do not translate</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="83"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="177"/>
         <source>Garmin BirdsEye (*.jnx)</source>
         <translation>Garmin BirdsEye (*.jnx)</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="178"/>
         <source>TwoNav Raster (*.rmap)</source>
         <translation>TwoNav Raster (*.rmap)</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="101"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="180"/>
         <source>not implemented yet</source>
         <translation>еще не реализовано</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="112"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="181"/>
         <source>Target File</source>
         <translation>Конечный файл</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="130"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="182"/>
         <source>Start</source>
         <translation>Запуск</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="183"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="173"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="184"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_map2jnx&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;qmt_map2jnx&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolExport.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExport.h" line="174"/>
         <source>Target Filename</source>
         <translation>Имя конечного файла</translation>
     </message>
@@ -1783,95 +1593,78 @@ or
     <name>IToolExportJnx</name>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="180"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="35"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="81"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="181"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="186"/>
         <source>BirdsEye</source>
         <translation>BirdsEye</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="182"/>
         <source>Product ID</source>
         <translation>Идентификатор продукта</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="57"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="183"/>
         <source>Copyright notice</source>
         <translation>Авторские права</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="64"/>
         <location filename="../tool/export/IToolExportJnx.ui" line="95"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="188"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="185"/>
         <source>Product name</source>
         <translation>Название продукта</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="88"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="187"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="105"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="189"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="133"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="190"/>
         <source>Quality</source>
         <translation>Качество</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="140"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="191"/>
         <source>Chroma subsampling</source>
         <translation>Цветовая субдискретизация</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="148"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="192"/>
         <source>411</source>
         <translation>411</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="153"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="193"/>
         <source>422</source>
         <translation>422</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="194"/>
         <source>444</source>
         <translation>444</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="169"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="196"/>
         <source>Device</source>
         <translation>Устройство</translation>
     </message>
     <message>
         <location filename="../tool/export/IToolExportJnx.ui" line="184"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolExportJnx.h" line="197"/>
         <source>Z-Order</source>
         <translation>Z-порядок</translation>
     </message>
@@ -1880,43 +1673,36 @@ or
     <name>IToolGDALGroupBox</name>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="167"/>
         <source>GroupBox</source>
         <translation>Окно группы</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="17"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="168"/>
         <source>GDAL Parameters</source>
         <translation>Параметры GDAL</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="50"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="169"/>
         <source>Resampling</source>
         <translation>Ресамплинг</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="84"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="170"/>
         <source>Compression</source>
         <translation>Компрессия</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="118"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="171"/>
         <source>Tiled</source>
         <translation>Мозаичный</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="172"/>
         <source>x</source>
         <translation>х</translation>
     </message>
     <message>
         <location filename="../tool/IToolGDALGroupBox.ui" line="188"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGDALGroupBox.h" line="173"/>
         <source>Other:</source>
         <translation>Прочие</translation>
     </message>
@@ -1925,37 +1711,31 @@ or
     <name>IToolGrid</name>
     <message>
         <location filename="../tool/IToolGrid.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="130"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="56"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="132"/>
         <source>Grid Tool</source>
         <translation>Инструмент сетки</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="65"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="133"/>
         <source>do not translate</source>
         <translation>do not translate</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="134"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="110"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="135"/>
         <source>Cancel</source>
         <translation>Отменить</translation>
     </message>
     <message>
         <location filename="../tool/IToolGrid.ui" line="134"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolGrid.h" line="136"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
@@ -1964,55 +1744,46 @@ or
     <name>IToolOverviewGroupBox</name>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="104"/>
         <source>GroupBox</source>
         <translation>Окно группы</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="71"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="105"/>
         <source>:2</source>
         <translation>:2</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="106"/>
         <source>:4</source>
         <translation>:4</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="85"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="107"/>
         <source>:8</source>
         <translation>:8</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="92"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="108"/>
         <source>:16</source>
         <translation>:16</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="99"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="109"/>
         <source>:32</source>
         <translation>:32</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="106"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="110"/>
         <source>:64</source>
         <translation>:64</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="119"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="112"/>
         <source>Do not copy the overviews into the file itself. Add them as external file.</source>
         <translation>Не копировать обзоры в сам файл. Добавьте их как внешний файл.</translation>
     </message>
     <message>
         <location filename="../tool/IToolOverviewGroupBox.ui" line="122"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolOverviewGroupBox.h" line="114"/>
         <source>Overview as external file</source>
         <translation>Обзор как внешний файл</translation>
     </message>
@@ -2021,87 +1792,72 @@ or
     <name>IToolPalettize</name>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="221"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="65"/>
         <location filename="../tool/IToolPalettize.ui" line="78"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="223"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="224"/>
         <source>do not translate</source>
         <translation>do not translate</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="96"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="225"/>
         <source>Single files, filename suffix</source>
         <translation>Отдельные файлы, суффикс имени файла</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="109"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="226"/>
         <source>_8bit</source>
         <translation>_8bit</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="123"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="227"/>
         <source>Combined file, filename:</source>
         <translation>Объединенный файл, имя файла:</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="135"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="228"/>
         <source>Embed result into *.vrt file.</source>
         <translation>Вставить результат в файл * .vrt.</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="142"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="229"/>
         <source>Create overviews for result.</source>
         <translation>Создать обзоры для результата.</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="149"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="230"/>
         <source>GDAL Parameter</source>
         <translation>Параметры GDAL</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="177"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="231"/>
         <source>Start</source>
         <translation>Запуск</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="191"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="232"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="220"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="233"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="230"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="234"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdal_translate&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="240"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="235"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;qmt_rgb2pct&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;qmt_rgb2pct&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolPalettize.ui" line="254"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolPalettize.h" line="222"/>
         <source>Select filename</source>
         <translation>Выбрать имя файла</translation>
     </message>
@@ -2110,79 +1866,66 @@ or
     <name>IToolRefMap</name>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="212"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="59"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="213"/>
         <source>do not translate</source>
         <translation>do not translate</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="113"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="214"/>
         <source>Output filename suffix</source>
         <translation>Суффикс имени выходного файла</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="132"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="215"/>
         <source>_ref</source>
         <translation>_ref</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="144"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="216"/>
         <source>Embed result into *.vrt file.</source>
         <translation>Вставить результат в файл * .vrt.</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="151"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="217"/>
         <source>Create overviews for result.</source>
         <translation>Создать обзоры для результата.</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="158"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="218"/>
         <source>GDAL Parameters</source>
         <translation>Параметры GDAL</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="186"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="219"/>
         <source>Start</source>
         <translation>Запуск</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="200"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="220"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="211"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="221"/>
         <source>For all files</source>
         <translation>все файлы</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="236"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="222"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdalwarp&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdalwarp&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="246"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="223"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdal_translate&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdal_translate&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../tool/IToolRefMap.ui" line="256"/>
-        <location filename="../../../build/src/qmaptool/ui_IToolRefMap.h" line="224"/>
         <source>&lt;b style=&apos;color: red;&apos;&gt;No &quot;gdaladdo&quot; found. Please check setup!&lt;/b&gt;</source>
         <translation>&lt;b style=&apos;color: red;&apos;&gt;&quot;gdaladdo&quot; не найдено. Пожалуйста, проверьте настройки!&lt;/b&gt;</translation>
     </message>
@@ -2213,31 +1956,26 @@ or
     <name>IUnitsSetup</name>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="14"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="103"/>
         <source>Setup units...</source>
         <translation>Настройка единиц измерения...</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="24"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="104"/>
         <source>Nautical</source>
         <translation>Морские</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="31"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="105"/>
         <source>Imperial</source>
         <translation>Британские</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="38"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="106"/>
         <source>Metric</source>
         <translation>Метрические</translation>
     </message>
     <message>
         <location filename="../units/IUnitsSetup.ui" line="53"/>
-        <location filename="../../../build/src/qmaptool/ui_IUnitsSetup.h" line="107"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; For some GUI elements changing the units will not take effect until you restart QMapTool.</source>
         <translation>&lt;b&gt;Примечание:&lt;/b&gt; Изменение единиц для некоторых элементов графического пользовательского интерфейса вступят в силу только после перезапуска QMapTool.</translation>
     </message>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1101

### What you have done:
[comment]: # (Describe roughly.)

Prevent Qt help browser from automatically trying to open links.
Instead, catch signal `anchorClicked` and either open external or internal link depending on URL scheme.

In addition, the help browser's context menu has been expanded to include page history navigation:
<img width="832" height="540" alt="grafik" src="https://github.com/user-attachments/assets/dbfbf59e-7aea-43cd-85fa-c3a448145225" />
Although the navigation keys in the help browser worked previously, they were likely little known.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. In QMS, hit F1 key to open help browser -> page _QMapShack Manual_ opens
2. Click any link on page -> selected internal document's page opens
3. Click internal link _Home_ in tab bar -> page _Welcome to QMapShack_ opens
4. Click external link _download page_ in page -> QMS download page opens in operating system's default browser

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
