### PR TITLE
[QMS-1115] Improve performance of DEM rendering

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-1105] Fix: Context menu shortcuts not shown (macOS)
 [QMS-1111] Add percentage values to track range
+[QMS-1115] Improve performance for high resolution DEMs
 [QMS-1117] Suggest track name when converting routes
 
 V1.20.3

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -19,7 +19,9 @@
 
 #include "dem/CDemVRT.h"
 
+#include <gdal.h>
 #include <gdal_priv.h>
+#include <gdalwarper.h>
 
 #include <QtWidgets>
 
@@ -91,12 +93,60 @@ CDemVRT::CDemVRT(const QString& filename, CDemDraw* parent) : IDem(parent), file
   noData = pBand->GetNoDataValue(&hasNoData);
   qDebug() << "no data:" << hasNoData << noData;
 
+  // ------- setup warped VRT ---------------
+  // if the projection of the dataset is different then that of the drawing context we wrap the dataset in a virtual
+  // warped dataset to transparently resample it into the drawing contexts projection.
+  OGRSpatialReference targetSRS;
+  OGRErr rv = targetSRS.SetFromUserInput(dem->getProjection().toUtf8());
+  const OGRSpatialReference* sourceSRS = dataset->GetSpatialRef();
+  if (rv == OGRERR_NONE && sourceSRS != nullptr && !sourceSRS->IsSame(&targetSRS)) {
+    srcDataset = dataset;
+
+    GDALWarpOptions* psOptions = GDALCreateWarpOptions();
+    psOptions->pProgressArg = dem;
+    psOptions->pfnProgress = [](double dfc, const char* msg, void* arg) -> int {
+      auto dem = reinterpret_cast<CDemDraw*>(arg);
+      return !dem->needsRedraw();
+    };
+
+    dataset = GDALDataset::FromHandle(GDALAutoCreateWarpedVRT(
+        GDALDataset::ToHandle(srcDataset), nullptr, targetSRS.exportToWkt().c_str(), GRA_Bilinear, 0.1, psOptions));
+
+    GDALDestroyWarpOptions(psOptions);
+
+    if (dataset == nullptr) {
+      GDALClose(srcDataset);
+      srcDataset = nullptr;
+      QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
+                           tr("Failed to create Warp for:") % '\n' % filename);
+      return;
+    }
+
+    if (hasOverviews) {
+      // to make GDAL take advantage of overviews in the original dataset we need to add "virtual overviews" with the
+      // same decimation factors to the WarpedVRT so first build a list of the overviews the original dataset
+      // contains...
+      QVector<qint32> overviews(pBand->GetOverviewCount());
+      for (int i = 0; i < overviews.size(); ++i) {
+        GDALRasterBand* overview = pBand->GetOverview(i);
+        qreal decimationFactor = (qreal)pBand->GetXSize() / overview->GetXSize();
+        overviews[i] = qRound(decimationFactor);
+      }
+      // ...and attach them as virtual overview
+      CPLSetConfigOption("VRT_VIRTUAL_OVERVIEWS", "YES");
+      dataset->BuildOverviews("NONE", overviews.size(), overviews.data(), 0, nullptr, nullptr, nullptr);
+      CPLSetConfigOption("VRT_VIRTUAL_OVERVIEWS", "NO");
+    }
+  }
+
   // ------- setup projection ---------------
   proj.init(dataset->GetProjectionRef(), "EPSG:4326");
 
   if (!proj.isValid()) {
     GDALClose(dataset);
     dataset = nullptr;
+    GDALClose(srcDataset);
+    srcDataset = nullptr;
     QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
                          tr("No georeference information found:") % '\n' % filename);
     return;
@@ -146,6 +196,7 @@ CDemVRT::CDemVRT(const QString& filename, CDemDraw* parent) : IDem(parent), file
 CDemVRT::~CDemVRT() {
   threadPool.waitForDone();
   GDALClose(dataset);
+  GDALClose(srcDataset);
 }
 
 void CDemVRT::slotNeedsRedraw() { threadPool.clear(); }
@@ -322,6 +373,17 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf) {
   QVector<float> data(static_cast<qsizetype>(w_buf) * h_buf);
   {
     QMutexLocker lock(&mutex);
+
+    // add a temporary GDAL error handler to filter out errors that are caused by intentionally aborted reads
+    // automatically removed at end of scope
+    CPLErrorHandlerPusher oCurrentHandler(
+        [](CPLErr eErrClass, CPLErrorNum errNo, const char* msg) {
+          if (errNo == CPLE_UserInterrupt || errNo == CPLE_AppDefined) {
+            return;
+          }
+          CPLDefaultErrorHandler(eErrClass, errNo, msg);
+        },
+        nullptr);
 
     // by requesting a different size than the size of the buffer GDAL will automatically do scaling for us and use
     // overviews

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -243,11 +243,18 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf) {
     return;
   }
 
-  // get pixel offset of top left buffer corner
-  QPointF pp = buf.ref1;
-  dem->convertRad2Px(pp);
+  // use bufferScale (and therefore the zoom level) and the pixel scale of the DEM to caluclate a downsampling factor
+  qreal buf_scale_x = qAbs(bufferScale.x() / xscale);
+  qreal buf_scale_y = qAbs(bufferScale.y() / yscale);
+  // <1 would mean GDAL does upscaling which is pointless
+  if (buf_scale_x < 1.0) {
+    buf_scale_x = 1.0;
+  }
+  if (buf_scale_y < 1.0) {
+    buf_scale_y = 1.0;
+  }
 
-  // calculate area to read from file
+  // corners of the area we shall draw
   QPointF pt1 = buf.ref1;
   QPointF pt2 = buf.ref2;
   QPointF pt3 = buf.ref3;
@@ -263,42 +270,77 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf) {
   pt3 = trInv.map(pt3);
   pt4 = trInv.map(pt4);
 
-  qint32 left, right, top, bottom;
-  left = qRound(pt1.x() < pt4.x() ? pt1.x() : pt4.x());
-  right = qRound(pt2.x() > pt3.x() ? pt2.x() : pt3.x());
-  top = qRound(pt1.y() < pt2.y() ? pt1.y() : pt2.y());
-  bottom = qRound(pt4.y() > pt3.y() ? pt4.y() : pt3.y());
+  // bounds of the area to draw in the coordinate space of the DEM
+  qreal left = pt1.x() < pt4.x() ? pt1.x() : pt4.x();
+  qreal right = pt2.x() > pt3.x() ? pt2.x() : pt3.x();
+  qreal top = pt1.y() < pt2.y() ? pt1.y() : pt2.y();
+  qreal bottom = pt4.y() > pt3.y() ? pt4.y() : pt3.y();
 
-  if (left <= 0) {
-    left = 1;
-  }
-  if (left >= xsize_px) {
-    left = xsize_px - 1;
+  if ((top > ysize_px) || (left > xsize_px) || (bottom < 0) || (right < 0)) {
+    // current view is entirely outside the bounds of the DEM so there is nothing to draw
+    return;
   }
 
-  if (top <= 0) {
-    top = 1;
+  // clip bounds
+  if (left < buf_scale_x) {
+    left = buf_scale_x;
   }
-  if (top >= ysize_px) {
-    top = ysize_px - 1;
+  if (top < buf_scale_y) {
+    top = buf_scale_y;
   }
-
-  if (right >= xsize_px) {
-    right = xsize_px - 1;
+  if (right + buf_scale_x > xsize_px) {
+    right = xsize_px - buf_scale_x;
   }
-  if (right <= 0) {
-    right = 1;
-  }
-
-  if (bottom >= ysize_px) {
-    bottom = ysize_px - 1;
-  }
-  if (bottom <= 0) {
-    bottom = 1;
+  if (bottom + buf_scale_y > ysize_px) {
+    bottom = ysize_px - buf_scale_y;
   }
 
-  const qint32 w = 2048 / xscale;
-  const qint32 h = 2048 / xscale;
+  // guard against degenerate/inverted bounds (e.g. extreme geotransforms or
+  // projections where the corner pairing above doesn't yield left<right/top<bottom)
+  if (right <= left || bottom <= top) {
+    return;
+  }
+
+  // the shading algorithms need a extra 1px border
+  // that border needs to be scaled as well
+  qreal x = left - buf_scale_x;
+  qreal y = top - buf_scale_y;
+  qreal w = right - left;
+  qreal h = bottom - top;
+
+  // dimensions we request from the DEM
+  qreal w_dem = w + 2.0 * buf_scale_x;
+  qreal h_dem = h + 2.0 * buf_scale_y;
+
+  // dimensions of the buffer GDAL will read into
+  quint32 w_buf = qRound(w_dem / buf_scale_x);
+  quint32 h_buf = qRound(h_dem / buf_scale_y);
+  if (w_buf < 3 || h_buf < 3) {
+    return;
+  }
+
+  QVector<float> data(static_cast<qsizetype>(w_buf) * h_buf);
+  {
+    QMutexLocker lock(&mutex);
+
+    // by requesting a different size than the size of the buffer GDAL will automatically do scaling for us and use
+    // overviews
+    CPLErr err = dataset->GetRasterBand(1)->ReadRaster(
+        data.data(), static_cast<size_t>(w_buf) * h_buf, x, y, w_dem, h_dem, w_buf, h_buf, GRIORA_Bilinear,
+        [](double dfc, const char* msg, void* arg) -> int {
+          auto dem = reinterpret_cast<CDemDraw*>(arg);
+          return !dem->needsRedraw();
+        },
+        dem);
+
+    if (err != CE_None) {
+      return;
+    }
+  }
+
+  // get pixel offset of top left buffer corner
+  QPointF pp = buf.ref1;
+  dem->convertRad2Px(pp);
 
   // start to draw the map
   QPainter p(&buf.image);
@@ -309,77 +351,58 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf) {
   qreal o2 = ((o1 + 0.4) >= 1.0) ? o1 : (o1 + 0.4);
   p.setOpacity(o1);
 
-  for (qint32 y = top - 1; y < bottom; y += h) {
-    if (dem->needsRedraw()) {
-      break;
-    }
+  quint32 w_used = w_buf - 2;
+  quint32 h_used = h_buf - 2;
 
-    for (qint32 x = left - 1; x < right; x += w) {
+  // run the shadings in paralell on equal sized chunks
+  quint32 n_x = w_buf/32;
+  quint32 n_y = h_buf/32;
+  for (quint32 i = 0; i < n_y; ++i) {
+    for (quint32 j = 0; j < n_x; ++j) {
       if (dem->needsRedraw()) {
-        break;
+        goto endloop;
       }
-      // queue task to render tile
-      threadPool.start([this, x, y, w, h, &p, o1, o2]() { drawTile(x, y, w, h, o1, o2, p); });
+
+      // position and dimensions of this chunk in the `data` buffer...
+      quint32 step_w_buf = w_used / n_x;
+      quint32 step_h_buf = h_used / n_y;
+      quint32 x_chunk = step_w_buf * j + 1;
+      quint32 y_chunk = step_h_buf * i + 1;
+      quint32 w_chunk = (j == n_x - 1) ? (w_used + 1 - x_chunk) : step_w_buf;
+      quint32 h_chunk = (i == n_y - 1) ? (h_used + 1 - y_chunk) : step_h_buf;
+
+      // ...and in the coordinate space of the DEM
+      qreal chunk_top = y + y_chunk * buf_scale_y;
+      qreal chunk_left = x + x_chunk * buf_scale_x;
+      qreal chunk_right = chunk_left + w_chunk * buf_scale_x;
+      qreal chunk_bottom = chunk_top + h_chunk * buf_scale_y;
+      QPolygonF l(4);
+      l[0] = QPointF(chunk_left, chunk_top);
+      l[1] = QPointF(chunk_right, chunk_top);
+      l[2] = QPointF(chunk_right, chunk_bottom);
+      l[3] = QPointF(chunk_left, chunk_bottom);
+
+      threadPool.start(
+          [=, this, &data, &p]() { drawTile(data, x_chunk, y_chunk, w_buf, w_chunk, h_chunk, l, o1, o2, p); });
     }
   }
+endloop:
   threadPool.waitForDone();
+
   drawElevationShadeScale(p);
 }
 
-void CDemVRT::drawTile(const qint32 x, const qint32 y, const qint32 w, const qint32 h, const qreal o1, const qreal o2,
-                       QPainter& p) const {
-  /*
-      As the 3x3 window will create a border of one pixel
-      more data is read than displayed to compensate.
-   */
-  const qint32 wp2 = w + 2;
-  const qint32 hp2 = h + 2;
-  qreal wp2_used = wp2;
-  qreal hp2_used = hp2;
-  qreal w_used = w;
-  qreal h_used = h;
-
-  if ((x + wp2) > xsize_px) {
-    wp2_used = xsize_px - x;
-    w_used = wp2_used - 2;
-    if (w_used < 2) {
-      return;
-    }
-  }
-
-  if ((y + hp2) > ysize_px) {
-    hp2_used = ysize_px - y;
-    h_used = hp2_used - 2;
-    if (h_used < 2) {
-      return;
-    }
-  }
-
-  QVector<float> data(wp2_used * hp2_used);
-  {
-    QMutexLocker lock(&mutex);
-    CPLErr err = dataset->RasterIO(GF_Read, x, y, wp2_used, hp2_used, data.data(), wp2_used, hp2_used, GDT_Float32, 1,
-                                   0, 0, 0, 0);
-    if (err != CE_None) {
-      return;
-    }
-  }
-
-  QPolygonF l(4);
-  l[0] = QPointF(x + 1, y + 1);
-  l[1] = QPointF(x + 1 + w_used, y + 1);
-  l[2] = QPointF(x + 1 + w_used, y + 1 + h_used);
-  l[3] = QPointF(x + 1, y + 1 + h_used);
+void CDemVRT::drawTile(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h, QPolygonF l,
+                       qreal o1, qreal o2, QPainter& p) const {
   l = trFwd.map(l);
-
   proj.transform(l, PJ_FWD);
 
   if (doHillshading()) {
     QPolygonF r = l;
-    QImage img(w_used, h_used, QImage::Format_Indexed8);
+    QImage img(w, h, QImage::Format_Indexed8);
     img.setColorTable(graytable);
 
-    hillshading(data, w_used, h_used, img);
+    hillshading(data, x, y, stride, w, h, img);
 
     {
       QMutexLocker lock(&mutex);
@@ -389,8 +412,8 @@ void CDemVRT::drawTile(const qint32 x, const qint32 y, const qint32 w, const qin
 
   if (doSlopeShading()) {
     QPolygonF r = l;
-    QImage img(w_used, h_used, QImage::Format_Alpha8);
-    slopeShading(data, w_used, h_used, img);
+    QImage img(w, h, QImage::Format_Alpha8);
+    slopeShading(data, x, y, stride, w, h, img);
 
     {
       QMutexLocker lock(&mutex);
@@ -400,9 +423,9 @@ void CDemVRT::drawTile(const qint32 x, const qint32 y, const qint32 w, const qin
 
   if (doSlopeColor()) {
     QPolygonF r = l;
-    QImage img(w_used, h_used, QImage::Format_Indexed8);
+    QImage img(w, h, QImage::Format_Indexed8);
     img.setColorTable(slopetable);
-    slopecolor(data, w_used, h_used, img);
+    slopecolor(data, x, y, stride, w, h, img);
 
     {
       QMutexLocker lock(&mutex);
@@ -414,9 +437,9 @@ void CDemVRT::drawTile(const qint32 x, const qint32 y, const qint32 w, const qin
 
   if (doElevationLimit()) {
     QPolygonF r = l;
-    QImage img(w_used, h_used, QImage::Format_Indexed8);
+    QImage img(w, h, QImage::Format_Indexed8);
     img.setColorTable(elevationtable);
-    elevationLimit(data, w_used, h_used, img);
+    elevationLimit(data, x, y, stride, w, h, img);
 
     {
       QMutexLocker lock(&mutex);
@@ -428,9 +451,9 @@ void CDemVRT::drawTile(const qint32 x, const qint32 y, const qint32 w, const qin
 
   if (doElevationShading()) {
     QPolygonF r = l;
-    QImage img(w_used, h_used, QImage::Format_Indexed8);
+    QImage img(w, h, QImage::Format_Indexed8);
     img.setColorTable(elevationShadeTable);
-    elevationShading(data, w_used, h_used, img);
+    elevationShading(data, x, y, stride, w, h, img);
 
     {
       QMutexLocker lock(&mutex);

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -338,6 +338,40 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf) {
     }
   }
 
+  quint32 w_used = w_buf - 2;
+  quint32 h_used = h_buf - 2;
+
+  QVector<uchar> outbuf(w_used * h_used);
+
+  using shadeFnPtr =
+      void (CDemVRT::*)(QVector<float>&, QVector<uchar>&, quint32, quint32, quint32, quint32, quint32) const;
+  auto computeShading = [=, this, &data, &outbuf](shadeFnPtr shadeFn) {
+    // run the shadings in paralell on equal sized chunks
+    quint32 n_x = 4;
+    quint32 n_y = 4;
+    for (quint32 i = 0; i < n_y; ++i) {
+      for (quint32 j = 0; j < n_x; ++j) {
+        if (dem->needsRedraw()) {
+          threadPool.waitForDone();
+          return false;
+        }
+
+        quint32 step_w_buf = w_used / n_x;
+        quint32 step_h_buf = h_used / n_y;
+        quint32 x_chunk = step_w_buf * j;
+        quint32 y_chunk = step_h_buf * i;
+        quint32 w_chunk = (j == n_x - 1) ? (w_used - x_chunk) : step_w_buf;
+        quint32 h_chunk = (i == n_y - 1) ? (h_used - y_chunk) : step_h_buf;
+
+        threadPool.start([=, this, &data, &outbuf]() {
+          std::invoke(shadeFn, this, data, outbuf, x_chunk, y_chunk, w_used, w_chunk, h_chunk);
+        });
+      }
+    }
+    threadPool.waitForDone();
+    return true;
+  };
+
   // get pixel offset of top left buffer corner
   QPointF pp = buf.ref1;
   dem->convertRad2Px(pp);
@@ -351,115 +385,60 @@ void CDemVRT::draw(IDrawContext::buffer_t& buf) {
   qreal o2 = ((o1 + 0.4) >= 1.0) ? o1 : (o1 + 0.4);
   p.setOpacity(o1);
 
-  quint32 w_used = w_buf - 2;
-  quint32 h_used = h_buf - 2;
-
-  // run the shadings in paralell on equal sized chunks
-  quint32 n_x = w_buf/32;
-  quint32 n_y = h_buf/32;
-  for (quint32 i = 0; i < n_y; ++i) {
-    for (quint32 j = 0; j < n_x; ++j) {
-      if (dem->needsRedraw()) {
-        goto endloop;
-      }
-
-      // position and dimensions of this chunk in the `data` buffer...
-      quint32 step_w_buf = w_used / n_x;
-      quint32 step_h_buf = h_used / n_y;
-      quint32 x_chunk = step_w_buf * j + 1;
-      quint32 y_chunk = step_h_buf * i + 1;
-      quint32 w_chunk = (j == n_x - 1) ? (w_used + 1 - x_chunk) : step_w_buf;
-      quint32 h_chunk = (i == n_y - 1) ? (h_used + 1 - y_chunk) : step_h_buf;
-
-      // ...and in the coordinate space of the DEM
-      qreal chunk_top = y + y_chunk * buf_scale_y;
-      qreal chunk_left = x + x_chunk * buf_scale_x;
-      qreal chunk_right = chunk_left + w_chunk * buf_scale_x;
-      qreal chunk_bottom = chunk_top + h_chunk * buf_scale_y;
-      QPolygonF l(4);
-      l[0] = QPointF(chunk_left, chunk_top);
-      l[1] = QPointF(chunk_right, chunk_top);
-      l[2] = QPointF(chunk_right, chunk_bottom);
-      l[3] = QPointF(chunk_left, chunk_bottom);
-
-      threadPool.start(
-          [=, this, &data, &p]() { drawTile(data, x_chunk, y_chunk, w_buf, w_chunk, h_chunk, l, o1, o2, p); });
-    }
-  }
-endloop:
-  threadPool.waitForDone();
-
-  drawElevationShadeScale(p);
-}
-
-void CDemVRT::drawTile(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h, QPolygonF l,
-                       qreal o1, qreal o2, QPainter& p) const {
-  l = trFwd.map(l);
-  proj.transform(l, PJ_FWD);
+  // compute the destination rect we will draw the shadings into
+  QPointF top_left = trFwd.map(QPointF(left, top));
+  QPointF bottom_right = trFwd.map(QPointF(right, bottom));
+  proj.transform(top_left, PJ_FWD);
+  proj.transform(bottom_right, PJ_FWD);
+  dem->convertRad2Px(top_left);
+  dem->convertRad2Px(bottom_right);
+  QRectF dest(top_left, bottom_right);
 
   if (doHillshading()) {
-    QPolygonF r = l;
-    QImage img(w, h, QImage::Format_Indexed8);
+    if (!computeShading(&CDemVRT::hillshading)) {
+      return;
+    }
+    QImage img(outbuf.constData(), w_used, h_used, w_used, QImage::Format_Indexed8);
     img.setColorTable(graytable);
-
-    hillshading(data, x, y, stride, w, h, img);
-
-    {
-      QMutexLocker lock(&mutex);
-      drawTile(img, r, p);
-    }
+    p.drawImage(dest, img);
   }
-
   if (doSlopeShading()) {
-    QPolygonF r = l;
-    QImage img(w, h, QImage::Format_Alpha8);
-    slopeShading(data, x, y, stride, w, h, img);
-
-    {
-      QMutexLocker lock(&mutex);
-      drawTile(img, r, p);
+    if (!computeShading(&CDemVRT::slopeShading)) {
+      return;
     }
+    QImage img(outbuf.constData(), w_used, h_used, w_used, QImage::Format_Alpha8);
+    p.drawImage(dest, img);
   }
-
   if (doSlopeColor()) {
-    QPolygonF r = l;
-    QImage img(w, h, QImage::Format_Indexed8);
+    if (!computeShading(&CDemVRT::slopecolor)) {
+      return;
+    }
+    QImage img(outbuf.constData(), w_used, h_used, w_used, QImage::Format_Indexed8);
     img.setColorTable(slopetable);
-    slopecolor(data, x, y, stride, w, h, img);
-
-    {
-      QMutexLocker lock(&mutex);
-      p.setOpacity(o2);
-      drawTile(img, r, p);
-      p.setOpacity(o1);
-    }
+    p.setOpacity(o2);
+    p.drawImage(dest, img);
+    p.setOpacity(o1);
   }
-
   if (doElevationLimit()) {
-    QPolygonF r = l;
-    QImage img(w, h, QImage::Format_Indexed8);
+    if (!computeShading(&CDemVRT::elevationLimit)) {
+      return;
+    }
+    QImage img(outbuf.constData(), w_used, h_used, w_used, QImage::Format_Indexed8);
     img.setColorTable(elevationtable);
-    elevationLimit(data, x, y, stride, w, h, img);
-
-    {
-      QMutexLocker lock(&mutex);
-      p.setOpacity(o2);
-      drawTile(img, r, p);
-      p.setOpacity(o1);
-    }
+    p.setOpacity(o2);
+    p.drawImage(dest, img);
+    p.setOpacity(o1);
   }
-
   if (doElevationShading()) {
-    QPolygonF r = l;
-    QImage img(w, h, QImage::Format_Indexed8);
-    img.setColorTable(elevationShadeTable);
-    elevationShading(data, x, y, stride, w, h, img);
-
-    {
-      QMutexLocker lock(&mutex);
-      drawTile(img, r, p);
+    if (!computeShading(&CDemVRT::elevationShading)) {
+      return;
     }
+    QImage img(outbuf.constData(), w_used, h_used, w_used, QImage::Format_Indexed8);
+    img.setColorTable(elevationShadeTable);
+    p.drawImage(dest, img);
   }
+
+  drawElevationShadeScale(p);
 }
 
 void CDemVRT::drawElevationShadeScale(QPainter& p) const {

--- a/src/qmapshack/dem/CDemVRT.h
+++ b/src/qmapshack/dem/CDemVRT.h
@@ -44,8 +44,6 @@ class CDemVRT : public IDem {
  private:
   using IDem::drawTile;
   void drawElevationShadeScale(QPainter& p) const;
-  void drawTile(QVector<float>& data, quint32 x, quint32 y, quint32 dx, quint32 w, quint32 h,
-                QPolygonF l, qreal o1, qreal o2, QPainter& p) const;
 
   mutable QMutex mutex;
 

--- a/src/qmapshack/dem/CDemVRT.h
+++ b/src/qmapshack/dem/CDemVRT.h
@@ -44,8 +44,8 @@ class CDemVRT : public IDem {
  private:
   using IDem::drawTile;
   void drawElevationShadeScale(QPainter& p) const;
-  void drawTile(const qint32 x, const qint32 y, const qint32 w, const qint32 h,
-                const qreal o1, const qreal o2, QPainter& p) const;
+  void drawTile(QVector<float>& data, quint32 x, quint32 y, quint32 dx, quint32 w, quint32 h,
+                QPolygonF l, qreal o1, qreal o2, QPainter& p) const;
 
   mutable QMutex mutex;
 

--- a/src/qmapshack/dem/CDemVRT.h
+++ b/src/qmapshack/dem/CDemVRT.h
@@ -49,7 +49,8 @@ class CDemVRT : public IDem {
 
   QString filename;
   /// instance of GDAL dataset
-  GDALDataset* dataset;
+  GDALDataset* srcDataset = nullptr;
+  GDALDataset* dataset = nullptr;
 
   QPointF ref1;
   QPointF ref2;

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -213,18 +213,18 @@ int IDem::getFactorHillshading() const {
   }
 }
 
-void IDem::hillshading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                       QImage& img) const {
+void IDem::hillshading(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                       quint32 h) const {
 #define ZFACT 0.125
 #define ZFACT_BY_ZFACT (ZFACT * ZFACT)
 #define SIN_ALT (qSin(45 * DEG_TO_RAD))
 #define ZFACT_COS_ALT (ZFACT * qCos(45 * DEG_TO_RAD))
 #define AZ (315 * DEG_TO_RAD)
   for (unsigned int m = 0; m < h; m++) {
-    unsigned char* scan = img.scanLine(m);
+    unsigned char* scan = out.data() + (m + y) * stride + x;
     for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n + x, m + y, stride, win);
+      fillWindow(data, n + x + 1, m + y + 1, stride + 2, win);
 
       if (hasNoData && win[4] == noData) {
         scan[n] = 255;
@@ -253,13 +253,13 @@ void IDem::hillshading(QVector<float>& data, quint32 x, quint32 y, quint32 strid
 
 int IDem::getFactorSlopeShading() const { return factorSlopeShading * 100.; }
 
-void IDem::slopeShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                        QImage& img) const {
+void IDem::slopeShading(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                        quint32 h) const {
   for (unsigned int m = 0; m < h; m++) {
-    unsigned char* scan = img.scanLine(m);
+    unsigned char* scan = out.data() + (m + y) * stride + x;
     for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n + x, m + y, stride, win);
+      fillWindow(data, n + x + 1, m + y + 1, stride + 2, win);
 
       if (hasNoData && win[4] == noData) {
         scan[n] = 0;
@@ -331,13 +331,13 @@ qreal IDem::slopeOfWindowInterp(float* win2, winsize_e size, qreal x, qreal y) c
   return slope;
 }
 
-void IDem::slopecolor(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                      QImage& img) const {
+void IDem::slopecolor(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                      quint32 h) const {
   for (unsigned int m = 0; m < h; m++) {
-    unsigned char* scan = img.scanLine(m);
+    unsigned char* scan = out.data() + (m + y) * stride + x;
     for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n + x, m + y, stride, win);
+      fillWindow(data, n + x + 1, m + y + 1, stride + 2, win);
       qreal slope = slopeOfWindowInterp(win, eWinsize3x3, 0, 0);
 
       if (slope == NOFLOAT) {
@@ -364,13 +364,13 @@ void IDem::slopecolor(QVector<float>& data, quint32 x, quint32 y, quint32 stride
   }
 }
 
-void IDem::elevationLimit(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                          QImage& img) const {
+void IDem::elevationLimit(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                          quint32 h) const {
   for (unsigned int m = 0; m < h; m++) {
-    unsigned char* scan = img.scanLine(m);
+    unsigned char* scan = out.data() + (m + y) * stride + x;
     for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n + x, m + y, stride, win);
+      fillWindow(data, n + x + 1, m + y + 1, stride + 2, win);
 
       // get maximum of window (_not_ mean)
       //
@@ -393,13 +393,13 @@ void IDem::elevationLimit(QVector<float>& data, quint32 x, quint32 y, quint32 st
   }
 }
 
-void IDem::elevationShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                            QImage& img) const {
+void IDem::elevationShading(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                            quint32 h) const {
   for (unsigned int m = 0; m < h; m++) {
-    unsigned char* scan = img.scanLine(m);
+    unsigned char* scan = out.data() + (m + y) * stride + x;
     for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n + x, m + y, stride, win);
+      fillWindow(data, n + x + 1, m + y + 1, stride + 2, win);
 
       // get maximum of window (_not_ mean)
       //

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -30,39 +30,39 @@ inline T getValue(QVector<T>& data, int x, int y, int dx) {
 }
 
 template <typename T>
-inline void fillWindow(QVector<T>& data, int x, int y, int dx, T* w) {
-  w[0] = getValue(data, x - 1, y - 1, dx);
-  w[1] = getValue(data, x, y - 1, dx);
-  w[2] = getValue(data, x + 1, y - 1, dx);
-  w[3] = getValue(data, x - 1, y, dx);
-  w[4] = getValue(data, x, y, dx);
-  w[5] = getValue(data, x + 1, y, dx);
-  w[6] = getValue(data, x - 1, y + 1, dx);
-  w[7] = getValue(data, x, y + 1, dx);
-  w[8] = getValue(data, x + 1, y + 1, dx);
+inline void fillWindow(QVector<T>& data, int x, int y, int stride, T* w) {
+  w[0] = getValue(data, x - 1, y - 1, stride);
+  w[1] = getValue(data, x, y - 1, stride);
+  w[2] = getValue(data, x + 1, y - 1, stride);
+  w[3] = getValue(data, x - 1, y, stride);
+  w[4] = getValue(data, x, y, stride);
+  w[5] = getValue(data, x + 1, y, stride);
+  w[6] = getValue(data, x - 1, y + 1, stride);
+  w[7] = getValue(data, x, y + 1, stride);
+  w[8] = getValue(data, x + 1, y + 1, stride);
 }
 
 template <typename T>
-inline void fillWindow4x4(QVector<T>& data, qreal x, qreal y, int dx, T* w) {
+inline void fillWindow4x4(QVector<T>& data, qreal x, qreal y, int stride, T* w) {
   x = qFloor(x);
   y = qFloor(y);
 
-  w[0] = getValue(data, x - 1, y - 1, dx);
-  w[1] = getValue(data, x, y - 1, dx);
-  w[2] = getValue(data, x + 1, y - 1, dx);
-  w[3] = getValue(data, x + 2, y - 1, dx);
-  w[4] = getValue(data, x - 1, y, dx);
-  w[5] = getValue(data, x, y, dx);
-  w[6] = getValue(data, x + 1, y, dx);
-  w[7] = getValue(data, x + 2, y, dx);
-  w[8] = getValue(data, x - 1, y + 1, dx);
-  w[9] = getValue(data, x, y + 1, dx);
-  w[10] = getValue(data, x + 1, y + 1, dx);
-  w[11] = getValue(data, x + 2, y + 1, dx);
-  w[12] = getValue(data, x - 1, y + 2, dx);
-  w[13] = getValue(data, x, y + 2, dx);
-  w[14] = getValue(data, x + 1, y + 2, dx);
-  w[15] = getValue(data, x + 2, y + 2, dx);
+  w[0] = getValue(data, x - 1, y - 1, stride);
+  w[1] = getValue(data, x, y - 1, stride);
+  w[2] = getValue(data, x + 1, y - 1, stride);
+  w[3] = getValue(data, x + 2, y - 1, stride);
+  w[4] = getValue(data, x - 1, y, stride);
+  w[5] = getValue(data, x, y, stride);
+  w[6] = getValue(data, x + 1, y, stride);
+  w[7] = getValue(data, x + 2, y, stride);
+  w[8] = getValue(data, x - 1, y + 1, stride);
+  w[9] = getValue(data, x, y + 1, stride);
+  w[10] = getValue(data, x + 1, y + 1, stride);
+  w[11] = getValue(data, x + 2, y + 1, stride);
+  w[12] = getValue(data, x - 1, y + 2, stride);
+  w[13] = getValue(data, x, y + 2, stride);
+  w[14] = getValue(data, x + 1, y + 2, stride);
+  w[15] = getValue(data, x + 2, y + 2, stride);
 }
 
 const struct SlopePresets IDem::slopePresets[7]{
@@ -213,22 +213,21 @@ int IDem::getFactorHillshading() const {
   }
 }
 
-void IDem::hillshading(QVector<float>& data, qreal w, qreal h, QImage& img) const {
-  int wp2 = w + 2;
-
+void IDem::hillshading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                       QImage& img) const {
 #define ZFACT 0.125
 #define ZFACT_BY_ZFACT (ZFACT * ZFACT)
 #define SIN_ALT (qSin(45 * DEG_TO_RAD))
 #define ZFACT_COS_ALT (ZFACT * qCos(45 * DEG_TO_RAD))
 #define AZ (315 * DEG_TO_RAD)
-  for (unsigned int m = 1; m <= h; m++) {
-    unsigned char* scan = img.scanLine(m - 1);
-    for (unsigned int n = 1; n <= w; n++) {
+  for (unsigned int m = 0; m < h; m++) {
+    unsigned char* scan = img.scanLine(m);
+    for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n, m, wp2, win);
+      fillWindow(data, n + x, m + y, stride, win);
 
       if (hasNoData && win[4] == noData) {
-        scan[n - 1] = 255;
+        scan[n] = 255;
         continue;
       }
 
@@ -247,37 +246,36 @@ void IDem::hillshading(QVector<float>& data, qreal w, qreal h, QImage& img) cons
         cang = 1.0 + (254.0 * cang);
       }
 
-      scan[n - 1] = cang;
+      scan[n] = cang;
     }
   }
 }
 
 int IDem::getFactorSlopeShading() const { return factorSlopeShading * 100.; }
 
-void IDem::slopeShading(QVector<float>& data, qreal w, qreal h, QImage& img) const {
-  int wp2 = w + 2;
-
-  for (unsigned int m = 1; m <= h; m++) {
-    unsigned char* scan = img.scanLine(m - 1);
-    for (unsigned int n = 1; n <= w; n++) {
+void IDem::slopeShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                        QImage& img) const {
+  for (unsigned int m = 0; m < h; m++) {
+    unsigned char* scan = img.scanLine(m);
+    for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n, m, wp2, win);
+      fillWindow(data, n + x, m + y, stride, win);
 
       if (hasNoData && win[4] == noData) {
-        scan[n - 1] = 0;
+        scan[n] = 0;
         continue;
       }
 
       qreal slope = slopeOfWindowInterp(win, eWinsize3x3, 0, 0);
       if (slope == NOFLOAT) {
-        scan[n - 1] = 0;
+        scan[n] = 0;
       } else {
         int alphaValue = slope * 255. / 90.     // map slope angle to alpha [0 .. 255]
                          * factorSlopeShading;  // apply slider value [0.25 .. 3.0]
         if (alphaValue > 255) {
           alphaValue = 255;
         }
-        scan[n - 1] = alphaValue;
+        scan[n] = alphaValue;
       }
     }
   }
@@ -333,48 +331,46 @@ qreal IDem::slopeOfWindowInterp(float* win2, winsize_e size, qreal x, qreal y) c
   return slope;
 }
 
-void IDem::slopecolor(QVector<float>& data, qreal w, qreal h, QImage& img) const {
-  int wp2 = w + 2;
-
-  for (unsigned int m = 1; m <= h; m++) {
-    unsigned char* scan = img.scanLine(m - 1);
-    for (unsigned int n = 1; n <= w; n++) {
+void IDem::slopecolor(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                      QImage& img) const {
+  for (unsigned int m = 0; m < h; m++) {
+    unsigned char* scan = img.scanLine(m);
+    for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n, m, wp2, win);
+      fillWindow(data, n + x, m + y, stride, win);
       qreal slope = slopeOfWindowInterp(win, eWinsize3x3, 0, 0);
 
       if (slope == NOFLOAT) {
-        scan[n - 1] = 0;
+        scan[n] = 0;
         continue;
       }
 
       const qreal* currentSlopeStepTable = getCurrentSlopeStepTable();
 
       if (slope > currentSlopeStepTable[4]) {
-        scan[n - 1] = 5;
+        scan[n] = 5;
       } else if (slope > currentSlopeStepTable[3]) {
-        scan[n - 1] = 4;
+        scan[n] = 4;
       } else if (slope > currentSlopeStepTable[2]) {
-        scan[n - 1] = 3;
+        scan[n] = 3;
       } else if (slope > currentSlopeStepTable[1]) {
-        scan[n - 1] = 2;
+        scan[n] = 2;
       } else if (slope > currentSlopeStepTable[0]) {
-        scan[n - 1] = 1;
+        scan[n] = 1;
       } else {
-        scan[n - 1] = 0;
+        scan[n] = 0;
       }
     }
   }
 }
 
-void IDem::elevationLimit(QVector<float>& data, qreal w, qreal h, QImage& img) const {
-  int wp2 = w + 2;
-
-  for (unsigned int m = 1; m <= h; m++) {
-    unsigned char* scan = img.scanLine(m - 1);
-    for (unsigned int n = 1; n <= w; n++) {
+void IDem::elevationLimit(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                          QImage& img) const {
+  for (unsigned int m = 0; m < h; m++) {
+    unsigned char* scan = img.scanLine(m);
+    for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n, m, wp2, win);
+      fillWindow(data, n + x, m + y, stride, win);
 
       // get maximum of window (_not_ mean)
       //
@@ -389,22 +385,21 @@ void IDem::elevationLimit(QVector<float>& data, qreal w, qreal h, QImage& img) c
       QString unit;     // result not used
       IUnit::self().meter2elevation(meters, elevation, unit);
       if (elevation >= getElevationLimit()) {
-        scan[n - 1] = 1;
+        scan[n] = 1;
       } else {
-        scan[n - 1] = 0;
+        scan[n] = 0;
       }
     }
   }
 }
 
-void IDem::elevationShading(QVector<float>& data, qreal w, qreal h, QImage& img) const {
-  int wp2 = w + 2;
-
-  for (unsigned int m = 1; m <= h; m++) {
-    unsigned char* scan = img.scanLine(m - 1);
-    for (unsigned int n = 1; n <= w; n++) {
+void IDem::elevationShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                            QImage& img) const {
+  for (unsigned int m = 0; m < h; m++) {
+    unsigned char* scan = img.scanLine(m);
+    for (unsigned int n = 0; n < w; n++) {
       float win[eWinsize3x3];
-      fillWindow(data, n, m, wp2, win);
+      fillWindow(data, n + x, m + y, stride, win);
 
       // get maximum of window (_not_ mean)
       //
@@ -424,12 +419,12 @@ void IDem::elevationShading(QVector<float>& data, qreal w, qreal h, QImage& img)
       int limitHi = std::max(getElevationShadeLimitLow(), getElevationShadeLimitHi());
 
       if (elevation < limitLow) {
-        scan[n - 1] = 0;
+        scan[n] = 0;
       } else if (elevation < limitHi) {
         qreal relLimit = (elevation - limitLow) / (limitHi - limitLow);
-        scan[n - 1] = 1 + relLimit * 253;
+        scan[n] = 1 + relLimit * 253;
       } else {
-        scan[n - 1] = 255;
+        scan[n] = 255;
       }
     }
   }

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -124,15 +124,18 @@ class IDem : public IDrawObject {
   void slotShowElevationShadeScale(bool yes);
 
  protected:
-  void hillshading(QVector<float>& data, qreal w, qreal h, QImage& img) const;
+  void hillshading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h, QImage& img) const;
 
-  void slopeShading(QVector<float>& data, qreal w, qreal h, QImage& img) const;
+  void slopeShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                    QImage& img) const;
 
-  void slopecolor(QVector<float>& data, qreal w, qreal h, QImage& img) const;
+  void slopecolor(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h, QImage& img) const;
 
-  void elevationLimit(QVector<float>& data, qreal w, qreal h, QImage& img) const;
+  void elevationLimit(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                      QImage& img) const;
 
-  void elevationShading(QVector<float>& data, qreal w, qreal h, QImage& img) const;
+  void elevationShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
+                        QImage& img) const;
 
   /**
      @brief Slope in degrees based on a window. Origin is at point (1,1), counting from zero.

--- a/src/qmapshack/dem/IDem.h
+++ b/src/qmapshack/dem/IDem.h
@@ -124,18 +124,20 @@ class IDem : public IDrawObject {
   void slotShowElevationShadeScale(bool yes);
 
  protected:
-  void hillshading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h, QImage& img) const;
+  void hillshading(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                   quint32 h) const;
 
-  void slopeShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                    QImage& img) const;
+  void slopeShading(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                    quint32 h) const;
 
-  void slopecolor(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h, QImage& img) const;
+  void slopecolor(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                  quint32 h) const;
 
-  void elevationLimit(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                      QImage& img) const;
+  void elevationLimit(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                      quint32 h) const;
 
-  void elevationShading(QVector<float>& data, quint32 x, quint32 y, quint32 stride, quint32 w, quint32 h,
-                        QImage& img) const;
+  void elevationShading(QVector<float>& data, QVector<uchar>& out, quint32 x, quint32 y, quint32 stride, quint32 w,
+                        quint32 h) const;
 
   /**
      @brief Slope in degrees based on a window. Origin is at point (1,1), counting from zero.


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1115

### What you have done:
[comment]: # (Describe roughly.)

Rewrite most of CDemVRT::draw to dramatically speed up rendering of DEMs.

Calculate an appropriate (down-)scale factor from the DEM according to current zoom level. Then use GDALs ReadRaster function to retrieve the data already scaled which will also automatically use overviews if available.
Read all of the data in one call to make things simpler and more efficient as reading them in chunks inside multiple threads was pointless since GDAL is not threadsafe. Then calculate the shadings in parallel on chunks of the data.
Also fix prev incorrect datatypes in the signatures of shading/coloring functions.

With those changes even very high resolution DEMs will be really fast now, especially when they have overviews.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Load a DEM (with very high resolution and overviews)
2. Activate hillshading, slopeshading, ...
3. Enjoy

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

*Note:* There are no configs for clang-tidy and clazy provided making usage of those tools pretty much pointless.

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
