### PR TITLE
[QMS-963] Replace switch on QKeyCombination with if/else in tree widg…

### DIFF
--- a/src/qmapshack/dem/CDemList.cpp
+++ b/src/qmapshack/dem/CDemList.cpp
@@ -44,21 +44,17 @@ void CDemTreeWidget::slotUpdateItem(const QString& key) {
 }
 
 void CDemTreeWidget::keyPressEvent(QKeyEvent* e) {
-  switch (e->keyCombination()) {
-    case QKeyCombination(Qt::SHIFT, Qt::Key_Home):
-      emit sigMoveHome();
-      break;
-    case QKeyCombination(Qt::SHIFT, Qt::Key_Up):
-      emit sigMoveUp();
-      break;
-    case QKeyCombination(Qt::SHIFT, Qt::Key_Down):
-      emit sigMoveDown();
-      break;
-    case QKeyCombination(Qt::SHIFT, Qt::Key_End):
-      emit sigMoveEnd();
-      break;
-    default:
-      QTreeWidget::keyPressEvent(e);
+  const QKeyCombination keyCombination = e->keyCombination();
+  if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Home)) {
+    emit sigMoveHome();
+  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Up)) {
+    emit sigMoveUp();
+  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Down)) {
+    emit sigMoveDown();
+  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_End)) {
+    emit sigMoveEnd();
+  } else {
+    QTreeWidget::keyPressEvent(e);
   }
 }
 

--- a/src/qmapshack/map/CMapList.cpp
+++ b/src/qmapshack/map/CMapList.cpp
@@ -45,21 +45,17 @@ void CMapTreeWidget::slotUpdateItem(const QString& key) {
 }
 
 void CMapTreeWidget::keyPressEvent(QKeyEvent* e) {
-  switch (e->keyCombination()) {
-    case QKeyCombination(Qt::SHIFT, Qt::Key_Home):
-      emit sigMoveHome();
-      break;
-    case QKeyCombination(Qt::SHIFT, Qt::Key_Up):
-      emit sigMoveUp();
-      break;
-    case QKeyCombination(Qt::SHIFT, Qt::Key_Down):
-      emit sigMoveDown();
-      break;
-    case QKeyCombination(Qt::SHIFT, Qt::Key_End):
-      emit sigMoveEnd();
-      break;
-    default:
-      QTreeWidget::keyPressEvent(e);
+  const QKeyCombination keyCombination = e->keyCombination();
+  if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Home)) {
+    emit sigMoveHome();
+  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Up)) {
+    emit sigMoveUp();
+  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Down)) {
+    emit sigMoveDown();
+  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_End)) {
+    emit sigMoveEnd();
+  } else {
+    QTreeWidget::keyPressEvent(e);
   }
 }
 


### PR DESCRIPTION
…et keyPressEvent

QKeyCombination::operator int() is deprecated, so case labels comparing the combination directly trigger -Wdeprecated-declarations. Affects CDemTreeWidget and CMapTreeWidget.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#963

### What you have done:
[comment]: # (Describe roughly.)

Concert the switch case to an if /else. This is the recommended way and avoids warnings.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Compile CMapList and CDemList -> no warnings.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
