### PR TITLE
[QMS-902] Add basic HiDPI support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-902] Add basic HiDPI support
 [QMS-963] Add action to move a map to the top in map list
 [QMS-1105] Fix: Context menu shortcuts not shown (macOS)
 [QMS-1111] Add percentage values to track range

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -1183,6 +1183,14 @@ bool CCanvas::setDrawContextSize(const QSize& s) {
   return done;
 }
 
+bool CCanvas::setDrawContextPixelRatio(qreal ratio) {
+  bool done = true;
+  for (IDrawContext* context : std::as_const(allDrawContext)) {
+    done &= context->setPixelRatio(ratio);
+  }
+  return done;
+}
+
 void CCanvas::print(QPainter& p, const QRectF& area, const QPointF& focus, bool printScale) {
   const QSize oldSize = size();
   const QSize newSize(area.size().toSize());
@@ -1233,6 +1241,15 @@ bool CCanvas::event(QEvent* event) {
       // as some mouse-events may have been lost
       mouse->afterMouseLostEvent(me);
       mouseLost = false;
+    }
+  }
+  if (event->type() == QEvent::DevicePixelRatioChange) {
+    if (!setDrawContextPixelRatio(devicePixelRatio())) {
+      // reschedule resize event because one of the draw context threads is still running
+      // and blocking the access to internal data.
+      QApplication::postEvent(this, new QEvent(QEvent::DevicePixelRatioChange));
+    } else {
+      needsRedraw = eRedrawAll;
     }
   }
   return QWidget::event(event);

--- a/src/qmapshack/canvas/CCanvas.h
+++ b/src/qmapshack/canvas/CCanvas.h
@@ -240,6 +240,8 @@ class CCanvas : public QWidget {
    */
   bool setDrawContextSize(const QSize& s);
 
+  bool setDrawContextPixelRatio(qreal ratio);
+
   bool isShowMinMaxSummary() const;
   bool isShowTrackSummary() const;
   bool isShowTrackInfoTable() const;

--- a/src/qmapshack/canvas/IDrawContext.cpp
+++ b/src/qmapshack/canvas/IDrawContext.cpp
@@ -50,6 +50,7 @@ IDrawContext::IDrawContext(const QString& name, CCanvas::redraw_e maskRedraw, CC
 
   zoom(5);
 
+  pixelRatio = canvas->devicePixelRatio();
   resize(canvas->size());
   connect(this, &IDrawContext::finished, canvas, static_cast<void (CCanvas::*)()>(&CCanvas::update));
   connect(this, &IDrawContext::finished, this, &IDrawContext::sigStopThread);
@@ -73,20 +74,45 @@ bool IDrawContext::resize(const QSize& size) {
   QMutexLocker lock(&mutex);
 
   lastSize = size;
-  viewWidth = size.width();
-  viewHeight = size.height();
+  resize();
+
+  return true;
+}
+
+bool IDrawContext::setPixelRatio(qreal ratio) {
+  if (pixelRatio == ratio) {
+    // nothing to do
+    return true;
+  }
+
+  if (isRunning() && !wait(100)) {
+    // blocked by thread, reschedule
+    return false;
+  }
+
+  QMutexLocker lock(&mutex);
+
+  pixelRatio = ratio;
+  resize();
+
+  return true;
+}
+
+void IDrawContext::resize() {
+  viewWidth = lastSize.width();
+  viewHeight = lastSize.height();
 
   center = QPointF(viewWidth / 2.0, viewHeight / 2.0);
-  bufWidth = viewWidth + 2 * BUFFER_BORDER;
-  bufHeight = viewHeight + 2 * BUFFER_BORDER;
+  bufWidth = viewWidth * pixelRatio + 2 * BUFFER_BORDER;
+  bufHeight = viewHeight * pixelRatio + 2 * BUFFER_BORDER;
 
   buffer[0].image = QImage(bufWidth, bufHeight, QImage::Format_ARGB32);
   buffer[0].image.fill(Qt::transparent);
+  buffer[0].image.setDevicePixelRatio(pixelRatio);
 
   buffer[1].image = QImage(bufWidth, bufHeight, QImage::Format_ARGB32);
   buffer[1].image.fill(Qt::transparent);
-
-  return true;
+  buffer[1].image.setDevicePixelRatio(pixelRatio);
 }
 
 QString IDrawContext::getProjection() const { return proj.getProjSrc(); }
@@ -170,7 +196,7 @@ void IDrawContext::zoom(int idx) {
     zoomFactor.ry() = scales[idx];
     intNeedsRedraw = true;
     emit sigNeedsRedraw();
-    emit sigScaleChanged(scale * zoomFactor);
+    emit sigScaleChanged(scale * zoomFactor / pixelRatio);
   }
   mutex.unlock();  // --------- stop serialize with thread
 }
@@ -318,7 +344,7 @@ void IDrawContext::draw(QPainter& p, CCanvas::redraw_e needsRedraw, const QPoint
   QPointF f1 = focus;
   convertRad2M(f1);
 
-  QPointF bufferScale = scale * zoomFactor;
+  QPointF bufferScale = scale * zoomFactor / pixelRatio;
 
   mutex.lock();  // --------- start serialize with thread
 
@@ -397,6 +423,7 @@ void IDrawContext::run() {
     // map render objects to buffer structure
     currentBuffer.zoomFactor = zoomFactor;
     currentBuffer.scale = scale;
+    currentBuffer.pixelRatio = pixelRatio;
     currentBuffer.ref1 = ref1;
     currentBuffer.ref2 = ref2;
     currentBuffer.ref3 = ref3;

--- a/src/qmapshack/canvas/IDrawContext.h
+++ b/src/qmapshack/canvas/IDrawContext.h
@@ -43,6 +43,7 @@ class IDrawContext : public QThread {
     int zoomLevels;                //< the number of zoom levels
     QPointF zoomFactor{1.0, 1.0};  //< the zoomfactor used to draw the canvas
     QPointF scale{1.0, 1.0};       //< the scale of the global viewport
+    qreal pixelRatio = 1.0;        //< device pixel ratio of the canvas
 
     QPointF ref1;   //< top left corner
     QPointF ref2;   //< top right corner
@@ -57,6 +58,14 @@ class IDrawContext : public QThread {
      @return Return false if the request could not access data because the thread is running.
    */
   bool resize(const QSize& size);
+
+  /**
+     @brief change the device pixel ratio and resize the internal buffer
+     @param ratio the new pixel ratio
+     @return Return false if the request could not access data because the thread is running.
+   */
+  bool setPixelRatio(qreal ratio);
+
   /**
      @brief Zoom in and out of the map by the scale factors defined in CMapDB::scales.
      @param in            set true to zoom in, and false to zoom out
@@ -183,6 +192,8 @@ class IDrawContext : public QThread {
 
   QSize lastSize;
 
+  qreal pixelRatio = 1.0;
+
   QPointF center;  /// the center of the viewport
 
   /**
@@ -195,6 +206,7 @@ class IDrawContext : public QThread {
   int zoomIndex = 0;
 
  private:
+  void resize();
   /// the used scales and the type of scale levels
   const qreal* scales = nullptr;
   CCanvas::scales_type_e scalesType;

--- a/src/qmapshack/map/CMapGEMF.cpp
+++ b/src/qmapshack/map/CMapGEMF.cpp
@@ -161,7 +161,7 @@ void CMapGEMF::draw(IDrawContext::buffer_t& buf) {
     x2 = 180 * DEG_TO_RAD;
   }
 
-  QPointF s1 = buf.scale * buf.zoomFactor;
+  QPointF s1 = buf.scale * buf.zoomFactor / buf.pixelRatio;
   qreal d = NOFLOAT;
   quint32 z = MAX_ZOOM_LEVEL;
 

--- a/src/qmapshack/map/CMapJNX.cpp
+++ b/src/qmapshack/map/CMapJNX.cpp
@@ -287,7 +287,7 @@ void CMapJNX::draw(IDrawContext::buffer_t& buf) /* override */
       break;
     }
 
-    qint32 level = scale2level(bufferScale.x() / 5, mapFile);
+    qint32 level = scale2level(bufferScale.x() / (5 * buf.pixelRatio), mapFile);
 
     // no scalable level found, draw bounding box of map
     // derive maps corner coordinate

--- a/src/qmapshack/map/CMapRMAP.cpp
+++ b/src/qmapshack/map/CMapRMAP.cpp
@@ -343,7 +343,7 @@ void CMapRMAP::draw(IDrawContext::buffer_t& buf) /* override */
     return;
   }
 
-  level_t& level = findBestLevel(bufferScale);
+  level_t& level = findBestLevel(bufferScale / buf.pixelRatio);
 
   // convert top left and bottom right point of buffer to local coord. system
   QPointF p1 = buf.ref1;

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -324,7 +324,7 @@ void CMapTMS::draw(IDrawContext::buffer_t& buf) /* override */
     }
 
     qint32 z = 20;
-    QPointF s1 = buf.scale * buf.zoomFactor;
+    QPointF s1 = buf.scale * buf.zoomFactor / buf.pixelRatio;
     qreal d = NOFLOAT;
 
     for (qint32 i = layer.minZoomLevel; i < 21; i++) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#902

### What you have done:
[comment]: # (Describe roughly.)

Add handling for device pixel ratios to canvas and draw context. This makes IMG maps behave correctly on scaled displays. Some minor tweaks to raster based maps that make them scale properly at least under some conditions and plattforms.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Try different types of maps with different scaling ratios configured in the OS. Move window between displays with different scaling ratios.

See also discussion in #902 where changes where tested already. This is just my "hidpi" branch rolled into a PR.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
