### PR TITLE
[QMS-1125] Use GDAL's warp and scale API to draw *.vrt maps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ if (condition)
 
 **Prefer `QFileInfo::exists(path)` (static) over `QFileInfo(path).exists()`** when you only need an existence check — no need to construct a full `QFileInfo`.
 
+**Prefer Qt's fixed-width typedefs over plain C++ types**: `qint32`/`quint32` over `int`/`unsigned int`, `qreal` over `double`, `qsizetype` over `size_t`/`ptrdiff_t` for sizes coming from Qt containers. Exception: when a parameter type is dictated by an external API (e.g. GDAL's `int*` out-param, or `size_t` in a `ReadRaster()` signature), match that API's type instead of casting.
+
 ---
 
 ## Building
@@ -205,5 +207,47 @@ Do not add `Co-Authored-By` lines to commit messages.
 
 `animations_t` is defined after `getAnimations()` in the private section. The forward
 declaration `struct animations_t;` before `getAnimations()` is required — do not remove it.
+
+### QImage::Format_Indexed8 + GDAL RasterIO/ReadRaster — row padding pitfall
+
+Never pass `img.bits()` directly as the destination buffer for a GDAL `RasterIO`/`ReadRaster`
+call when the image width isn't guaranteed to be a multiple of 4. Qt may pad
+`QImage::bytesPerLine()` beyond the pixel width for 1-byte-per-pixel formats (`Format_Indexed8`),
+but a GDAL read with no explicit line spacing assumes the buffer is tightly packed
+(`bytesPerLine == width`), silently corrupting/skewing every row once they diverge.
+
+The old `CMapVRT` tiling code (pre-GDAL-warp version) masked tile width with `& 0xFFFFFFFC` to
+dodge exactly this for partial edge tiles — a sign the bug is real, not theoretical. The fix
+(used by both `CDemVRT` and the current `CMapVRT`, see `map/CMapVRT.cpp`'s `draw()`): read into a
+flat `QVector<quint8>` (no padding concerns, it's just linear memory) and build the `QImage` via
+the constructor that takes an explicit `bytesPerLine` argument:
+`QImage(buf.constData(), w, h, w, QImage::Format_Indexed8)`. Multi-byte-per-pixel formats
+(`Format_ARGB32`, 4 bytes/px) aren't affected since `width * 4` is always a multiple of 4.
+
+### CMapVRT/CDemVRT warped VRT — transparency outside the source footprint
+
+`GDALAutoCreateWarpedVRT` resamples onto an axis-aligned bounding box around the (possibly
+rotated) reprojected footprint, so corners with no source coverage exist whenever the source
+isn't already axis-aligned with the target SRS. What fills those corners depends on the data path:
+
+- Single-band palette/gray (`CMapVRT`): already handled. If the source declares a nodata value,
+  GDAL falls back to using it as both src/dst nodata for the warp (we never set
+  `padfSrcNoDataReal`/`padfDstNoDataReal` ourselves), so uncovered pixels come back as that nodata
+  index — and the constructor already zeroes that index's alpha in the colortable. No source
+  nodata declared means no automatic transparency here; `Format_Indexed8` has no separate alpha
+  channel to retrofit one.
+- Multi-band RGB(A) without its own alpha band (`CMapVRT`): fixed via a synthetic destination alpha
+  band (`GDALWarpInitDefaultBandMapping` + `psOptions->nDstAlphaBand = nBandCount + 1`, mirroring
+  `gdalwarp -dstalpha`). The warp tracks per-pixel source coverage into that band automatically;
+  `rasterBandCount` is re-read from the warped dataset afterward so `draw()`'s band loop picks it
+  up like any other band. Verified with a standalone `gdalwarp`/Pillow test (rotated 3-band source,
+  `-dstalpha` on vs. off): without the alpha band, uncovered corners come back **solid black**
+  (0,0,0) - GDAL's own warp fill, not the `img.fill(white)` pre-fill in `draw()`, which gets
+  unconditionally overwritten by the per-band `ReadRaster` call regardless of coverage. With the
+  alpha band, those same corners get alpha=0 and composite-out correctly.
+- `CDemVRT`: no such handling exists. Uncovered elevation samples read back as whatever the
+  destination buffer was zero-initialized to (not `NOFLOAT`), since `getElevationAt()`/`draw()`
+  never check warp coverage explicitly. Hasn't been revisited — only matters for non-axis-aligned
+  DEM sources.
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-1111] Add percentage values to track range
 [QMS-1115] Improve performance for high resolution DEMs
 [QMS-1117] Suggest track name when converting routes
+[QMS-1125] Use GDAL's warp and scale API to draw *.vrt maps
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -18,88 +18,54 @@
 
 #include "map/CMapVRT.h"
 
+#include <gdal.h>
 #include <gdal_priv.h>
+#include <gdalwarper.h>
 
 #include <QtWidgets>
+#include <algorithm>
 
 #include "CMainWindow.h"
 #include "helpers/CDraw.h"
 #include "map/CMapDraw.h"
-#include "units/IUnit.h"
-
-#define TILELIMIT 2500
-#define TILESIZEX 64
-#define TILESIZEY 64
 
 CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibility, parent), filename(filename) {
   qDebug() << "------------------------------";
   qDebug() << "VRT: try to open" << filename;
 
-  dataset = (GDALDataset*)GDALOpen(filename.toUtf8(), GA_ReadOnly);
-
+  dataset = GDALDataset::FromHandle(GDALOpen(filename.toUtf8(), GA_ReadOnly));
   if (nullptr == dataset) {
-    QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
-                         tr("Failed to load file:") % '\n' % filename);
+    fail(tr("Failed to load file:") % '\n' % filename);
     return;
   }
 
-  QString fileItem;
-  char** fileList = dataset->GetFileList();
-  int n = 0;
-  while (fileList[n] != nullptr) {
-#if defined(Q_OS_WIN32)
-    fileItem = QString::fromLocal8Bit(fileList[n]);
-    if (QFileInfo(fileItem).exists()) {
-      n++;
-      continue;
-    }
-#endif // defined(Q_OS_WIN32)
-    fileItem = QString::fromUtf8(fileList[n]);
-    if (QFileInfo(fileItem).exists()) {
-      n++;
-      continue;
-    }
-    n = -1;
-    break;
-  }
-  CSLDestroy(fileList);
-  if (n < 0) {
-    GDALClose(dataset);
-    dataset = nullptr;
-    QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
-                           tr("File does not exist:") % '\n' % fileItem % '\n' %
-                           tr("referenced by file:") % '\n' % filename);
+  QString missingFile;
+  if (!allReferencedFilesExist(dataset, missingFile)) {
+    fail(tr("File does not exist:") % '\n' % missingFile % '\n' % tr("referenced by file:") % '\n' % filename);
     return;
   }
 
   // ------- setup color table ---------
   rasterBandCount = dataset->GetRasterCount();
+  GDALRasterBand* pBand = dataset->GetRasterBand(1);
   if (rasterBandCount == 1) {
-    GDALRasterBand* pBand = dataset->GetRasterBand(1);
-
     if (nullptr == pBand) {
-      GDALClose(dataset);
-      dataset = nullptr;
-      QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
-                           tr("Failed to load file:") % '\n' % filename);
+      fail(tr("Failed to load file:") % '\n' % filename);
       return;
     }
 
     if (pBand->GetColorInterpretation() == GCI_PaletteIndex) {
       GDALColorTable* pct = pBand->GetColorTable();
-      for (int i = 0; i < pct->GetColorEntryCount(); ++i) {
+      for (qint32 i = 0; i < pct->GetColorEntryCount(); ++i) {
         const GDALColorEntry& e = *pct->GetColorEntry(i);
         colortable << qRgba(e.c1, e.c2, e.c3, e.c4);
       }
     } else if (pBand->GetColorInterpretation() == GCI_GrayIndex) {
-      for (int i = 0; i < 256; ++i) {
+      for (qint32 i = 0; i < 256; ++i) {
         colortable << qRgba(i, i, i, 255);
       }
     } else {
-      GDALClose(dataset);
-      dataset = nullptr;
-      QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
-                           tr("File must be 8 bit palette or gray indexed:") % '\n' % filename);
+      fail(tr("File must be 8 bit palette or gray indexed:") % '\n' % filename);
       return;
     }
 
@@ -112,58 +78,152 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibili
     }
   }
 
-  if (dataset->GetRasterCount() > 0) {
-    hasOverviews = dataset->GetRasterBand(1)->GetOverviewCount() != 0;
-  }
+  qreal masterGeoTransform[6];
+  const qreal masterPixelSizeX =
+      (pBand != nullptr && dataset->GetGeoTransform(masterGeoTransform) == CE_None) ? qAbs(masterGeoTransform[1]) : 0.0;
+  const QVector<qint32> overviewFactors =
+      (pBand != nullptr) ? collectOverviewFactors(dataset, pBand, masterPixelSizeX) : QVector<qint32>();
+  qDebug() << "overview factors" << overviewFactors;
 
-  // if the master VRT does not return a positive overview feedback
-  // test all files combined by the VRT to have overviews.
-  if (!hasOverviews) {
-    qDebug() << "extended test for overviews";
-    hasOverviews = testForOverviews(filename);
+  // single band palette/gray data is categorical: nearest neighbour avoids blending index
+  // values into meaningless colors when resampling. Multi-band true color benefits from
+  // a smoother bilinear resampling.
+  const GDALResampleAlg resampleAlg = (rasterBandCount == 1) ? GRA_NearestNeighbour : GRA_Bilinear;
+
+  // true color sources that don't already carry their own alpha band have no per-pixel way to
+  // mark "outside the source footprint" - ask the warp to synthesize a coverage-tracking
+  // destination alpha band so those areas come back transparent instead of opaque garbage.
+  // Single band palette/gray data is left alone: it already gets transparency for nodata-marked
+  // pixels via the colortable alpha tweak above, and Format_Indexed8 has no room for a separate
+  // alpha channel anyway.
+  bool hasAlphaBand = false;
+  for (qint32 b = 1; b <= rasterBandCount; ++b) {
+    const GDALColorInterp bandColour = dataset->GetRasterBand(b)->GetColorInterpretation();
+    if (bandColour == GCI_AlphaBand) {
+      hasAlphaBand = true;
+    } else if (rasterBandCount > 1 && bandColour != GCI_RedBand && bandColour != GCI_GreenBand &&
+               bandColour != GCI_BlueBand && bandColour != GCI_GrayIndex) {
+      // draw()'s ARGB32 compositing only understands Red/Green/Blue/Alpha/Gray; anything else
+      // (e.g. GCI_Undefined, or one of the YCbCr/HSL-style tags) is silently not drawn there
+      qWarning() << "CMapVRT:" << filename << "band" << b << "has unsupported color interpretation"
+                 << GDALGetColorInterpretationName(bandColour) << "- it will not be drawn";
+    }
   }
-  qDebug() << "has overviews" << hasOverviews;
+  const bool addDstAlphaBand = (rasterBandCount > 1) && !hasAlphaBand;
+
+  // ------- setup warped VRT ---------------
+  // if the projection of the dataset is different then that of the drawing context we wrap the dataset in a virtual
+  // warped dataset to transparently resample it into the drawing contexts projection.
+  OGRSpatialReference targetSRS;
+  OGRErr rv = targetSRS.SetFromUserInput(map->getProjection().toUtf8());
+  const OGRSpatialReference* sourceSRS = dataset->GetSpatialRef();
+  if (rv == OGRERR_NONE && sourceSRS != nullptr && !sourceSRS->IsSame(&targetSRS)) {
+    srcDataset = dataset;
+
+    GDALWarpOptions* psOptions = GDALCreateWarpOptions();
+    psOptions->pProgressArg = map;
+    psOptions->pfnProgress = &CMapVRT::progressCallback;
+
+    if (addDstAlphaBand) {
+      GDALWarpInitDefaultBandMapping(psOptions, rasterBandCount);
+      psOptions->nDstAlphaBand = psOptions->nBandCount + 1;
+    }
+
+    dataset = GDALDataset::FromHandle(GDALAutoCreateWarpedVRT(
+        GDALDataset::ToHandle(srcDataset), nullptr, targetSRS.exportToWkt().c_str(), resampleAlg, 0.1, psOptions));
+
+    GDALDestroyWarpOptions(psOptions);
+
+    if (dataset == nullptr) {
+      fail(tr("Failed to create Warp for:") % '\n' % filename);
+      return;
+    }
+
+    // pick up the synthetic alpha band (if any) so draw() reads/composites it like any other band
+    rasterBandCount = dataset->GetRasterCount();
+
+    if (!overviewFactors.isEmpty()) {
+      // attach them as virtual overviews so GDAL can serve a decimated read straight from
+      // whichever source file(s) actually have a matching level, instead of always warping
+      // at full resolution and only downsampling the output
+      CPLSetConfigOption("VRT_VIRTUAL_OVERVIEWS", "YES");
+      dataset->BuildOverviews("NONE", overviewFactors.size(), overviewFactors.data(), 0, nullptr, nullptr, nullptr);
+      CPLSetConfigOption("VRT_VIRTUAL_OVERVIEWS", "NO");
+    }
+  }
 
   // ------- setup projection ---------------
   proj.init(dataset->GetProjectionRef(), "EPSG:4326");
 
   if (!proj.isValid()) {
-    delete dataset;
-    dataset = nullptr;
-    QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),
-                         tr("No georeference information found:") % '\n' % filename);
+    fail(tr("No georeference information found:") % '\n' % filename);
     return;
   }
 
   xsize_px = dataset->GetRasterXSize();
   ysize_px = dataset->GetRasterYSize();
 
+  if (xsize_px <= 0 || ysize_px <= 0) {
+    fail(tr("Raster has an invalid (zero) size:") % '\n' % filename);
+    return;
+  }
+
   qreal adfGeoTransform[6];
-  dataset->GetGeoTransform(adfGeoTransform);
+  if (dataset->GetGeoTransform(adfGeoTransform) != CE_None) {
+    fail(tr("No pixel-to-map transform found:") % '\n' % filename);
+    return;
+  }
 
   xscale = adfGeoTransform[1];
   yscale = adfGeoTransform[5];
-  xrot = adfGeoTransform[4];
-  yrot = adfGeoTransform[2];
 
-  trFwd.translate(adfGeoTransform[0], adfGeoTransform[3]);
-  trFwd.scale(adfGeoTransform[1], adfGeoTransform[5]);
-
-  if (adfGeoTransform[4] != 0.0) {
-    trFwd.rotate(qAtan(adfGeoTransform[2] / adfGeoTransform[4]));
-  }
+  // Build trFwd directly from GDAL's affine matrix instead of decomposing it into
+  // translate+scale+rotate: adfGeoTransform[2]/[4] is a general shear term, not
+  // necessarily a pure rotation, so there is no single angle that reproduces it via
+  // QTransform::rotate() (which, in addition, takes degrees - qAtan() returns radians).
+  trFwd = QTransform(adfGeoTransform[1], adfGeoTransform[4], adfGeoTransform[2], adfGeoTransform[5], adfGeoTransform[0],
+                     adfGeoTransform[3]);
 
   if (proj.isSrcLatLong()) {
-    // convert to RAD to match internal notations
+    // Scale every element of the homogeneous matrix by DEG_TO_RAD to convert trFwd's
+    // mapped output from degrees to radians. This works because QTransform::map() never
+    // reads m13/m23/m33 as long as the transform stays non-projective (true here, since
+    // trFwd is built only from translate/scale/shear) - so scaling the whole matrix
+    // scales the mapped point without having to touch dx/dy and the linear part separately.
     trFwd = trFwd * DEG_TO_RAD;
   }
 
   trInv = trFwd.inverted();
 
-  ref1 = trFwd.map(QPointF(0, 0));
-  ref2 = trFwd.map(QPointF(xsize_px, 0));
-  ref3 = trFwd.map(QPointF(xsize_px, ysize_px));
-  ref4 = trFwd.map(QPointF(0, ysize_px));
+  // ------- setup outline ---------------
+  // ref1..ref4 outline the *original* (pre-warp) raster's true footprint, not the
+  // (possibly enlarged, axis-aligned-in-target-SRS) warped VRT's pixel grid - so
+  // drawOutline() still shows the real, potentially rotated shape of the source data
+  // instead of the padded bounding box GDALAutoCreateWarpedVRT introduces.
+  GDALDataset* origDataset = (srcDataset != nullptr) ? srcDataset : dataset;
+
+  CProj projOrig;
+  projOrig.init(origDataset->GetProjectionRef(), "EPSG:4326");
+
+  qreal origGeoTransform[6];
+  origDataset->GetGeoTransform(origGeoTransform);
+
+  QTransform origTrFwd(origGeoTransform[1], origGeoTransform[4], origGeoTransform[2], origGeoTransform[5],
+                       origGeoTransform[0], origGeoTransform[3]);
+  if (projOrig.isSrcLatLong()) {
+    origTrFwd = origTrFwd * DEG_TO_RAD;
+  }
+
+  QPolygonF outline;
+  outline << origTrFwd.map(QPointF(0, 0)) << origTrFwd.map(QPointF(origDataset->GetRasterXSize(), 0))
+          << origTrFwd.map(QPointF(origDataset->GetRasterXSize(), origDataset->GetRasterYSize()))
+          << origTrFwd.map(QPointF(0, origDataset->GetRasterYSize()));
+  projOrig.transform(outline, PJ_FWD);
+
+  ref1 = outline[0];
+  ref2 = outline[1];
+  ref3 = outline[2];
+  ref4 = outline[3];
 
   qDebug() << "FF" << trFwd;
   qDebug() << "RR" << trInv;
@@ -171,92 +231,261 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibili
   isActivated = true;
 }
 
-CMapVRT::~CMapVRT() { GDALClose(dataset); }
+CMapVRT::~CMapVRT() {
+  closeDataset(dataset);
+  closeDataset(srcDataset);
+}
 
-bool CMapVRT::testForOverviews(const QString& filename) {
-  QFile file(filename);
-  if (!file.open(QIODevice::ReadOnly)) {
-    qDebug() << "Failed to open" << filename;
+int CMapVRT::progressCallback(double /*dfComplete*/, const char* /*message*/, void* pProgressArg) {
+  auto* drawCtx = reinterpret_cast<CMapDraw*>(pProgressArg);
+  return !drawCtx->needsRedraw();
+}
+
+bool CMapVRT::allReferencedFilesExist(GDALDataset* dataset, QString& missingFile) {
+  char** fileList = dataset->GetFileList();
+  bool allExist = true;
+  for (qint32 n = 0; fileList != nullptr && fileList[n] != nullptr; ++n) {
+#if defined(Q_OS_WIN32)
+    missingFile = QString::fromLocal8Bit(fileList[n]);
+    if (QFileInfo::exists(missingFile)) {
+      continue;
+    }
+#endif  // defined(Q_OS_WIN32)
+    missingFile = QString::fromUtf8(fileList[n]);
+    if (QFileInfo::exists(missingFile)) {
+      continue;
+    }
+    allExist = false;
+    break;
+  }
+  CSLDestroy(fileList);
+  return allExist;
+}
+
+QVector<qint32> CMapVRT::collectOverviewFactors(GDALDataset* dataset, GDALRasterBand* pBand, qreal pixelSizeX) {
+  QSet<qint32> factors;
+
+  if (pBand->GetOverviewCount() != 0) {
+    for (qint32 i = 0; i < pBand->GetOverviewCount(); ++i) {
+      factors << qRound((qreal)pBand->GetXSize() / pBand->GetOverview(i)->GetXSize());
+    }
+  } else if (pixelSizeX > 0) {
+    char** fileList = dataset->GetFileList();
+    for (qint32 n = 0; fileList != nullptr && fileList[n] != nullptr; ++n) {
+      GDALDatasetUniquePtr subDataset(GDALDataset::FromHandle(GDALOpen(fileList[n], GA_ReadOnly)));
+      GDALRasterBand* subBand = subDataset ? subDataset->GetRasterBand(1) : nullptr;
+      qreal subGeoTransform[6];
+      if (subBand == nullptr || subBand->GetOverviewCount() == 0 ||
+          subDataset->GetGeoTransform(subGeoTransform) != CE_None) {
+        continue;
+      }
+
+      const qreal subPixelSizeX = qAbs(subGeoTransform[1]);
+      for (qint32 i = 0; i < subBand->GetOverviewCount(); ++i) {
+        const qreal overviewPixelSizeX = subPixelSizeX * subBand->GetXSize() / subBand->GetOverview(i)->GetXSize();
+        factors << qRound(overviewPixelSizeX / pixelSizeX);
+      }
+    }
+    CSLDestroy(fileList);
+  }
+
+  QVector<qint32> result(factors.begin(), factors.end());
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+void CMapVRT::closeDataset(GDALDataset*& dataset) {
+  if (dataset != nullptr) {
+    GDALClose(dataset);
+    dataset = nullptr;
+  }
+}
+
+void CMapVRT::fail(const QString& msg) {
+  closeDataset(dataset);
+  closeDataset(srcDataset);
+  QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."), msg);
+}
+
+bool CMapVRT::computeSourceWindow(const IDrawContext::buffer_t& buf, const QPointF& bufferScale,
+                                  sourceWindow_t& window) const {
+  // use bufferScale (and therefore the zoom level) and the pixel scale of the map to calculate a downsampling
+  // factor; <1 would mean GDAL does upscaling which is pointless
+  const qreal bufScaleX = qMax(1.0, qAbs(bufferScale.x() / xscale));
+  const qreal bufScaleY = qMax(1.0, qAbs(bufferScale.y() / yscale));
+
+  // corners of the area we shall draw, converted from the canvas projection into the
+  // map's own pixel coordinate space
+  auto toMapPixel = [this](QPointF pt) {
+    proj.transform(pt, PJ_INV);
+    return trInv.map(pt);
+  };
+  const QPointF pt1 = toMapPixel(buf.ref1);
+  const QPointF pt2 = toMapPixel(buf.ref2);
+  const QPointF pt3 = toMapPixel(buf.ref3);
+  const QPointF pt4 = toMapPixel(buf.ref4);
+
+  // bounds of the area to draw in the coordinate space of the map
+  qreal left = std::min({pt1.x(), pt2.x(), pt3.x(), pt4.x()});
+  qreal right = std::max({pt1.x(), pt2.x(), pt3.x(), pt4.x()});
+  qreal top = std::min({pt1.y(), pt2.y(), pt3.y(), pt4.y()});
+  qreal bottom = std::max({pt1.y(), pt2.y(), pt3.y(), pt4.y()});
+
+  const bool intersectsMap = (top <= ysize_px) && (left <= xsize_px) && (bottom >= 0) && (right >= 0);
+  if (!intersectsMap) {
     return false;
   }
 
-  QDomDocument xml;
-  const QDomDocument::ParseResult& result = xml.setContent(&file);
-  if (!result) {
-    file.close();
-    throw tr("Failed to read: %1\nline %2, column %3:\n %4")
-        .arg(filename)
-        .arg(result.errorLine)
-        .arg(result.errorColumn)
-        .arg(result.errorMessage);
-    qDebug() << "Failed to read:" << filename << Qt::endl
-             << "line" << result.errorLine << ", column" << result.errorColumn << Qt::endl
-             << result.errorMessage;
-    return false;
-  }
-  file.close();
+  // current view intersects the bounds of the map, so clip to them
+  left = std::clamp(left, 0.0, (qreal)xsize_px);
+  top = std::clamp(top, 0.0, (qreal)ysize_px);
+  right = std::clamp(right, 0.0, (qreal)xsize_px);
+  bottom = std::clamp(bottom, 0.0, (qreal)ysize_px);
 
-  QSet<QString> files;
-  QDir basePath(QFileInfo(filename).absoluteDir());
-  const QDomElement& xmlVrt = xml.documentElement();
-
-  {
-    const QDomNodeList& xmlComplexSources = xmlVrt.elementsByTagName("ComplexSource");
-    const int N = xmlComplexSources.count();
-    for (int n = 0; n < N; ++n) {
-      const QDomNode& xmlComplexSource = xmlComplexSources.item(n);
-      const QDomNode& xmlSourceFilename = xmlComplexSource.namedItem("SourceFilename");
-      const QDomNamedNodeMap& attr = xmlSourceFilename.attributes();
-      QString subFilename = xmlSourceFilename.toElement().text();
-
-      if (attr.contains("relativeToVRT") && (attr.namedItem("relativeToVRT").nodeValue() == "1")) {
-        subFilename = basePath.absoluteFilePath(subFilename);
-      }
-
-      files << subFilename;
-    }
-  }
-
-  {
-    const QDomNodeList& xmlSimpleSources = xmlVrt.elementsByTagName("SimpleSource");
-    const int N = xmlSimpleSources.count();
-    for (int n = 0; n < N; ++n) {
-      const QDomNode& xmlSimpleSource = xmlSimpleSources.item(n);
-      const QDomNode& xmlSourceFilename = xmlSimpleSource.namedItem("SourceFilename");
-      const QDomNamedNodeMap& attr = xmlSourceFilename.attributes();
-      QString subFilename = xmlSourceFilename.toElement().text();
-
-      if (attr.contains("relativeToVRT") && (attr.namedItem("relativeToVRT").nodeValue() == "1")) {
-        subFilename = basePath.absoluteFilePath(subFilename);
-      }
-
-      files << subFilename;
-    }
-  }
-
-  if (files.isEmpty()) {
+  if ((right <= left) || (bottom <= top)) {
     return false;
   }
 
-  for (const QString& file : std::as_const(files)) {
-    using pGDALDataset = QSharedPointer<GDALDataset>;
-    pGDALDataset _dataset = pGDALDataset((GDALDataset*)GDALOpen(file.toUtf8(), GA_ReadOnly), GDALClose);
-    // _dataset will be destroyed automatically by shared pointer.
-
-    if (_dataset == nullptr) {
-      return false;
-    }
-
-    if (_dataset->GetRasterCount() > 0) {
-      if (_dataset->GetRasterBand(1)->GetOverviewCount() == 0) {
-        return false;
-      }
-    } else {
-      return false;
-    }
-  }
-
+  window.left = left;
+  window.top = top;
+  window.right = right;
+  window.bottom = bottom;
+  // dimensions of the buffer GDAL will read into; requesting a different size than the size of the source
+  // window lets GDAL do the scaling for us and use overviews
+  window.bufWidth = qMax(1, qRound((right - left) / bufScaleX));
+  window.bufHeight = qMax(1, qRound((bottom - top) / bufScaleY));
   return true;
+}
+
+QImage CMapVRT::readSourceImage(const sourceWindow_t& window) {
+  const qreal w_map = window.right - window.left;
+  const qreal h_map = window.bottom - window.top;
+  const qint32 w_buf = window.bufWidth;
+  const qint32 h_buf = window.bufHeight;
+
+  // add a temporary GDAL error handler to filter out errors that are caused by intentionally aborted reads
+  // automatically removed at end of scope
+  CPLErrorHandlerPusher oCurrentHandler(
+      [](CPLErr eErrClass, CPLErrorNum errNo, const char* msg) {
+        if (errNo == CPLE_UserInterrupt || errNo == CPLE_AppDefined) {
+          return;
+        }
+        CPLDefaultErrorHandler(eErrClass, errNo, msg);
+      },
+      nullptr);
+
+  QImage img;
+  CPLErr err = CE_Failure;
+  if (rasterBandCount == 1) {
+    // backs img's pixel buffer: QImage's own row alignment may pad bytesPerLine() beyond
+    // w_buf, so we read into a tightly packed member buffer instead (resized, not
+    // reallocated, across draw() calls) and hand it to QImage with an explicit
+    // bytesPerLine; it outlives img below since indexData is a member, not a local
+    indexData.resize(static_cast<qsizetype>(w_buf) * h_buf);
+
+    err = dataset->GetRasterBand(1)->ReadRaster(indexData.data(), static_cast<size_t>(indexData.size()), window.left,
+                                                window.top, w_map, h_map, w_buf, h_buf, GRIORA_NearestNeighbour,
+                                                &CMapVRT::progressCallback, map);
+    if (err == CE_None) {
+      img = QImage(indexData.constData(), w_buf, h_buf, w_buf, QImage::Format_Indexed8);
+      img.setColorTable(colortable);
+    }
+  } else {
+    img = QImage(w_buf, h_buf, QImage::Format_ARGB32);
+    img.fill(qRgba(255, 255, 255, 255));
+
+    bandBuf.resize(static_cast<qsizetype>(w_buf) * h_buf);
+    const QRgb testPix = qRgba(GCI_RedBand, GCI_GreenBand, GCI_BlueBand, GCI_AlphaBand);
+
+    // byte offset of channel within one ARGB32 pixel - exploits testPix's in-memory
+    // layout, where each component ends up at the offset matching its own enum value
+    // since GCI_RedBand/GreenBand/BlueBand/AlphaBand happen to be 3/4/5/6
+    auto offsetOf = [&testPix](GDALColorInterp channel) {
+      quint32 offset = 0;
+      while (offset < sizeof(testPix) && *(((const quint8*)&testPix) + offset) != channel) {
+        ++offset;
+      }
+      return offset;
+    };
+    auto copyBandInto = [&](quint32 offset) {
+      quint8* pTar = img.bits() + offset;
+      const quint8* pSrc = bandBuf.constData();
+      for (qsizetype i = 0; i < bandBuf.size(); ++i) {
+        *pTar = *pSrc;
+        pTar += sizeof(testPix);
+        pSrc += 1;
+      }
+    };
+    const quint32 offsetR = offsetOf(GCI_RedBand);
+    const quint32 offsetG = offsetOf(GCI_GreenBand);
+    const quint32 offsetB = offsetOf(GCI_BlueBand);
+
+    for (qint32 b = 1; b <= rasterBandCount; ++b) {
+      GDALRasterBand* pBand = dataset->GetRasterBand(b);
+
+      err = pBand->ReadRaster(bandBuf.data(), static_cast<size_t>(bandBuf.size()), window.left, window.top, w_map,
+                              h_map, w_buf, h_buf, GRIORA_Bilinear, &CMapVRT::progressCallback, map);
+      if (err != CE_None) {
+        break;
+      }
+
+      const GDALColorInterp pbandColour = pBand->GetColorInterpretation();
+      if (pbandColour == GCI_GrayIndex) {
+        // a lone gray channel among other bands (e.g. gray+alpha) - duplicate it into
+        // R, G and B rather than dropping it
+        copyBandInto(offsetR);
+        copyBandInto(offsetG);
+        copyBandInto(offsetB);
+      } else {
+        const quint32 offset = offsetOf(pbandColour);
+        if (offset < sizeof(testPix)) {
+          copyBandInto(offset);
+        }
+      }
+    }
+  }
+
+  return (err == CE_None) ? img : QImage();
+}
+
+void CMapVRT::drawSourceImage(QPainter& p, const sourceWindow_t& window, const QImage& img) const {
+  // Map img onto screen with the exact affine transform instead of an axis-aligned
+  // QRectF. GDAL's warp (in the ctor) already resolved any cross-projection curvature
+  // into the dataset's own pixel grid, and proj.transform(PJ_FWD) here is the exact
+  // inverse of what map->convertRad2Px() does internally to get back to this view's
+  // CRS, so the two cancel to identity. What's left is trFwd: a fixed matrix that can
+  // carry shear/rotation from a non-north-up source geotransform, composed with
+  // convertRad2Px()'s affine pan/zoom - both affine, so 3 corners fully determine the
+  // map; no curve-fitting/subdivision (as used for genuinely curved projections
+  // elsewhere) is needed.
+  auto toScreenPx = [this](QPointF pt) {
+    pt = trFwd.map(pt);
+    proj.transform(pt, PJ_FWD);
+    map->convertRad2Px(pt);
+    return pt;
+  };
+  const QPointF s0 = toScreenPx(QPointF(window.left, window.top));
+  const QPointF s1 = toScreenPx(QPointF(window.right, window.top));
+  const QPointF s3 = toScreenPx(QPointF(window.left, window.bottom));
+
+  const QTransform imgToScreen((s1.x() - s0.x()) / window.bufWidth, (s1.y() - s0.y()) / window.bufWidth,
+                               (s3.x() - s0.x()) / window.bufHeight, (s3.y() - s0.y()) / window.bufHeight, s0.x(),
+                               s0.y());
+
+  p.save();
+  p.setTransform(imgToScreen, true);
+  p.drawImage(QPointF(0, 0), img);
+  p.restore();
+}
+
+void CMapVRT::drawOutline(QPainter& p) const {
+  QPolygonF boundingBox;
+  boundingBox << ref1 << ref2 << ref3 << ref4;
+  map->convertRad2Px(boundingBox);
+
+  p.setPen(Qt::black);
+  p.setBrush(Qt::NoBrush);
+  p.drawPolygon(boundingBox);
 }
 
 void CMapVRT::draw(IDrawContext::buffer_t& buf) /* override */
@@ -265,97 +494,11 @@ void CMapVRT::draw(IDrawContext::buffer_t& buf) /* override */
     return;
   }
 
-  QPointF bufferScale = buf.scale * buf.zoomFactor;
-
-  // calculate bounding box;
-  QPointF pt1 = ref1;
-  QPointF pt2 = ref2;
-  QPointF pt3 = ref3;
-  QPointF pt4 = ref4;
-
-  proj.transform(pt1, PJ_FWD);
-  proj.transform(pt2, PJ_FWD);
-  proj.transform(pt3, PJ_FWD);
-  proj.transform(pt4, PJ_FWD);
-
-  QPolygonF boundingBox;
-  boundingBox << pt1 << pt2 << pt3 << pt4;
-  map->convertRad2Px(boundingBox);
+  const QPointF bufferScale = buf.scale * buf.zoomFactor;
 
   // get pixel offset of top left buffer corner
   QPointF pp = buf.ref1;
   map->convertRad2Px(pp);
-
-  // calculate area to read from file
-  pt1 = buf.ref1;
-  pt2 = buf.ref2;
-  pt3 = buf.ref3;
-  pt4 = buf.ref4;
-
-  proj.transform(pt1, PJ_INV);
-  proj.transform(pt2, PJ_INV);
-  proj.transform(pt3, PJ_INV);
-  proj.transform(pt4, PJ_INV);
-
-  pt1 = trInv.map(pt1);
-  pt2 = trInv.map(pt2);
-  pt3 = trInv.map(pt3);
-  pt4 = trInv.map(pt4);
-
-  qreal left, right, top, bottom;
-  left = pt1.x() < pt4.x() ? pt1.x() : pt4.x();
-  right = pt2.x() > pt3.x() ? pt2.x() : pt3.x();
-  top = pt1.y() < pt2.y() ? pt1.y() : pt2.y();
-  bottom = pt4.y() > pt3.y() ? pt4.y() : pt3.y();
-
-  if (left < 0) {
-    left = 0;
-  }
-  if (left > xsize_px) {
-    left = xsize_px;
-  }
-
-  if (top < 0) {
-    top = 0;
-  }
-  if (top > ysize_px) {
-    top = ysize_px;
-  }
-
-  if (right > xsize_px) {
-    right = xsize_px;
-  }
-  if (right < 0) {
-    right = 0;
-  }
-
-  if (bottom > ysize_px) {
-    bottom = ysize_px;
-  }
-  if (bottom < 0) {
-    bottom = 0;
-  }
-
-  qint32 imgw = TILESIZEX;
-  qint32 imgh = TILESIZEY;
-  qint32 dx = imgw;
-  qint32 dy = imgh;
-
-  // estimate number of tiles and use it as a limit if no
-  // user defined limit is given
-  qreal nTiles = ((right - left) * (bottom - top) / (dx * dy));
-  if (hasOverviews) {
-    // if there are overviews tiles can be reduced by reading
-    // with a scale factor from file. Increase amount of pixel
-    // read until tile limit is met.
-    while (nTiles > TILELIMIT) {
-      dx *= 2;
-      dy *= 2;
-      nTiles /= 4;
-    }
-  } else {
-    nTiles = getMaxScale() == NOFLOAT ? nTiles : 0;
-  }
 
   // start to draw the map
   QPainter p(&buf.image);
@@ -363,106 +506,13 @@ void CMapVRT::draw(IDrawContext::buffer_t& buf) /* override */
   p.setOpacity(getOpacity() / 100.0);
   p.translate(-pp);
 
-  //    qDebug() << imgw << dx << nTiles;
-  // limit number of tiles to keep performance
-  if (!isOutOfScale(bufferScale) && (nTiles < TILELIMIT)) {
-    for (qint32 y = top; y < bottom; y += dy) {
-      if (map->needsRedraw()) {
-        break;
-      }
-
-      for (qint32 x = left; x < right; x += dx) {
-        if (map->needsRedraw()) {
-          break;
-        }
-
-        // read tile from file
-        CPLErr err = CE_Failure;
-
-        // reduce tile size at the border of the file
-        qreal dx_used = dx;
-        qreal dy_used = dy;
-        qreal imgw_used = imgw;
-        qreal imgh_used = imgh;
-
-        if ((x + dx) > xsize_px) {
-          dx_used = xsize_px - x;
-          imgw_used = qRound(imgw * dx_used / dx) & 0xFFFFFFFC;
-        }
-        if ((y + dy) > ysize_px) {
-          dy_used = ysize_px - y;
-          imgh_used = imgh * dy_used / dy;
-        }
-
-        dx_used = qFloor(dx_used);
-        dy_used = qFloor(dy_used);
-        imgw_used = qRound(imgw_used);
-        imgh_used = qRound(imgh_used);
-
-        if (imgw_used < 1 || imgh_used < 1) {
-          continue;
-        }
-
-        QImage img;
-        if (rasterBandCount == 1) {
-          GDALRasterBand* pBand;
-          pBand = dataset->GetRasterBand(1);
-
-          img = QImage(QSize(imgw_used, imgh_used), QImage::Format_Indexed8);
-          img.setColorTable(colortable);
-
-          err = pBand->RasterIO(GF_Read, x, y, dx_used, dy_used, img.bits(), imgw_used, imgh_used, GDT_Byte, 0, 0);
-        } else {
-          img = QImage(imgw_used, imgh_used, QImage::Format_ARGB32);
-          img.fill(qRgba(255, 255, 255, 255));
-
-          QVector<quint8> buffer(imgw_used * imgh_used);
-
-          QRgb testPix = qRgba(GCI_RedBand, GCI_GreenBand, GCI_BlueBand, GCI_AlphaBand);
-
-          for (int b = 1; b <= rasterBandCount; ++b) {
-            GDALRasterBand* pBand;
-            pBand = dataset->GetRasterBand(b);
-
-            err = pBand->RasterIO(GF_Read, x, y, dx_used, dy_used, buffer.data(), imgw_used, imgh_used, GDT_Byte, 0, 0);
-
-            if (!err) {
-              int pbandColour = pBand->GetColorInterpretation();
-              unsigned int offset;
-
-              for (offset = 0; offset < sizeof(testPix) && *(((quint8*)&testPix) + offset) != pbandColour; offset++) {
-              }
-              if (offset < sizeof(testPix)) {
-                quint8* pTar = img.bits() + offset;
-                quint8* pSrc = buffer.data();
-                const int size = buffer.size();
-
-                for (int i = 0; i < size; ++i) {
-                  *pTar = *pSrc;
-                  pTar += sizeof(testPix);
-                  pSrc += 1;
-                }
-              }
-            }
-          }
-        }
-
-        if (err) {
-          continue;
-        }
-
-        QPolygonF l;
-        l << QPointF(x, y) << QPointF(x + dx_used, y) << QPointF(x + dx_used, y + dy_used) << QPointF(x, y + dy_used);
-        l = trFwd.map(l);
-
-        proj.transform(l, PJ_FWD);
-
-        drawTile(img, l, p);
-      }
+  sourceWindow_t window;
+  if (!isOutOfScale(bufferScale) && computeSourceWindow(buf, bufferScale, window)) {
+    const QImage img = readSourceImage(window);
+    if (!img.isNull()) {
+      drawSourceImage(p, window, img);
     }
   }
 
-  p.setPen(Qt::black);
-  p.setBrush(Qt::NoBrush);
-  p.drawPolygon(boundingBox);
+  drawOutline(p);
 }

--- a/src/qmapshack/map/CMapVRT.h
+++ b/src/qmapshack/map/CMapVRT.h
@@ -23,7 +23,26 @@
 
 class CMapDraw;
 class GDALDataset;
+class GDALRasterBand;
+class QPainter;
 
+/**
+   @brief GDAL-backed IMap implementation: reads raster map tiles from any format
+          GDAL can open (GeoTIFF, VRT, IMG, ...).
+
+   On construction, the file is opened read-only and its color table (single
+   palette/gray band) or band layout (multi-band RGB(A)) is read. If the dataset's
+   spatial reference differs from the draw context's projection, it is wrapped in a
+   GDALAutoCreateWarpedVRT so all later reads transparently happen in the draw
+   context's projection; the original dataset is then kept alive as srcDataset purely
+   because the warped VRT references it.
+
+   draw() reads exactly the (downsampled) window the current view needs via GDAL's
+   RasterIO/ReadRaster - letting GDAL pick overviews as needed - and composites it
+   onto the map in a single draw.
+
+   @see CDemVRT, which uses the same warp/read strategy for elevation data.
+ */
 class CMapVRT : public IMap {
   Q_OBJECT
  public:
@@ -34,18 +53,110 @@ class CMapVRT : public IMap {
 
  private:
   /**
-     @brief Test subfiles of VRT for overviews
-     @param filename The VRT filename to inspect
-     @return Return true if all subfiles have overviews.
+     @brief Check that every file GDAL reports as part of the dataset (e.g. the files a
+            VRT references) actually exists on disk.
+     @param dataset     the dataset to check
+     @param missingFile set to the first referenced file that could not be found; left
+                         unchanged if all files exist
+     @return false if a referenced file is missing
    */
-  bool testForOverviews(const QString& filename);
+  static bool allReferencedFilesExist(GDALDataset* dataset, QString& missingFile);
+
+  /**
+     @brief Collect virtual-overview decimation factors for dataset, in dataset's own pixel
+            scale.
+
+     Prefers dataset's own overview list. If dataset reports none - e.g. a gdalbuildvrt
+     mosaic whose <OverviewList> is stale, was never written because not every source had
+     overviews when the mosaic was built, or still has one source that lacks them - falls
+     back to the union of overview factors found across the individual files dataset depends
+     on, so one under-prepared source no longer disables overview-accelerated reads for the
+     whole mosaic. Each file's factors are converted via its own geotransform pixel size
+     rather than reused as raw pixel ratios, so sources of differing native resolution stay
+     consistent with dataset's own grid.
+     @param dataset    the (pre-warp) dataset to collect overview factors for
+     @param pBand      dataset's band 1
+     @param pixelSizeX the real-world size of one of dataset's own pixels along x; pass 0 if
+                       unknown to skip the per-file fallback entirely
+     @return sorted, de-duplicated decimation factors; empty if none are available anywhere
+   */
+  static QVector<qint32> collectOverviewFactors(GDALDataset* dataset, GDALRasterBand* pBand, qreal pixelSizeX);
+
+  /**
+     @brief GDAL progress callback aborting the read once a newer redraw has been
+            requested.
+     @param pProgressArg the CMapDraw passed in as progress callback context
+   */
+  static int progressCallback(double dfComplete, const char* message, void* pProgressArg);
+
+  /// Close a GDAL dataset and reset the pointer, tolerating a null dataset.
+  static void closeDataset(GDALDataset*& dataset);
+
+  /// Close dataset and srcDataset (either may already be null, e.g. if construction
+  /// failed before a warped VRT was needed) and show msg in an error dialog.
+  void fail(const QString& msg);
+
+  /// the read window for one draw() call, in dataset's own pixel coordinate space,
+  /// clipped to [0, xsize_px] x [0, ysize_px]; bufWidth/bufHeight are the dimensions of
+  /// the (possibly downsampled) buffer GDAL should read into
+  struct sourceWindow_t {
+    qreal left;
+    qreal top;
+    qreal right;
+    qreal bottom;
+    qint32 bufWidth;
+    qint32 bufHeight;
+  };
+
+  /**
+     @brief Compute the read window draw() needs for the current view.
+     @param buf         the canvas buffer being drawn; its ref1..ref4 corners are
+                         converted into this dataset's own pixel coordinate space
+     @param bufferScale buf.scale * buf.zoomFactor
+     @param window      set to the clipped read window and read buffer size
+     @return false if the current view does not intersect the dataset, or the
+             intersection is empty after clipping (window is left unchanged)
+   */
+  bool computeSourceWindow(const IDrawContext::buffer_t& buf, const QPointF& bufferScale, sourceWindow_t& window) const;
+
+  /**
+     @brief Read window from dataset into a QImage.
+     @param window the area/resolution to read, as computed by computeSourceWindow()
+     @return Format_Indexed8 image for single-band palette/gray data, Format_ARGB32 for
+             multi-band; a null QImage if the GDAL read failed or was aborted
+   */
+  QImage readSourceImage(const sourceWindow_t& window);
+
+  /**
+     @brief Composite img onto p at the screen position/orientation matching window.
+     @param p      the canvas painter, already translated/opacity-set by draw()
+     @param window the window img was read from, as computed by computeSourceWindow()
+     @param img    the image returned by readSourceImage()
+   */
+  void drawSourceImage(QPainter& p, const sourceWindow_t& window, const QImage& img) const;
+
+  /// Draw the outline of the loaded file's extent onto p.
+  void drawOutline(QPainter& p) const;
+
   QString filename;
-  /// instance of GDAL dataset
-  GDALDataset* dataset;
+  /// the dataset as originally opened by GDAL; null unless a warped VRT was needed, in
+  /// which case it is kept alive only because dataset (the warped VRT) references it
+  GDALDataset* srcDataset = nullptr;
+  /// the dataset actually read from: either the dataset as opened, or - if reprojection
+  /// was needed - the warped VRT wrapping srcDataset
+  GDALDataset* dataset = nullptr;
   /// number of color bands used by the *vrt
-  int rasterBandCount = 0;
+  qint32 rasterBandCount = 0;
   /// QT representation of the vrt's color table
   QVector<QRgb> colortable;
+
+  /// draw()'s read buffer for the single-band indexed case; kept as a member (resized, not
+  /// reallocated, per draw()) so repeated redraws at a stable viewport size don't churn the
+  /// heap every frame
+  QVector<quint8> indexData;
+  /// draw()'s read buffer for one band of the multi-band ARGB32 case; same rationale as
+  /// indexData
+  QVector<quint8> bandBuf;
 
   /// width in number of px
   qint32 xsize_px = 0;
@@ -57,18 +168,22 @@ class CMapVRT : public IMap {
   /// scale [px/m]
   qreal yscale = 0;
 
-  qreal xrot = 0;
-  qreal yrot = 0;
-
+  /// corners of the *original* (pre-warp) raster's true footprint, already in
+  /// canvas-internal WGS84 [rad] space; drawOutline() draws these via convertRad2Px()
+  /// directly, with no further reprojection. Deliberately not derived from trFwd/proj,
+  /// which (once a warp is in play) describe the padded, axis-aligned-in-target-SRS
+  /// warped VRT instead of the source data's real (possibly rotated) shape.
   QPointF ref1;
   QPointF ref2;
   QPointF ref3;
   QPointF ref4;
 
+  /// maps this map's pixel coordinates to the dataset's own (possibly warped) CRS;
+  /// output is in [rad] if that CRS is geographic (see proj.isSrcLatLong()), otherwise
+  /// in the CRS's native units
   QTransform trFwd;
+  /// trFwd inverted: maps the dataset's CRS back to this map's pixel coordinates
   QTransform trInv;
-
-  bool hasOverviews = false;
 };
 
 #endif  // CMAPVRT_H


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1125

### What you have done:
[comment]: # (Describe roughly.)

Used the same pattern as in CDemVrt to read re-projected and scaled map data via the GDAL API

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Test the PR on all kinds of raster maps, enclosed in a GDAL VRT file.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
