### PR TITLE
[QMS-1105] Fix: Context menu shortcuts not shown (macOS)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-1105] Fix: Context menu shortcuts not shown (macOS)
+
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links
 [QMS-1061] Fix: File not found error with non-ASCII characters in path (Umlauts)

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -41,6 +41,7 @@ int main(int argc, char** argv) {
   QCoreApplication::setOrganizationDomain("qlandkarte.org");
   QCoreApplication::setApplicationVersion(VER_STR);
   QCoreApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
+  QCoreApplication::setAttribute(Qt::AA_DontShowShortcutsInContextMenus, false);
 
   IAppSetup* env = IAppSetup::getPlatformInstance();
   env->processArguments();

--- a/src/qmaptool/main.cpp
+++ b/src/qmaptool/main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char** argv) {
   QCoreApplication::setOrganizationDomain("qlandkarte.org");
   QCoreApplication::setApplicationVersion(VER_STR);
   QCoreApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
+  QCoreApplication::setAttribute(Qt::AA_DontShowShortcutsInContextMenus, false);
 
   IAppSetup& env = IAppSetup::createInstance(qApp);
   env.processArguments();


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1105

### What you have done:
[comment]: # (Describe roughly.)

Attribute to force showing shortcuts in context menu on platform macOS too has been set.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS on platform macOS
2. Right click any page in F1 help browser -> context menu opens
3. Shortcuts in context menu are shown

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
