### PR TITLE
[QMS-1117] Suggest track name when converting routes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-1105] Fix: Context menu shortcuts not shown (macOS)
 [QMS-1111] Add percentage values to track range
+[QMS-1117] Suggest track name when converting routes
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/gis/rte/CGisItemRte.cpp
+++ b/src/qmapshack/gis/rte/CGisItemRte.cpp
@@ -272,7 +272,7 @@ void CGisItemRte::reverse() {
 }
 
 void CGisItemRte::toTrack() {
-  QString name;
+  QString name{getName()};
   IGisProject* project;
 
   if (!getNameAndProject(name, project, tr("track"))) {


### PR DESCRIPTION
When converting a route, the text input field in the dialog asking the user for a track name will use the name of the route the action was initiated on.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1117

### What you have done:
[comment]: # (Describe roughly.)

Initialize the name of the exported track with the name of the route on which the action was initiated on.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Right click on map -> Add route
2. Create a route with a couple of points
3. Save the route either into an existing or a newly created project (does not matter)
4. Find the newly created route in the workspace dock
5. Right click on it, select "Convert to track" in the context menu

Expected behavior: the text input field in the pop-up dialog asking for a track name is pre-filled with the route name

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
