### PR TITLE
Replace QPainter with Blend2D in CMapIMG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,21 @@ preview curve.
 - Below ~80 nodes the basis, not the penalty, limits the curve. That is where the quality setting
   changes the result.
 
+### IGarminStrTbl label cache (the `get`/`decode` split)
+
+Profiling (Tracy) showed label decoding (`strtbl.get`) was the single largest slice of
+`loadVisibleData` — an `mmap` (via `CFileExt::data()`) plus a codepage decode **per labelled object,
+re-done every frame** even though label content is immutable. To fix that, `IGarminStrTbl::get()` is a
+**non-virtual** cache wrapper over a bounded LRU `QCache<quint64, QStringList>` (key `(type << 32) |
+offset`); on a miss it delegates to the protected pure-virtual **`decode()`** (the per-coding work,
+implemented by `CGarminStrTbl6/8/Utf8`). Do not re-merge `get`/`decode` or make `get` virtual again —
+the split exists so the cache lives in exactly one place. The cap (`labelCacheMaxEntries`) bounds
+memory when panning huge gmapsupp files; a hit needs no `mmap` at all, which also shrinks the
+per-subfile `CFileExt::free()` `munmap` loop. The cache is touched only from the draw thread
+(`get()` ← `loadSubDiv` ← `loadVisibleData` ← `draw`, all serialized), so it needs no lock.
+Tracy zones: `strtbl.get` = wrapper (hits+misses), `strtbl.decode` = misses only — compare their call
+counts to read the hit rate.
+
 ---
 
 ## Architecture: tree item delegates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,49 @@ if(APPLE)
 endif(APPLE)
 
 
+include(FetchContent)
+
+###############################################################################################
+# Get Blend2D and it's dependency AsmJit
+###############################################################################################
+# asmjit does not do official releases so pinned it to what was HEAD at time of writing this
+set(ASMJIT_GIT_TAG  "0bd5787b54b575ed94bf32ac452153b34385c514" CACHE STRING "AsmJit git revision to fetch")
+# blend2d does releases but not set git tags; the commit set here referese to release v0.21.2
+set(BLEND2D_GIT_TAG "def0d1238c3e5d0983bb848e5676049d829e435b" CACHE STRING "Blend2D git revision to fetch")
+
+# asmjit is Blend2D's JIT backend. Fetch its sources only: SOURCE_SUBDIR points at a
+# directory with no CMakeLists.txt so FetchContent_MakeAvailable populates without calling
+# add_subdirectory(). Blend2D adds asmjit itself (via ASMJIT_DIR) and, because we build it
+# statically, embeds it directly into the blend2d library.
+FetchContent_Declare(asmjit
+    GIT_REPOSITORY https://github.com/asmjit/asmjit.git
+    GIT_TAG        ${ASMJIT_GIT_TAG}
+    GIT_SHALLOW    FALSE # FALSE required when using a commit hash
+    GIT_PROGRESS TRUE
+    SOURCE_SUBDIR  __populate_only__
+)
+FetchContent_MakeAvailable(asmjit)
+set(ASMJIT_DIR "${asmjit_SOURCE_DIR}" CACHE PATH "AsmJit source directory" FORCE)
+
+set(BLEND2D_STATIC TRUE)
+FetchContent_Declare(blend2d
+    GIT_REPOSITORY https://github.com/blend2d/blend2d.git
+    GIT_TAG        ${BLEND2D_GIT_TAG}
+    GIT_SHALLOW    FALSE
+    GIT_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(blend2d)
+
+# Blend2D's public headers use constructs our warning flags reject (anonymous structs vs
+# -Wpedantic, ...). Re-publish its interface include dirs as system to supress any warnings.
+# Once we bump our minimum cmake version to >= 3.25 we can instead just declare it `SYSTEM`
+# in the `FetchContent_Declare` call and get rid of this.
+get_target_property(BLEND2D_IFACE_INCLUDE_DIRS blend2d INTERFACE_INCLUDE_DIRECTORIES)
+if(BLEND2D_IFACE_INCLUDE_DIRS)
+    set_target_properties(blend2d PROPERTIES
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${BLEND2D_IFACE_INCLUDE_DIRS}")
+endif()
+
 ###############################################################################################
 # Create library from Garmin's FIT SDK
 ###############################################################################################

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-1123] Build error on platform Linux Ubuntu 24.04.4
 [QMS-1125] Use GDAL's warp and scale API to draw *.vrt maps
 [QMS-1128] Enhance VRT handling for maps and DEM
+[QMS-1130] Improve performance of IMG renderer + Fix: patterned areas shifting when panning
 [QMS-1132] Add action to move a map to the top in map list (macOS)
 [QMS-1135] Add guidance to improve overviews for DEM and map VRT
 [QMS-1139] Reject non-UTF-8 encoded VRT files with a clear error message

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -1068,6 +1068,7 @@ target_link_libraries(${APPLICATION_NAME} PRIVATE
     ROUTINO::ROUTINO
     QuaZip::QuaZip
     GarminFit
+    blend2d::blend2d
 )
 
 if(APPLE)

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -590,6 +590,7 @@ set( HDRS
     helpers/Platform.h
     helpers/Signals.h
     helpers/Tristate.h
+    map/Blend2dUtil.h
     map/CMapDraw.h
     map/CMapGEMF.h
     map/CMapIMG.h

--- a/src/qmapshack/map/Blend2dUtil.h
+++ b/src/qmapshack/map/Blend2dUtil.h
@@ -1,0 +1,64 @@
+/**********************************************************************************************
+    Copyright (C) 2026 Jens Mölzer <moelzerjens@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
+
+#ifndef BLEND2DUTIL_H
+#define BLEND2DUTIL_H
+
+#include <blend2d/blend2d.h>
+
+#include <QImage>
+#include <cstring>
+
+/**
+   @brief Deep-copy a QImage into an owning premultiplied BLImage.
+
+   @param img source image in any format; inputs are converted on the fly if necessary
+   @return the owning image, or an empty BLImage on failure
+ */
+inline BLImage toOwnedBLImage(const QImage& img) {
+  BLImage out;
+  if (img.isNull()) {
+    return out;
+  }
+
+  QImage storage;
+  const QImage& src = (img.format() == QImage::Format_ARGB32_Premultiplied)
+                          ? img
+                          : (storage = img.convertToFormat(QImage::Format_ARGB32_Premultiplied));
+
+  if (out.create(src.width(), src.height(), BL_FORMAT_PRGB32) != BL_SUCCESS) {
+    return out;
+  }
+
+  BLImageData dst;
+  if (out.make_mutable(&dst) != BL_SUCCESS) {
+    return BLImage();
+  }
+
+  const qsizetype bpl_src = src.bytesPerLine();
+  const qsizetype bpl_dst = static_cast<qsizetype>(dst.stride);
+  const qsizetype rowBytes = qMin(bpl_src, bpl_dst);
+  const uchar* const s = src.constBits();
+  uchar* const d = static_cast<uchar*>(dst.pixel_data);
+  for (int y = 0; y < src.height(); ++y) {
+    memcpy(d + bpl_dst * y, s + bpl_src * y, static_cast<size_t>(rowBytes));
+  }
+  return out;
+}
+
+#endif  // BLEND2DUTIL_H

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -123,23 +123,13 @@ namespace {
 /// Convert a QColor to a Blend2D non-premultiplied 0xAARRGGBB colour.
 inline BLRgba32 toBLColor(const QColor& c) { return BLRgba32(c.rgba()); }
 
-/// Build a Blend2D path from a polyline. When @p close is set the path is closed
-/// so it can be filled and its closing edge stroked (matching QPainter::drawPolygon).
-BLPath polyToPath(const QPolygonF& poly, bool close) {
-  BLPath path;
-  const int n = poly.size();
-  if (n == 0) {
-    return path;
-  }
-  path.move_to(poly[0].x(), poly[0].y());
-  for (int i = 1; i < n; ++i) {
-    path.line_to(poly[i].x(), poly[i].y());
-  }
-  if (close) {
-    path.close();
-  }
-  return path;
-}
+// QPointF and BLPoint are both two contiguous doubles, so a QPolygonF's storage can be
+// handed to Blend2D's bulk polygon/polyline calls without copying into a BLPath.
+static_assert(sizeof(QPointF) == sizeof(BLPoint), "QPointF must be layout-compatible with BLPoint");
+static_assert(sizeof(QPointF) == 2 * sizeof(double), "QPointF must be two doubles");
+
+/// View a QPolygonF as a contiguous array of BLPoint for Blend2D bulk geometry calls.
+inline const BLPoint* toBLPoints(const QPolygonF& poly) { return reinterpret_cast<const BLPoint*>(poly.constData()); }
 
 BLStrokeCap toBLCap(Qt::PenCapStyle cap) {
   switch (cap) {
@@ -1428,9 +1418,9 @@ void CMapIMG::loadVisibleData(bool fast, polytype_t& polygons, polytype_t& polyl
 
       map->convertRad2Px(poly);
 
-      ctx.setStrokeWidth(2);
-      ctx.setStrokeStyle(BLRgba32(0xFFFF00FFu));  // magenta
-      ctx.strokePath(polyToPath(poly, true));
+      ctx.set_stroke_width(2);
+      ctx.set_stroke_style(BLRgba32(0xFFFF00FFu));  // magenta
+      ctx.stroke_polygon(toBLPoints(poly), static_cast<size_t>(poly.size()));
 #endif  // DEBUG_SHOW_SECTION_BORDERS
     }
 
@@ -1447,9 +1437,9 @@ void CMapIMG::loadVisibleData(bool fast, polytype_t& polygons, polytype_t& polyl
 
     QPolygonF poly;
     poly << p1 << p2 << p3 << p4;
-    ctx.setStrokeWidth(1);
-    ctx.setStrokeStyle(BLRgba32(0xFF000000u));  // black
-    ctx.strokePath(polyToPath(poly, true));
+    ctx.set_stroke_width(1);
+    ctx.set_stroke_style(BLRgba32(0xFF000000u));  // black
+    ctx.stroke_polygon(toBLPoints(poly), static_cast<size_t>(poly.size()));
 #endif  // DEBUG_SHOW_SUBDIV_BORDERS
 
 #ifdef Q_OS_WIN32
@@ -1697,10 +1687,31 @@ void CMapIMG::drawPolygons(BLContext& ctx, polytype_t& lines) {
   // QPainter::drawPolygon fills using the odd-even rule; Blend2D defaults to non-zero.
   ctx.set_fill_rule(BL_FILL_RULE_EVEN_ODD);
 
-  const int N = polygonDrawOrder.size();
-  for (int n = 0; n < N; ++n) {
-    quint32 type = polygonDrawOrder[(N - 1) - n];
-    const CGarminTyp::polygon_property& property = polygonProperties[type];
+  // Bucket the polygon indices by type once, so each draw-order pass visits only the
+  // polygons of its type instead of scanning the whole list once per type.
+  QHash<quint32, QVector<qsizetype> > byType;
+  for (qsizetype i = 0; i < lines.size(); ++i) {
+    byType[lines[i].type].push_back(i);
+  }
+
+  // Fallback for types that have geometry but no matching property (magenta hatch,
+  // known == false). Static so we never mutate polygonProperties while drawing.
+  static const CGarminTyp::polygon_property unknownProperty;
+
+  for (qsizetype n = polygonDrawOrder.size() - 1; n >= 0; --n) {
+    const quint32 type = polygonDrawOrder[n];
+    const auto bucket = byType.constFind(type);
+    if (bucket == byType.constEnd()) {
+      continue;
+    }
+
+    const auto propIt = polygonProperties.constFind(type);
+    const CGarminTyp::polygon_property& property =
+        (propIt != polygonProperties.constEnd()) ? propIt.value() : unknownProperty;
+    if (!property.known) {
+      qDebug() << "unknown polygon" << Qt::hex << type;
+    }
+
     const QBrush& brush = night ? property.brushNight : property.brushDay;
 
     // Configure the fill style once per type. Solid colours map directly; texture
@@ -1723,25 +1734,19 @@ void CMapIMG::drawPolygons(BLContext& ctx, polytype_t& lines) {
       }
     }
 
-    const QPen& pen = property.pen;
-    const bool hasOutline = applyPen(ctx, pen);
+    const bool hasOutline = applyPen(ctx, property.pen);
 
-    for (CGarminPolygon& line : lines) {
-      if (line.type != type) {
-        continue;
-      }
-
-      QPolygonF& poly = line.pixel;
+    for (const qsizetype idx : *bucket) {
+      QPolygonF& poly = lines[idx].pixel;
       map->convertRad2Px(poly);
 
-      const BLPath path = polyToPath(poly, true);
-      ctx.fill_path(path);
+      // Blend2D treats a polygon as implicitly closed, matching the closed BLPath used
+      // before; stroke_polygon adds the closing edge just like QPainter::drawPolygon.
+      const BLPoint* pts = toBLPoints(poly);
+      const size_t n = static_cast<size_t>(poly.size());
+      ctx.fill_polygon(pts, n);
       if (hasOutline) {
-        ctx.stroke_path(path);
-      }
-
-      if (!property.known) {
-        qDebug() << "unknown polygon" << Qt::hex << type;
+        ctx.stroke_polygon(pts, n);
       }
     }
   }
@@ -1769,10 +1774,11 @@ void CMapIMG::drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& sc
     const quint32& type = props.key();
     const CGarminTyp::polyline_property& property = props.value();
 
-    const QList<quint32>& indices = dict[type];
-    if (indices.isEmpty()) {
+    const auto it = dict.constFind(type);
+    if (it == dict.constEnd()) {
       continue;
     }
+    const QList<quint32>& indices = *it;
 
     if (property.hasPixmap) {
       const QImage& pixmap = night ? property.imgNight : property.imgDay;
@@ -1866,10 +1872,11 @@ void CMapIMG::drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& sc
     const quint32& type = props.key();
     const CGarminTyp::polyline_property& property = props.value();
 
-    const QList<quint32>& indices = dict[type];
-    if (indices.isEmpty()) {
+    const auto it = dict.constFind(type);
+    if (it == dict.constEnd()) {
       continue;
     }
+    const QList<quint32>& indices = *it;
 
     if (property.hasBorder && !property.hasPixmap) {
       const QPen& pen = night ? property.penLineNight : property.penLineDay;
@@ -1910,7 +1917,7 @@ void CMapIMG::drawLine(BLContext& ctx, CGarminPolygon& l, bool stroke, int lineW
   }
 
   if (stroke) {
-    ctx.stroke_path(polyToPath(poly, false));
+    ctx.stroke_polyline(toBLPoints(poly), static_cast<size_t>(poly.size()));
   }
 }
 
@@ -1920,7 +1927,7 @@ void CMapIMG::drawLine(BLContext& ctx, const CGarminPolygon& l) {
     return;
   }
 
-  ctx.stroke_path(polyToPath(poly, false));
+  ctx.stroke_polyline(toBLPoints(poly), static_cast<size_t>(poly.size()));
 }
 
 void CMapIMG::collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font, qint32 lineWidth,
@@ -1981,11 +1988,14 @@ void CMapIMG::addLabel(const CGarminPoint& pt, const QRect& rect, const CGarminT
 
 void CMapIMG::drawPoints(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois) {
   const bool night = CMainWindow::self().isNight();
+  static const CGarminTyp::point_property unknownProperty;
   pointtype_t::iterator pt = pts.begin();
   while (pt != pts.end()) {
     map->convertRad2Px(pt->pos);
 
-    const CGarminTyp::point_property& property = pointProperties[pt->type];
+    const auto propIt = pointProperties.constFind(pt->type);
+    const CGarminTyp::point_property& property =
+        (propIt != pointProperties.constEnd()) ? propIt.value() : unknownProperty;
 
     const QImage& icon = night ? property.imgNight : property.imgDay;
     const QSizeF& size = icon.size();
@@ -2019,10 +2029,13 @@ void CMapIMG::drawPoints(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rect
 
 void CMapIMG::drawPois(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois) {
   const bool night = CMainWindow::self().isNight();
+  static const CGarminTyp::point_property unknownProperty;
   for (CGarminPoint& pt : pts) {
     map->convertRad2Px(pt.pos);
 
-    const CGarminTyp::point_property& property = pointProperties[pt.type];
+    const auto propIt = pointProperties.constFind(pt.type);
+    const CGarminTyp::point_property& property =
+        (propIt != pointProperties.constEnd()) ? propIt.value() : unknownProperty;
     const QImage& icon = night ? property.imgNight : property.imgDay;
     const QSizeF& size = icon.size();
 

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -33,6 +33,7 @@
 #include "helpers/CFileExt.h"
 #include "helpers/CProgressDialog.h"
 #include "helpers/Platform.h"
+#include "map/Blend2dUtil.h"
 #include "map/CMapDraw.h"
 #include "map/garmin/CGarminStrTbl6.h"
 #include "map/garmin/CGarminStrTbl8.h"
@@ -92,12 +93,12 @@ static inline bool isCompletelyOutside(const QPolygonF& poly, const QRectF& view
 // so Blend2D keeps them alive until the queued blit is rasterised — required once the
 // rendering context renders asynchronously/multithreaded. Returns an empty image on
 // failure.
-static inline BLImage img2line(const QImage& img, int width) {
-  Q_ASSERT(img.format() == QImage::Format_ARGB32_Premultiplied);
-
+static inline BLImage img2line(const BLImage& img, int width) {
+  BLImageData src;
   BLImage newImage;
   const int height = img.height();
-  if (width < 1 || height < 1 || newImage.create(width, height, BL_FORMAT_PRGB32) != BL_SUCCESS) {
+  if (width < 1 || height < 1 || img.get_data(&src) != BL_SUCCESS ||
+      newImage.create(width, height, BL_FORMAT_PRGB32) != BL_SUCCESS) {
     return newImage;
   }
 
@@ -106,10 +107,13 @@ static inline BLImage img2line(const QImage& img, int width) {
     return BLImage();
   }
 
-  const qsizetype bpl_src = img.bytesPerLine();
+  // A BLImage row may be padded, so stepping rows and copying one tile are two different
+  // lengths - unlike QImage's ARGB32 bytesPerLine(), which is always exactly width * 4.
+  const qsizetype bpl_src = static_cast<qsizetype>(src.stride);
+  const qsizetype tileBytes = static_cast<qsizetype>(img.width()) * 4;
   const qsizetype bpl_dst = static_cast<qsizetype>(dst.stride);
   const qsizetype rowBytes = static_cast<qsizetype>(width) * 4;  // tightly packed destination row (ARGB32)
-  const uchar* const srcBase = img.bits();
+  const uchar* const srcBase = static_cast<const uchar*>(src.pixel_data);
   uchar* const dstBase = static_cast<uchar*>(dst.pixel_data);
 
   for (int i = 0; i < height; ++i) {
@@ -118,7 +122,7 @@ static inline BLImage img2line(const QImage& img, int width) {
 
     qsizetype bytesToCopy = rowBytes;
     while (bytesToCopy > 0) {
-      const qsizetype chunk = qMin(bytesToCopy, bpl_src);
+      const qsizetype chunk = qMin(bytesToCopy, tileBytes);
       memcpy(dstBits, srcBits, static_cast<size_t>(chunk));
       dstBits += chunk;
       bytesToCopy -= chunk;
@@ -227,59 +231,19 @@ bool applyPen(BLContext& ctx, const QPen& pen) {
   return true;
 }
 
-/// Deep-copy a QImage into an *owning* premultiplied BLImage. A create_from_data()
-/// view merely aliases the QImage's pixels, which dangle once the (often temporary)
-/// source dies — fatal under Blend2D's deferred/multithreaded rendering, where the
-/// blit is rasterised after the call returns. An owning BLImage is refcounted and is
-/// kept alive by Blend2D (and by BLPattern) until the queued command completes.
-/// Non-premultiplied inputs are converted on the fly. Returns an empty image on failure.
-BLImage toOwnedBLImage(const QImage& img) {
-  BLImage out;
-  if (img.isNull()) {
-    return out;
-  }
-
-  QImage storage;
-  const QImage& src = (img.format() == QImage::Format_ARGB32_Premultiplied)
-                          ? img
-                          : (storage = img.convertToFormat(QImage::Format_ARGB32_Premultiplied));
-
-  if (out.create(src.width(), src.height(), BL_FORMAT_PRGB32) != BL_SUCCESS) {
-    return out;
-  }
-
-  BLImageData dst;
-  if (out.make_mutable(&dst) != BL_SUCCESS) {
-    return BLImage();
-  }
-
-  const qsizetype bpl_src = src.bytesPerLine();
-  const qsizetype bpl_dst = static_cast<qsizetype>(dst.stride);
-  const qsizetype rowBytes = qMin(bpl_src, bpl_dst);
-  const uchar* const s = src.constBits();
-  uchar* const d = static_cast<uchar*>(dst.pixel_data);
-  for (int y = 0; y < src.height(); ++y) {
-    memcpy(d + bpl_dst * y, s + bpl_src * y, static_cast<size_t>(rowBytes));
-  }
-  return out;
-}
-
-/// Blit a QImage at (@p x, @p y). The source is deep-copied into an owning BLImage so
-/// it survives Blend2D's deferred execution; the copy also handles non-premultiplied
-/// inputs on the fly.
-void blitQImage(BLContext& ctx, double x, double y, const QImage& img) {
-  const BLImage bl = toOwnedBLImage(img);
-  if (bl.is_empty()) {
+/// Blit an icon owned by a CGarminTyp property. Nothing is copied: BLImage is refcounted,
+/// so Blend2D keeps the property's pixels alive until the deferred blit is rasterised.
+void blitIcon(BLContext& ctx, double x, double y, const BLImage& img) {
+  if (img.is_empty()) {
     return;
   }
-  ctx.blit_image(BLPoint(x, y), bl);
+  ctx.blit_image(BLPoint(x, y), img);
 }
 
 /// Blit the small blue bullet used as a fallback marker for cluttered points.
 void blitBullet(BLContext& ctx, double x, double y) {
-  static const QImage bullet =
-      QImage(":/icons/8x8/bullet_blue.png").convertToFormat(QImage::Format_ARGB32_Premultiplied);
-  blitQImage(ctx, x, y, bullet);
+  static const BLImage bullet = toOwnedBLImage(QImage(":/icons/8x8/bullet_blue.png"));
+  blitIcon(ctx, x, y, bullet);
 }
 
 /// Render a non-solid QBrush into a small premultiplied tile usable as a repeating
@@ -1963,7 +1927,7 @@ void CMapIMG::drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& sc
     const QList<quint32>& indices = *it;
 
     if (property.hasPixmap) {
-      const QImage& pixmap = night ? property.imgNight : property.imgDay;
+      const BLImage& pixmap = night ? property.imgNight : property.imgDay;
       const qreal h = pixmap.height();
 
       for (quint32 idx : indices) {
@@ -2177,12 +2141,12 @@ void CMapIMG::drawPoints(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rect
     const CGarminTyp::point_property& property =
         (propIt != pointProperties.constEnd()) ? propIt.value() : unknownProperty;
 
-    const QImage& icon = night ? property.imgNight : property.imgDay;
-    const QSizeF& size = icon.size();
+    const BLImage& icon = night ? property.imgNight : property.imgDay;
+    const QSizeF size(icon.width(), icon.height());
 
     if (isCluttered(rectPois, QRectF(pt->pos, size))) {
       if (size.width() <= 8 && size.height() <= 8) {
-        blitQImage(ctx, pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
+        blitIcon(ctx, pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
       } else {
         blitBullet(ctx, pt->pos.x() - 4, pt->pos.y() - 4);
       }
@@ -2190,7 +2154,7 @@ void CMapIMG::drawPoints(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rect
       continue;
     }
 
-    blitQImage(ctx, pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
+    blitIcon(ctx, pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
 
     if (CMainWindow::self().isPoiText() && property.labelType != CGarminTyp::eNone) {
       // calculate bounding rectangle with a border of 2 px
@@ -2216,19 +2180,19 @@ void CMapIMG::drawPois(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPo
     const auto propIt = pointProperties.constFind(pt.type);
     const CGarminTyp::point_property& property =
         (propIt != pointProperties.constEnd()) ? propIt.value() : unknownProperty;
-    const QImage& icon = night ? property.imgNight : property.imgDay;
-    const QSizeF& size = icon.size();
+    const BLImage& icon = night ? property.imgNight : property.imgDay;
+    const QSizeF size(icon.width(), icon.height());
 
     if (isCluttered(rectPois, QRectF(pt.pos, size))) {
       if (size.width() <= 8 && size.height() <= 8) {
-        blitQImage(ctx, pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
+        blitIcon(ctx, pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
       } else {
         blitBullet(ctx, pt.pos.x() - 4, pt.pos.y() - 4);
       }
       continue;
     }
 
-    blitQImage(ctx, pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
+    blitIcon(ctx, pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
 
     if (CMainWindow::self().isPoiText()) {
       // calculate bounding rectangle with a border of 2 px

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -21,6 +21,7 @@
 #include <blend2d/blend2d.h>
 
 #include <QPainterPath>
+#include <QRawFont>
 #include <QtWidgets>
 #include <algorithm>
 #include <cmath>
@@ -29,7 +30,6 @@
 #include "CMainWindow.h"
 #include "canvas/CCanvas.h"
 #include "gis/GeoMath.h"
-#include "helpers/CDraw.h"
 #include "helpers/CFileExt.h"
 #include "helpers/CProgressDialog.h"
 #include "helpers/Platform.h"
@@ -296,6 +296,82 @@ QImage brushToTile(const QBrush& brush) {
   p.fillRect(tile.rect(), brush);
   p.end();
   return tile;
+}
+
+/**
+   @brief Convert a glyph outline (QPainterPath from QRawFont) into a BLPath.
+
+   QPainterPath stores a cubic as a CurveToElement followed by two CurveToDataElements
+   and never emits quadratics, so only move/line/cubic need handling.
+ */
+BLPath qPathToBLPath(const QPainterPath& pp) {
+  BLPath path;
+  const int count = pp.elementCount();
+  for (int i = 0; i < count; ++i) {
+    const QPainterPath::Element& e = pp.elementAt(i);
+    switch (e.type) {
+      case QPainterPath::MoveToElement:
+        path.move_to(e.x, e.y);
+        break;
+      case QPainterPath::LineToElement:
+        path.line_to(e.x, e.y);
+        break;
+      case QPainterPath::CurveToElement: {
+        const QPainterPath::Element& c2 = pp.elementAt(i + 1);
+        const QPainterPath::Element& end = pp.elementAt(i + 2);
+        path.cubic_to(e.x, e.y, c2.x, c2.y, end.x, end.y);
+        i += 2;
+        break;
+      }
+      case QPainterPath::CurveToDataElement:
+        // consumed together with its CurveToElement above
+        break;
+    }
+  }
+  return path;
+}
+
+/**
+   @brief Lay @p text out left-to-right from the origin into a single BLPath.
+
+   Glyph mapping is cmap-only (no complex shaping) via QRawFont, which keeps Qt's font
+   matching while emitting outlines Blend2D can fill. The glyph origin (0,0) is the pen
+   position on the baseline, matching QPainter::drawText().
+ */
+BLPath buildTextPath(const QRawFont& raw, const QString& text) {
+  BLPath path;
+  const QList<quint32> glyphs = raw.glyphIndexesForString(text);
+  const QList<QPointF> advances = raw.advancesForGlyphIndexes(glyphs);
+  QPointF pen(0, 0);
+  for (qsizetype i = 0; i < glyphs.size(); ++i) {
+    const QPainterPath gp = raw.pathForGlyph(glyphs[i]);
+    if (!gp.isEmpty()) {
+      path.add_path(qPathToBLPath(gp), BLPoint(pen.x(), pen.y()));
+    }
+    pen += advances[i];
+  }
+  return path;
+}
+
+/**
+   @brief Fill a glyph(-run) path with the white 8-neighbour halo, then the coloured text.
+
+   Offsets are applied in the current context transform space, so a caller drawing under a
+   rotated transform gets a correctly rotated halo. The same path is reused for all nine
+   fills (tessellated once), each placed via fill_path()'s origin argument.
+ */
+void fillGlyphHalo(BLContext& ctx, const BLPath& glyphs, const BLPoint& base, BLRgba32 fill, BLRgba32 halo) {
+  ctx.set_fill_style(halo);
+  ctx.fill_path(BLPoint(base.x - 1, base.y - 1), glyphs);
+  ctx.fill_path(BLPoint(base.x, base.y - 1), glyphs);
+  ctx.fill_path(BLPoint(base.x + 1, base.y - 1), glyphs);
+  ctx.fill_path(BLPoint(base.x - 1, base.y), glyphs);
+  ctx.fill_path(BLPoint(base.x + 1, base.y), glyphs);
+  ctx.fill_path(BLPoint(base.x - 1, base.y + 1), glyphs);
+  ctx.fill_path(BLPoint(base.x, base.y + 1), glyphs);
+  ctx.fill_path(BLPoint(base.x + 1, base.y + 1), glyphs);
+  ctx.set_fill_style(fill);
+  ctx.fill_path(base, glyphs);
 }
 }  // namespace
 
@@ -1392,23 +1468,18 @@ void CMapIMG::draw(IDrawContext::buffer_t& buf) /* override */
       drawPois(ctx, pois, rectPois);
     }
 
+    // Text and labels are drawn on top, in the same Blend2D context. Glyph outlines come
+    // from QRawFont (see drawText()/drawLabels()); the context already carries the global
+    // alpha, pixel-ratio scale and -pp translation, so no separate QPainter pass is needed.
+    if (ok && !map->needsRedraw()) {
+      drawText(ctx);
+    }
+    if (ok && !map->needsRedraw()) {
+      drawLabels(ctx, labels);
+    }
+
     // In multithreaded mode the queued rasterisation completes here.
     ctx.end();
-  }
-
-  // Text and labels are drawn on top with QPainter (see drawText()/drawLabels()).
-  if (ok && !map->needsRedraw()) {
-    QPainter p(&buf.image);
-    p.setOpacity(getOpacity() / 100.0);
-    USE_ANTI_ALIASING(p, true);
-    p.setFont(CMainWindow::self().getMapFont());
-    p.translate(-pp);
-
-    drawText(p);
-
-    if (!map->needsRedraw()) {
-      drawLabels(p, labels);
-    }
   }
 
   buf.image.convertTo(QImage::Format_ARGB32);
@@ -2128,20 +2199,34 @@ void CMapIMG::drawPois(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPo
   }
 }
 
-void CMapIMG::drawLabels(QPainter& p, const QVector<strlbl_t>& lbls) {
+void CMapIMG::drawLabels(BLContext& ctx, const QVector<strlbl_t>& lbls) {
   QFont f = CMainWindow::self().getMapFont();
   QVector<QFont> fonts(8, f);
   fonts[CGarminTyp::eSmall].setPointSize(f.pointSize() - 2);
   fonts[CGarminTyp::eLarge].setPointSize(f.pointSize() + 2);
 
+  // One QRawFont per label type, built on first use (QRawFont::fromFont is not free).
+  QVector<QRawFont> rawFonts(fonts.size());
+  const BLRgba32 halo = toBLColor(Qt::white);
+
   for (const strlbl_t& lbl : lbls) {
-    CDraw::text(lbl.str, p, lbl.pt, lbl.isNight ? lbl.property.colorLabelNight : lbl.property.colorLabelDay,
-                fonts[lbl.property.labelType]);
+    const int type = lbl.property.labelType;
+    if (!rawFonts[type].isValid()) {
+      rawFonts[type] = QRawFont::fromFont(fonts[type]);
+    }
+
+    // Match CDraw::text()'s placement: centre the metrics bounding box on the anchor and
+    // use its top-left as the baseline-left pen origin.
+    QRect r = QFontMetrics(fonts[type]).boundingRect(lbl.str);
+    r.moveCenter(lbl.pt);
+
+    const BLPath glyphs = buildTextPath(rawFonts[type], lbl.str);
+    const BLRgba32 fill = toBLColor(lbl.isNight ? lbl.property.colorLabelNight : lbl.property.colorLabelDay);
+    fillGlyphHalo(ctx, glyphs, BLPoint(r.left(), r.top()), fill, halo);
   }
 }
 
-void CMapIMG::drawText(QPainter& p) {
-  p.setPen(Qt::black);
+void CMapIMG::drawText(BLContext& ctx) {
 
   for (const textpath_t& textpath : std::as_const(textpaths)) {
     QPainterPath path;
@@ -2171,7 +2256,11 @@ void CMapIMG::drawText(QPainter& p) {
     }
 
     fm = QFontMetricsF(font);
-    p.setFont(font);
+    // Layout still uses QFontMetricsF (above); the glyph outlines are rasterised by
+    // Blend2D from QRawFont, which keeps Qt's font matching at the same resolved size.
+    const QRawFont raw = QRawFont::fromFont(font);
+    const BLRgba32 fill = toBLColor(textpath.color);
+    const BLRgba32 halo = toBLColor(Qt::white);
 
     // adjust exact offset to first half of segment
     const QVector<qreal>& lengths = textpath.lengths;
@@ -2200,8 +2289,6 @@ void CMapIMG::drawText(QPainter& p) {
     QPointF point1 = path.pointAtPercent(percent1);
     QPointF point2 = path.pointAtPercent(percent2);
 
-    qreal angle;  //     = qAtan((point2.y() - point1.y()) / (point2.x() - point1.x())) * 180 / M_PI;
-
     // flip path if string start is E->W direction
     // this helps, sometimes, in 50 % of the cases :)
     if (point2.x() - point1.x() < 0) {
@@ -2220,33 +2307,19 @@ void CMapIMG::drawText(QPainter& p) {
       point1 = point2;
       point2 = path.pointAtPercent(percent2);
 
-      angle = qAtan((point2.y() - point1.y()) / (point2.x() - point1.x())) * 180 / M_PI;
+      // BLContext::rotate() takes radians; atan2() also resolves the quadrant the old
+      // qAtan()+180 fix-up handled by hand.
+      const qreal angle = std::atan2(point2.y() - point1.y(), point2.x() - point1.x());
 
-      if (point2.x() - point1.x() < 0) {
-        angle += 180;
-      }
+      ctx.save();
+      ctx.translate(point1.x(), point1.y());
+      ctx.rotate(angle);
+      ctx.translate(0, -(textpath.lineWidth + 2));
 
-      p.save();
-      p.translate(point1);
-      p.rotate(angle);
+      const BLPath glyphs = buildTextPath(raw, text.mid(i, 1));
+      fillGlyphHalo(ctx, glyphs, BLPoint(0, 0), fill, halo);
 
-      p.translate(0, -(textpath.lineWidth + 2));
-
-      QString str = text.mid(i, 1);
-      p.setPen(Qt::white);
-      p.drawText(-1, -1, str);
-      p.drawText(0, -1, str);
-      p.drawText(+1, -1, str);
-      p.drawText(-1, 0, str);
-      p.drawText(+1, 0, str);
-      p.drawText(-1, +1, str);
-      p.drawText(0, +1, str);
-      p.drawText(+1, +1, str);
-
-      p.setPen(textpath.color);
-      p.drawText(0, 0, str);
-
-      p.restore();
+      ctx.restore();
 
       offset += fm.size(Qt::TextSingleLine, text[i]).width();
     }

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -22,7 +22,9 @@
 
 #include <QPainterPath>
 #include <QtWidgets>
+#include <algorithm>
 #include <cmath>
+#include <thread>
 
 #include "CMainWindow.h"
 #include "canvas/CCanvas.h"
@@ -85,25 +87,41 @@ static inline bool isCompletelyOutside(const QPolygonF& poly, const QRectF& view
   return !viewport.intersects(ref);
 }
 
-static inline QImage img2line(const QImage& img, int width) {
+// Build a copy of @p img tiled horizontally to @p width pixels as an *owning*
+// premultiplied BLImage. Unlike a create_from_data() view, the result owns its pixels,
+// so Blend2D keeps them alive until the queued blit is rasterised — required once the
+// rendering context renders asynchronously/multithreaded. Returns an empty image on
+// failure.
+static inline BLImage img2line(const QImage& img, int width) {
   Q_ASSERT(img.format() == QImage::Format_ARGB32_Premultiplied);
 
-  QImage newImage(width, img.height(), QImage::Format_ARGB32_Premultiplied);
+  BLImage newImage;
+  const int height = img.height();
+  if (width < 1 || height < 1 || newImage.create(width, height, BL_FORMAT_PRGB32) != BL_SUCCESS) {
+    return newImage;
+  }
 
-  const int bpl_src = img.bytesPerLine();
-  const int bpl_dst = newImage.bytesPerLine();
-  const uchar* _srcBits = img.bits();
-  uchar* _dstBits = newImage.bits();
+  BLImageData dst;
+  if (newImage.make_mutable(&dst) != BL_SUCCESS) {
+    return BLImage();
+  }
 
-  for (int i = 0; i < img.height(); i++) {
-    const uchar* srcBits = _srcBits + bpl_src * i;
-    uchar* dstBits = _dstBits + bpl_dst * i;
+  const qsizetype bpl_src = img.bytesPerLine();
+  const qsizetype bpl_dst = static_cast<qsizetype>(dst.stride);
+  const qsizetype rowBytes = static_cast<qsizetype>(width) * 4;  // tightly packed destination row (ARGB32)
+  const uchar* const srcBase = img.bits();
+  uchar* const dstBase = static_cast<uchar*>(dst.pixel_data);
 
-    int bytesToCopy = bpl_dst;
+  for (int i = 0; i < height; ++i) {
+    const uchar* srcBits = srcBase + bpl_src * i;
+    uchar* dstBits = dstBase + bpl_dst * i;
+
+    qsizetype bytesToCopy = rowBytes;
     while (bytesToCopy > 0) {
-      memcpy(dstBits, srcBits, qMin(bytesToCopy, bpl_src));
-      dstBits += bpl_src;
-      bytesToCopy -= bpl_src;
+      const qsizetype chunk = qMin(bytesToCopy, bpl_src);
+      memcpy(dstBits, srcBits, static_cast<size_t>(chunk));
+      dstBits += chunk;
+      bytesToCopy -= chunk;
     }
   }
   return newImage;
@@ -209,19 +227,49 @@ bool applyPen(BLContext& ctx, const QPen& pen) {
   return true;
 }
 
-/// Blit a QImage at (@p x, @p y). Blend2D only consumes premultiplied ARGB, so a
-/// conversion is done on the fly for sources that are stored in another format.
-void blitQImage(BLContext& ctx, double x, double y, const QImage& img) {
+/// Deep-copy a QImage into an *owning* premultiplied BLImage. A create_from_data()
+/// view merely aliases the QImage's pixels, which dangle once the (often temporary)
+/// source dies — fatal under Blend2D's deferred/multithreaded rendering, where the
+/// blit is rasterised after the call returns. An owning BLImage is refcounted and is
+/// kept alive by Blend2D (and by BLPattern) until the queued command completes.
+/// Non-premultiplied inputs are converted on the fly. Returns an empty image on failure.
+BLImage toOwnedBLImage(const QImage& img) {
+  BLImage out;
   if (img.isNull()) {
-    return;
+    return out;
   }
+
   QImage storage;
   const QImage& src = (img.format() == QImage::Format_ARGB32_Premultiplied)
                           ? img
                           : (storage = img.convertToFormat(QImage::Format_ARGB32_Premultiplied));
-  BLImage bl;
-  if (bl.create_from_data(src.width(), src.height(), BL_FORMAT_PRGB32, const_cast<uchar*>(src.constBits()),
-                          src.bytesPerLine(), BL_DATA_ACCESS_READ) != BL_SUCCESS) {
+
+  if (out.create(src.width(), src.height(), BL_FORMAT_PRGB32) != BL_SUCCESS) {
+    return out;
+  }
+
+  BLImageData dst;
+  if (out.make_mutable(&dst) != BL_SUCCESS) {
+    return BLImage();
+  }
+
+  const qsizetype bpl_src = src.bytesPerLine();
+  const qsizetype bpl_dst = static_cast<qsizetype>(dst.stride);
+  const qsizetype rowBytes = qMin(bpl_src, bpl_dst);
+  const uchar* const s = src.constBits();
+  uchar* const d = static_cast<uchar*>(dst.pixel_data);
+  for (int y = 0; y < src.height(); ++y) {
+    memcpy(d + bpl_dst * y, s + bpl_src * y, static_cast<size_t>(rowBytes));
+  }
+  return out;
+}
+
+/// Blit a QImage at (@p x, @p y). The source is deep-copied into an owning BLImage so
+/// it survives Blend2D's deferred execution; the copy also handles non-premultiplied
+/// inputs on the fly.
+void blitQImage(BLContext& ctx, double x, double y, const QImage& img) {
+  const BLImage bl = toOwnedBLImage(img);
+  if (bl.is_empty()) {
     return;
   }
   ctx.blit_image(BLPoint(x, y), bl);
@@ -1304,7 +1352,13 @@ void CMapIMG::draw(IDrawContext::buffer_t& buf) /* override */
       return;
     }
 
-    BLContext ctx(blBuf);
+    // use Blend2Ds parallel renderer
+    BLContextCreateInfo cci{};
+    cci.thread_count = std::min(std::thread::hardware_concurrency(), 4u);  // gains quickly diminish >4
+    // Render synchronously rather than erroring if the thread pool can't be acquired.
+    cci.flags = BL_CONTEXT_CREATE_FLAG_FALLBACK_TO_SYNC;
+
+    BLContext ctx(blBuf, cci);
     ctx.set_global_alpha(getOpacity() / 100.0);
     /*
        The buffer is allocated at device resolution (pixelRatio larger) and tagged with
@@ -1338,6 +1392,7 @@ void CMapIMG::draw(IDrawContext::buffer_t& buf) /* override */
       drawPois(ctx, pois, rectPois);
     }
 
+    // In multithreaded mode the queued rasterisation completes here.
     ctx.end();
   }
 
@@ -1725,15 +1780,15 @@ void CMapIMG::drawPolygons(BLContext& ctx, polytype_t& lines) {
     // Configure the fill style once per type. Solid colours map directly; texture
     // images and hatch patterns are realised as a repeating BLPattern. The pattern's
     // pixel data (tile) must outlive every fill that uses it, hence the outer scope.
-    QImage tile;
-    BLImage tileBL;
     BLPattern pattern;
     if (brush.style() == Qt::SolidPattern) {
       ctx.set_fill_style(toBLColor(brush.color()));
     } else {
-      tile = brushToTile(brush);
-      if (tileBL.create_from_data(tile.width(), tile.height(), BL_FORMAT_PRGB32, const_cast<uchar*>(tile.constBits()),
-                                  tile.bytesPerLine(), BL_DATA_ACCESS_READ) == BL_SUCCESS) {
+      const QImage tile = brushToTile(brush);
+      // Owning copy so the pattern's pixels outlive this per-type scope and any
+      // deferred fills that reference it (see toOwnedBLImage()).
+      const BLImage tileBL = toOwnedBLImage(tile);
+      if (!tileBL.is_empty()) {
         pattern.set_image(tileBL);
         pattern.set_extend_mode(BL_EXTEND_MODE_REPEAT);
         // REPEAT makes only the fractional offset matter; fmod keeps the translation small
@@ -1850,17 +1905,15 @@ void CMapIMG::drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& sc
           const QPointF& p2 = poly[i + 1];
           const double angle = std::atan2(p2.y() - p1.y(), p2.x() - p1.x());
 
-          const QImage seg = img2line(pixmap, segLength);
-          BLImage segBL;
-          if (segBL.create_from_data(seg.width(), seg.height(), BL_FORMAT_PRGB32, const_cast<uchar*>(seg.constBits()),
-                                     seg.bytesPerLine(), BL_DATA_ACCESS_READ) != BL_SUCCESS) {
+          const BLImage seg = img2line(pixmap, static_cast<int>(segLength));
+          if (seg.is_empty()) {
             continue;
           }
 
           ctx.save();
           ctx.translate(p1.x(), p1.y());
           ctx.rotate(angle);
-          ctx.blit_image(BLPoint(0.0, -h / 2.0), segBL);
+          ctx.blit_image(BLPoint(0.0, -h / 2.0), seg);
           ctx.restore();
         }
       }

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -47,7 +47,8 @@
 #undef DEBUG_SHOW_SECTION_BORDERS
 #undef DEBUG_SHOW_SUBDIV_BORDERS
 
-#define STREETNAME_THRESHOLD 5.0
+/// Maximum map scale [m/px] at which street / way names are still drawn.
+constexpr qreal kStreetNameThreshold = 5.0;
 
 int CFileExt::cnt = 0;
 
@@ -598,19 +599,19 @@ void CMapIMG::readFile(CFileExt& file, quint32 offset, quint32 size, QByteArray&
   }
 
 #ifdef HOST_IS_64_BIT
-  quint64* p64 = (quint64*)data.data();
+  quint64* p64 = reinterpret_cast<quint64*>(data.data());
   for (quint32 i = 0; i < size / 8; ++i) {
     *p64++ ^= mask64;
   }
   quint32 rest = size % 8;
-  quint8* p = (quint8*)p64;
+  quint8* p = reinterpret_cast<quint8*>(p64);
 #else
-  quint32* p32 = (quint32*)data.data();
+  quint32* p32 = reinterpret_cast<quint32*>(data.data());
   for (quint32 i = 0; i < size / 4; ++i) {
     *p32++ ^= mask32;
   }
   quint32 rest = size % 4;
-  quint8* p = (quint8*)p32;
+  quint8* p = reinterpret_cast<quint8*>(p32);
 #endif
 
   for (quint32 i = 0; i < rest; ++i) {
@@ -627,7 +628,7 @@ void CMapIMG::readBasics() {
     throw exce_t(eErrOpen, tr("Failed to open: ") + filename);
   }
 
-  mask = (quint8)*file.data(0, 1);
+  mask = static_cast<quint8>(*file.data(0, 1));
 
   mask32 = mask;
   mask32 <<= 8;
@@ -644,7 +645,7 @@ void CMapIMG::readBasics() {
   // read hdr_img_t
   QByteArray imghdr;
   readFile(file, 0, sizeof(hdr_img_t), imghdr);
-  hdr_img_t* pImgHdr = (hdr_img_t*)imghdr.data();
+  hdr_img_t* pImgHdr = reinterpret_cast<hdr_img_t*>(imghdr.data());
 
   if (strncmp(pImgHdr->signature, "DSKIMG", 7) != 0) {
     throw exce_t(errFormat, tr("Bad file format: ") + filename);
@@ -662,18 +663,18 @@ void CMapIMG::readBasics() {
   // 1st read FAT
   QByteArray FATblock;
   readFile(file, sizeof(hdr_img_t), sizeof(FATblock_t), FATblock);
-  const FATblock_t* pFATBlock = (const FATblock_t*)FATblock.data();
+  const FATblock_t* pFATBlock = reinterpret_cast<const FATblock_t*>(FATblock.data());
 
   size_t dataoffset = sizeof(hdr_img_t);
 
   // skip dummy blocks at the beginning
-  while (dataoffset < (size_t)fsize) {
+  while (dataoffset < static_cast<size_t>(fsize)) {
     if (pFATBlock->flag != 0x00) {
       break;
     }
     dataoffset += sizeof(FATblock_t);
     readFile(file, quint32(dataoffset), quint32(sizeof(FATblock_t)), FATblock);
-    pFATBlock = (const FATblock_t*)FATblock.data();
+    pFATBlock = reinterpret_cast<const FATblock_t*>(FATblock.data());
   }
 
   // start of new subfile part
@@ -698,7 +699,7 @@ void CMapIMG::readBasics() {
                   set is used to get the location information.
    */
   QSet<QString> subfileNames;
-  while (dataoffset < (size_t)fsize) {
+  while (dataoffset < static_cast<size_t>(fsize)) {
     if (pFATBlock->flag != 0x01) {
       break;
     }
@@ -728,10 +729,10 @@ void CMapIMG::readBasics() {
 
     dataoffset += sizeof(FATblock_t);
     readFile(file, quint32(dataoffset), quint32(sizeof(FATblock_t)), FATblock);
-    pFATBlock = (const FATblock_t*)FATblock.data();
+    pFATBlock = reinterpret_cast<const FATblock_t*>(FATblock.data());
   }
 
-  if ((dataoffset == sizeof(hdr_img_t)) || (dataoffset >= (size_t)fsize)) {
+  if ((dataoffset == sizeof(hdr_img_t)) || (dataoffset >= static_cast<size_t>(fsize))) {
     throw exce_t(errFormat, tr("Failed to read file structure: ") + filename);
   }
 
@@ -793,9 +794,14 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
     return;
   }
 
+  // Both parts are guaranteed to exist by the guard above; bind them once instead of
+  // repeating the map lookup for every offset computed below.
+  const subfile_part_t& trePart = subfile.parts["TRE"];
+  const subfile_part_t& rgnPart = subfile.parts["RGN"];
+
   QByteArray trehdr;
-  readFile(file, subfile.parts["TRE"].offset, sizeof(hdr_tre_t), trehdr);
-  hdr_tre_t* pTreHdr = (hdr_tre_t*)trehdr.data();
+  readFile(file, trePart.offset, sizeof(hdr_tre_t), trehdr);
+  hdr_tre_t* pTreHdr = reinterpret_cast<hdr_tre_t*>(trehdr.data());
 
   subfile.isTransparent = pTreHdr->POI_flags & 0x02;
   transparent = subfile.isTransparent ? true : transparent;
@@ -809,7 +815,7 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
   qDebug() << "TRE2 size          :" << dec << gar_load(quint32, pTreHdr->tre2_size);
 #endif  // DEBUG_SHOW_TRE_DATA
 
-  copyrights << QString(file.data(subfile.parts["TRE"].offset + gar_load(uint16_t, pTreHdr->length), 0x7FFF));
+  copyrights << QString(file.data(trePart.offset + gar_load(uint16_t, pTreHdr->length), 0x7FFF));
 
   // read map boundaries from header
   qint32 i32;
@@ -845,9 +851,9 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
 #endif  // DEBUG_SHOW_TRE_DATA
 
   QByteArray maplevel;
-  readFile(file, subfile.parts["TRE"].offset + gar_load(quint32, pTreHdr->tre1_offset),
-           gar_load(quint32, pTreHdr->tre1_size), maplevel);
-  const tre_map_level_t* pMapLevel = (const tre_map_level_t*)maplevel.data();
+  readFile(file, trePart.offset + gar_load(quint32, pTreHdr->tre1_offset), gar_load(quint32, pTreHdr->tre1_size),
+           maplevel);
+  const tre_map_level_t* pMapLevel = reinterpret_cast<const tre_map_level_t*>(maplevel.data());
 
   if (pTreHdr->flag & 0x80) {
     throw exce_t(errLock, tr("File contains locked / encrypted data. Garmin does not "
@@ -887,9 +893,9 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
 
   // point to first 16 byte subdivision definition entry
   QByteArray subdiv_n;
-  readFile(file, subfile.parts["TRE"].offset + gar_load(quint32, pTreHdr->tre2_offset),
-           gar_load(quint32, pTreHdr->tre2_size), subdiv_n);
-  tre_subdiv_next_t* pSubDivN = (tre_subdiv_next_t*)subdiv_n.data();
+  readFile(file, trePart.offset + gar_load(quint32, pTreHdr->tre2_offset), gar_load(quint32, pTreHdr->tre2_size),
+           subdiv_n);
+  tre_subdiv_next_t* pSubDivN = reinterpret_cast<tre_subdiv_next_t*>(subdiv_n.data());
 
   QVector<subdiv_desc_t> subdivs;
   subdivs.resize(nsubdivs);
@@ -898,8 +904,8 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
 
   // absolute offset of RGN data
   QByteArray rgnhdr;
-  readFile(file, subfile.parts["RGN"].offset, sizeof(hdr_rgn_t), rgnhdr);
-  hdr_rgn_t* pRgnHdr = (hdr_rgn_t*)rgnhdr.data();
+  readFile(file, rgnPart.offset, sizeof(hdr_rgn_t), rgnhdr);
+  hdr_rgn_t* pRgnHdr = reinterpret_cast<hdr_rgn_t*>(rgnhdr.data());
   quint32 rgnoff = /*subfile.parts["RGN"].offset +*/ gar_load(quint32, pRgnHdr->offset);
 
   quint32 rgnOffPolyg2 = /*subfile.parts["RGN"].offset +*/ gar_load(quint32, pRgnHdr->offset_polyg2);
@@ -1022,9 +1028,9 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
     // rgnoff = subfile.parts["RGN"].offset;
     //          qDebug() << subdivs.count() << (pTreHdr->tre7_size / pTreHdr->tre7_rec_size) << pTreHdr->tre7_rec_size;
     QByteArray subdiv2;
-    readFile(file, subfile.parts["TRE"].offset + gar_load(quint32, pTreHdr->tre7_offset),
-             gar_load(quint32, pTreHdr->tre7_size), subdiv2);
-    tre_subdiv2_t* pSubDiv2 = (tre_subdiv2_t*)subdiv2.data();
+    readFile(file, trePart.offset + gar_load(quint32, pTreHdr->tre7_offset), gar_load(quint32, pTreHdr->tre7_size),
+             subdiv2);
+    tre_subdiv2_t* pSubDiv2 = reinterpret_cast<tre_subdiv2_t*>(subdiv2.data());
 
     //        const quint32 entries1 = gar_load(quint32, pTreHdr->tre7_size) / gar_load(quint32,
     //        pTreHdr->tre7_rec_size); const quint32 entries2 = subdivs.size();
@@ -1044,7 +1050,8 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
     subdiv->offsetPoints2 = skipPois ? 0 : gar_load(quint32, pSubDiv2->offsetPoints) + rgnOffPoint2;
 
     ++subdiv;
-    pSubDiv2 = reinterpret_cast<tre_subdiv2_t*>((quint8*)pSubDiv2 + gar_endian(uint16_t, pTreHdr->tre7_rec_size));
+    pSubDiv2 = reinterpret_cast<tre_subdiv2_t*>(reinterpret_cast<quint8*>(pSubDiv2) +
+                                                gar_endian(uint16_t, pTreHdr->tre7_rec_size));
 
     while (subdiv != subdivs.end()) {
       //             for(int i = 0; i < pTreHdr->tre7_rec_size; ++i){
@@ -1064,7 +1071,8 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
       subdiv_prev = subdiv;
 
       ++subdiv;
-      pSubDiv2 = reinterpret_cast<tre_subdiv2_t*>((quint8*)pSubDiv2 + gar_endian(uint16_t, pTreHdr->tre7_rec_size));
+      pSubDiv2 = reinterpret_cast<tre_subdiv2_t*>(reinterpret_cast<quint8*>(pSubDiv2) +
+                                                  gar_endian(uint16_t, pTreHdr->tre7_rec_size));
     }
 
     subdiv_prev->lengthPolygons2 = rgnOffPolyg2 + rgnLenPolyg2 - subdiv_prev->offsetPolygons2;
@@ -1109,20 +1117,23 @@ void CMapIMG::readSubfileBasics(subfile_desc_t& subfile, CFileExt& file) {
   //     pRgnHdr->length_point2);
 
   if (subfile.parts.contains("LBL")) {
-    QByteArray lblhdr;
-    readFile(file, subfile.parts["LBL"].offset, sizeof(hdr_lbl_t), lblhdr);
-    hdr_lbl_t* pLblHdr = (hdr_lbl_t*)lblhdr.data();
+    const subfile_part_t& lblPart = subfile.parts["LBL"];
 
-    quint32 offsetLbl1 = subfile.parts["LBL"].offset + gar_load(quint32, pLblHdr->lbl1_offset);
-    quint32 offsetLbl6 = subfile.parts["LBL"].offset + gar_load(quint32, pLblHdr->lbl6_offset);
+    QByteArray lblhdr;
+    readFile(file, lblPart.offset, sizeof(hdr_lbl_t), lblhdr);
+    hdr_lbl_t* pLblHdr = reinterpret_cast<hdr_lbl_t*>(lblhdr.data());
+
+    quint32 offsetLbl1 = lblPart.offset + gar_load(quint32, pLblHdr->lbl1_offset);
+    quint32 offsetLbl6 = lblPart.offset + gar_load(quint32, pLblHdr->lbl6_offset);
 
     QByteArray nethdr;
     quint32 offsetNet1 = 0;
     hdr_net_t* pNetHdr = nullptr;
     if (subfile.parts.contains("NET")) {
-      readFile(file, subfile.parts["NET"].offset, sizeof(hdr_net_t), nethdr);
-      pNetHdr = (hdr_net_t*)nethdr.data();
-      offsetNet1 = subfile.parts["NET"].offset + gar_load(quint32, pNetHdr->net1_offset);
+      const subfile_part_t& netPart = subfile.parts["NET"];
+      readFile(file, netPart.offset, sizeof(hdr_net_t), nethdr);
+      pNetHdr = reinterpret_cast<hdr_net_t*>(nethdr.data());
+      offsetNet1 = netPart.offset + gar_load(quint32, pNetHdr->net1_offset);
     }
 
     quint16 codepage = 0;
@@ -1463,12 +1474,12 @@ void CMapIMG::loadSubDiv(CFileExt& file, const subdiv_desc_t& subdiv, IGarminStr
   // fprintf(stderr, "loadSubDiv\n");
   //      qDebug() << "---------" << file.fileName() << "---------";
 
-  const quint8* pRawData = (quint8*)rgndata.data();
+  const quint8* pRawData = reinterpret_cast<const quint8*>(rgndata.constData());
 
   quint32 opnt = 0, oidx = 0, opline = 0, opgon = 0;
   quint32 objCnt = subdiv.hasIdxPoints + subdiv.hasPoints + subdiv.hasPolylines + subdiv.hasPolygons;
 
-  quint16* pOffset = (quint16*)(pRawData + subdiv.rgn_start);
+  const quint16* pOffset = reinterpret_cast<const quint16*>(pRawData + subdiv.rgn_start);
 
   // test for points
   if (subdiv.hasPoints) {
@@ -1794,7 +1805,7 @@ void CMapIMG::drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& sc
           v1 = v2;
         }
 
-        if (scale.x() < STREETNAME_THRESHOLD && property.labelType != CGarminTyp::eNone) {
+        if (scale.x() < kStreetNameThreshold && property.labelType != CGarminTyp::eNone) {
           QFont f(font);
           switch (property.labelType) {
             case CGarminTyp::eSmall:
@@ -1882,7 +1893,7 @@ void CMapIMG::drawLine(BLContext& ctx, CGarminPolygon& l, bool stroke, int lineW
 
   map->convertRad2Px(poly);
 
-  if (scale.x() < STREETNAME_THRESHOLD && property.labelType != CGarminTyp::eNone) {
+  if (scale.x() < kStreetNameThreshold && property.labelType != CGarminTyp::eNone) {
     QFont f(font);
     switch (property.labelType) {
       case CGarminTyp::eSmall:
@@ -2169,37 +2180,30 @@ void CMapIMG::getToolTip(const QPoint& px, QString& infotext) const /* override 
 {
   QString str;
 
-  QMultiMap<QString, QString> dict;
-  getInfoPoints(points, px, dict);
-  getInfoPoints(pois, px, dict);
-  getInfoPolylines(px, dict);
-
-  const QStringList& values = dict.values();
-  for (const QString& value : values) {
-    if (value == "-") {
-      continue;
-    }
-
-    if (!str.isEmpty()) {
-      str += "\n";
-    }
-    str += value;
-  }
-
-  if (str.isEmpty()) {
-    dict.clear();
-    getInfoPolygons(px, dict);
-    const QStringList& values = dict.values();
-    for (const QString& value : values) {
+  // Append every value of a dict (skipping the "-" placeholder) as newline-separated lines.
+  const auto appendValues = [&str](const QMultiMap<QString, QString>& dict) {
+    for (const QString& value : dict.values()) {
       if (value == "-") {
         continue;
       }
-
       if (!str.isEmpty()) {
         str += "\n";
       }
       str += value;
     }
+  };
+
+  QMultiMap<QString, QString> dict;
+  getInfoPoints(points, px, dict);
+  getInfoPoints(pois, px, dict);
+  getInfoPolylines(px, dict);
+  appendValues(dict);
+
+  // Fall back to polygon (area) info only when nothing closer was found.
+  if (str.isEmpty()) {
+    dict.clear();
+    getInfoPolygons(px, dict);
+    appendValues(dict);
   }
 
   if (!infotext.isEmpty() && !str.isEmpty()) {

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -331,47 +331,92 @@ BLPath qPathToBLPath(const QPainterPath& pp) {
   return path;
 }
 
-/**
-   @brief Lay @p text out left-to-right from the origin into a single BLPath.
+/// The coloured glyph outline plus a pre-built white halo (the glyph unioned with its eight
+/// ±1 px neighbours). Both are tessellated once and cached; drawing is then two path fills.
+struct GlyphPaths {
+  BLPath glyph;
+  BLPath halo;
+};
 
-   Glyph mapping is cmap-only (no complex shaping) via QRawFont, which keeps Qt's font
-   matching while emitting outlines Blend2D can fill. The glyph origin (0,0) is the pen
-   position on the baseline, matching QPainter::drawText().
- */
-BLPath buildTextPath(const QRawFont& raw, const QString& text) {
-  BLPath path;
-  const QList<quint32> glyphs = raw.glyphIndexesForString(text);
-  const QList<QPointF> advances = raw.advancesForGlyphIndexes(glyphs);
-  QPointF pen(0, 0);
-  for (qsizetype i = 0; i < glyphs.size(); ++i) {
-    const QPainterPath gp = raw.pathForGlyph(glyphs[i]);
-    if (!gp.isEmpty()) {
-      path.add_path(qPathToBLPath(gp), BLPoint(pen.x(), pen.y()));
-    }
-    pen += advances[i];
-  }
-  return path;
+/// A resolved QRawFont together with its per-glyph outline cache.
+struct FontGlyphs {
+  QRawFont raw;
+  QHash<quint32, GlyphPaths> glyphs;
+};
+
+/// Signature identifying a QFont for glyph-cache lookup (only attributes that affect the
+/// resolved outlines matter).
+quint64 fontKey(const QFont& f) {
+  return quint64(qHashMulti(0, f.family(), f.pointSize(), f.pixelSize(), int(f.weight()), f.italic(), f.styleName()));
 }
 
 /**
-   @brief Fill a glyph(-run) path with the white 8-neighbour halo, then the coloured text.
+   @brief Resolve @p font to a QRawFont and its glyph cache, memoised per thread.
 
-   Offsets are applied in the current context transform space, so a caller drawing under a
-   rotated transform gets a correctly rotated halo. The same path is reused for all nine
-   fills (tessellated once), each placed via fill_path()'s origin argument.
+   QRawFont::fromFont() (Qt's font matching) and the per-glyph outline extraction are the
+   expensive parts of text drawing, and both are immutable for a given font, so they are
+   cached across frames. The cache is thread-local: draw() is serialised per render thread,
+   so no locking is needed and independent canvases never share (or race on) an entry.
  */
-void fillGlyphHalo(BLContext& ctx, const BLPath& glyphs, const BLPoint& base, BLRgba32 fill, BLRgba32 halo) {
+FontGlyphs& fontGlyphsFor(const QFont& font) {
+  thread_local QHash<quint64, FontGlyphs> cache;
+  const quint64 key = fontKey(font);
+  auto it = cache.find(key);
+  if (it == cache.end()) {
+    FontGlyphs fg;
+    fg.raw = QRawFont::fromFont(font);
+    it = cache.insert(key, fg);
+  }
+  return it.value();
+}
+
+/// Fetch (building on first use) the cached outline + halo for a single glyph. The halo is
+/// the union of the glyph shifted by its eight ±1 px neighbours, filled once under non-zero
+/// winding — visually identical to eight separate offset draws but a single rasterisation.
+const GlyphPaths& glyphPathsFor(FontGlyphs& fg, quint32 glyphIndex) {
+  auto it = fg.glyphs.find(glyphIndex);
+  if (it == fg.glyphs.end()) {
+    GlyphPaths gp;
+    gp.glyph = qPathToBLPath(fg.raw.pathForGlyph(glyphIndex));
+    static const BLPoint offsets[8] = {{-1, -1}, {0, -1}, {1, -1}, {-1, 0}, {1, 0}, {-1, 1}, {0, 1}, {1, 1}};
+    for (const BLPoint& o : offsets) {
+      gp.halo.add_path(gp.glyph, o);
+    }
+    it = fg.glyphs.insert(glyphIndex, gp);
+  }
+  return it.value();
+}
+
+/**
+   @brief Lay @p text out left-to-right from the origin into cached glyph + halo paths.
+
+   Glyph mapping is cmap-only (no complex shaping) via QRawFont, which keeps Qt's font
+   matching while emitting outlines Blend2D can fill. The glyph origin (0,0) is the pen
+   position on the baseline, matching QPainter::drawText(). Per-glyph outlines come from the
+   cache, so a repeated word only tessellates each distinct glyph once.
+ */
+GlyphPaths buildTextRun(FontGlyphs& fg, const QString& text) {
+  GlyphPaths run;
+  const QList<quint32> glyphs = fg.raw.glyphIndexesForString(text);
+  const QList<QPointF> advances = fg.raw.advancesForGlyphIndexes(glyphs);
+  QPointF pen(0, 0);
+  for (qsizetype i = 0; i < glyphs.size(); ++i) {
+    const GlyphPaths& gp = glyphPathsFor(fg, glyphs[i]);
+    const BLPoint at(pen.x(), pen.y());
+    run.glyph.add_path(gp.glyph, at);
+    run.halo.add_path(gp.halo, at);
+    pen += advances[i];
+  }
+  return run;
+}
+
+/// Fill @p gp's white halo then its coloured glyph(s) at @p base — two path fills. Callers
+/// must have selected BL_FILL_RULE_NON_ZERO (the halo union relies on it).
+void fillGlyphRun(BLContext& ctx, const GlyphPaths& gp, const BLPoint& base, BLRgba32 fill, BLRgba32 halo) {
   ctx.set_fill_style(halo);
-  ctx.fill_path(BLPoint(base.x - 1, base.y - 1), glyphs);
-  ctx.fill_path(BLPoint(base.x, base.y - 1), glyphs);
-  ctx.fill_path(BLPoint(base.x + 1, base.y - 1), glyphs);
-  ctx.fill_path(BLPoint(base.x - 1, base.y), glyphs);
-  ctx.fill_path(BLPoint(base.x + 1, base.y), glyphs);
-  ctx.fill_path(BLPoint(base.x - 1, base.y + 1), glyphs);
-  ctx.fill_path(BLPoint(base.x, base.y + 1), glyphs);
-  ctx.fill_path(BLPoint(base.x + 1, base.y + 1), glyphs);
+  ctx.fill_path(base, gp.halo);
   ctx.set_fill_style(fill);
-  ctx.fill_path(base, glyphs);
+  ctx.fill_path(base, gp.glyph);
 }
 }  // namespace
 
@@ -2200,33 +2245,35 @@ void CMapIMG::drawPois(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPo
 }
 
 void CMapIMG::drawLabels(BLContext& ctx, const QVector<strlbl_t>& lbls) {
+  // See drawText(): non-zero winding for glyph outlines and the unioned halo.
+  ctx.set_fill_rule(BL_FILL_RULE_NON_ZERO);
+
   QFont f = CMainWindow::self().getMapFont();
   QVector<QFont> fonts(8, f);
   fonts[CGarminTyp::eSmall].setPointSize(f.pointSize() - 2);
   fonts[CGarminTyp::eLarge].setPointSize(f.pointSize() + 2);
 
-  // One QRawFont per label type, built on first use (QRawFont::fromFont is not free).
-  QVector<QRawFont> rawFonts(fonts.size());
   const BLRgba32 halo = toBLColor(Qt::white);
 
   for (const strlbl_t& lbl : lbls) {
     const int type = lbl.property.labelType;
-    if (!rawFonts[type].isValid()) {
-      rawFonts[type] = QRawFont::fromFont(fonts[type]);
-    }
+    FontGlyphs& fg = fontGlyphsFor(fonts[type]);
 
     // Match CDraw::text()'s placement: centre the metrics bounding box on the anchor and
     // use its top-left as the baseline-left pen origin.
     QRect r = QFontMetrics(fonts[type]).boundingRect(lbl.str);
     r.moveCenter(lbl.pt);
 
-    const BLPath glyphs = buildTextPath(rawFonts[type], lbl.str);
+    const GlyphPaths run = buildTextRun(fg, lbl.str);
     const BLRgba32 fill = toBLColor(lbl.isNight ? lbl.property.colorLabelNight : lbl.property.colorLabelDay);
-    fillGlyphHalo(ctx, glyphs, BLPoint(r.left(), r.top()), fill, halo);
+    fillGlyphRun(ctx, run, BLPoint(r.left(), r.top()), fill, halo);
   }
 }
 
 void CMapIMG::drawText(BLContext& ctx) {
+  // Glyph outlines want non-zero winding (drawPolygons leaves the context on even-odd), and
+  // the cached halo is a union of offset copies that only fills correctly under non-zero.
+  ctx.set_fill_rule(BL_FILL_RULE_NON_ZERO);
 
   for (const textpath_t& textpath : std::as_const(textpaths)) {
     QPainterPath path;
@@ -2256,9 +2303,11 @@ void CMapIMG::drawText(BLContext& ctx) {
     }
 
     fm = QFontMetricsF(font);
-    // Layout still uses QFontMetricsF (above); the glyph outlines are rasterised by
-    // Blend2D from QRawFont, which keeps Qt's font matching at the same resolved size.
-    const QRawFont raw = QRawFont::fromFont(font);
+    // Layout still uses QFontMetricsF (above); glyph outlines are rasterised by Blend2D from
+    // QRawFont (cached across frames), keeping Qt's font matching at the same resolved size.
+    // Glyph ids for the whole label are looked up once here rather than per character.
+    FontGlyphs& fg = fontGlyphsFor(font);
+    const QList<quint32> glyphIds = fg.raw.glyphIndexesForString(textpath.text);
     const BLRgba32 fill = toBLColor(textpath.color);
     const BLRgba32 halo = toBLColor(Qt::white);
 
@@ -2316,8 +2365,9 @@ void CMapIMG::drawText(BLContext& ctx) {
       ctx.rotate(angle);
       ctx.translate(0, -(textpath.lineWidth + 2));
 
-      const BLPath glyphs = buildTextPath(raw, text.mid(i, 1));
-      fillGlyphHalo(ctx, glyphs, BLPoint(0, 0), fill, halo);
+      if (i < glyphIds.size()) {
+        fillGlyphRun(ctx, glyphPathsFor(fg, glyphIds[i]), BLPoint(0, 0), fill, halo);
+      }
 
       ctx.restore();
 

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -18,8 +18,11 @@
 
 #include "map/CMapIMG.h"
 
+#include <blend2d/blend2d.h>
+
 #include <QPainterPath>
 #include <QtWidgets>
+#include <cmath>
 
 #include "CMainWindow.h"
 #include "canvas/CCanvas.h"
@@ -114,6 +117,148 @@ static inline bool isCluttered(QVector<QRectF>& rectPois, const QRectF& rect) {
   rectPois << rect;
   return false;
 }
+
+namespace {
+/// Convert a QColor to a Blend2D non-premultiplied 0xAARRGGBB colour.
+inline BLRgba32 toBLColor(const QColor& c) { return BLRgba32(c.rgba()); }
+
+/// Build a Blend2D path from a polyline. When @p close is set the path is closed
+/// so it can be filled and its closing edge stroked (matching QPainter::drawPolygon).
+BLPath polyToPath(const QPolygonF& poly, bool close) {
+  BLPath path;
+  const int n = poly.size();
+  if (n == 0) {
+    return path;
+  }
+  path.move_to(poly[0].x(), poly[0].y());
+  for (int i = 1; i < n; ++i) {
+    path.line_to(poly[i].x(), poly[i].y());
+  }
+  if (close) {
+    path.close();
+  }
+  return path;
+}
+
+BLStrokeCap toBLCap(Qt::PenCapStyle cap) {
+  switch (cap) {
+    case Qt::SquareCap:
+      return BL_STROKE_CAP_SQUARE;
+    case Qt::RoundCap:
+      return BL_STROKE_CAP_ROUND;
+    case Qt::FlatCap:
+    default:
+      return BL_STROKE_CAP_BUTT;
+  }
+}
+
+BLStrokeJoin toBLJoin(Qt::PenJoinStyle join) {
+  switch (join) {
+    case Qt::BevelJoin:
+      return BL_STROKE_JOIN_BEVEL;
+    case Qt::RoundJoin:
+      return BL_STROKE_JOIN_ROUND;
+    case Qt::MiterJoin:
+    case Qt::SvgMiterJoin:
+    default:
+      return BL_STROKE_JOIN_MITER_BEVEL;
+  }
+}
+
+/**
+   @brief Configure a context's stroke state from a QPen.
+
+   Maps width, cap, join, colour and the simple Qt dash styles to their Blend2D
+   counterparts. Qt dash patterns are expressed in pen-width units, so they are
+   scaled by the stroke width here.
+
+   @return false for Qt::NoPen, telling the caller to skip stroking entirely.
+ */
+bool applyPen(BLContext& ctx, const QPen& pen) {
+  if (pen.style() == Qt::NoPen) {
+    return false;
+  }
+
+  const double width = pen.widthF() > 0.0 ? pen.widthF() : 1.0;
+  ctx.set_stroke_width(width);
+  ctx.set_stroke_caps(toBLCap(pen.capStyle()));
+  ctx.set_stroke_join(toBLJoin(pen.joinStyle()));
+
+  BLArray<double> dashes;
+  switch (pen.style()) {
+    case Qt::DashLine:
+      dashes.append(4.0 * width);
+      dashes.append(2.0 * width);
+      break;
+    case Qt::DotLine:
+      dashes.append(1.0 * width);
+      dashes.append(2.0 * width);
+      break;
+    case Qt::DashDotLine:
+      dashes.append(4.0 * width);
+      dashes.append(2.0 * width);
+      dashes.append(1.0 * width);
+      dashes.append(2.0 * width);
+      break;
+    case Qt::DashDotDotLine:
+      dashes.append(4.0 * width);
+      dashes.append(2.0 * width);
+      dashes.append(1.0 * width);
+      dashes.append(2.0 * width);
+      dashes.append(1.0 * width);
+      dashes.append(2.0 * width);
+      break;
+    default:  // SolidLine (and custom dashes, treated as solid)
+      break;
+  }
+  // An empty dash array clears any dash pattern left over from a previous type.
+  ctx.set_stroke_dash_array(dashes);
+  ctx.set_stroke_dash_offset(0.0);
+  ctx.set_stroke_style(toBLColor(pen.color()));
+  return true;
+}
+
+/// Blit a QImage at (@p x, @p y). Blend2D only consumes premultiplied ARGB, so a
+/// conversion is done on the fly for sources that are stored in another format.
+void blitQImage(BLContext& ctx, double x, double y, const QImage& img) {
+  if (img.isNull()) {
+    return;
+  }
+  QImage storage;
+  const QImage& src = (img.format() == QImage::Format_ARGB32_Premultiplied)
+                          ? img
+                          : (storage = img.convertToFormat(QImage::Format_ARGB32_Premultiplied));
+  BLImage bl;
+  if (bl.create_from_data(src.width(), src.height(), BL_FORMAT_PRGB32, const_cast<uchar*>(src.constBits()),
+                          src.bytesPerLine(), BL_DATA_ACCESS_READ) != BL_SUCCESS) {
+    return;
+  }
+  ctx.blit_image(BLPoint(x, y), bl);
+}
+
+/// Blit the small blue bullet used as a fallback marker for cluttered points.
+void blitBullet(BLContext& ctx, double x, double y) {
+  static const QImage bullet =
+      QImage(":/icons/8x8/bullet_blue.png").convertToFormat(QImage::Format_ARGB32_Premultiplied);
+  blitQImage(ctx, x, y, bullet);
+}
+
+/// Render a non-solid QBrush into a small premultiplied tile usable as a repeating
+/// Blend2D pattern. Texture brushes return their image directly; hatch and dense
+/// patterns are rasterised by Qt onto an 8x8 transparent tile (their period).
+QImage brushToTile(const QBrush& brush) {
+  if (brush.style() == Qt::TexturePattern) {
+    return brush.textureImage().convertToFormat(QImage::Format_ARGB32_Premultiplied);
+  }
+
+  QImage tile(8, 8, QImage::Format_ARGB32_Premultiplied);
+  tile.fill(Qt::transparent);
+  QPainter p(&tile);
+  p.fillRect(tile.rect(), brush);
+  p.end();
+  return tile;
+}
+}  // namespace
 
 CMapIMG::CMapIMG(const QString& filename, CMapDraw* parent)
     : IMap(eFeatVisibility | eFeatVectorItems | eFeatTypFile, parent),
@@ -1108,16 +1253,6 @@ void CMapIMG::draw(IDrawContext::buffer_t& buf) /* override */
     return;
   }
 
-  QPainter p(&buf.image);
-  p.setOpacity(getOpacity() / 100.0);
-  USE_ANTI_ALIASING(p, true);
-
-  QFont f = CMainWindow::self().getMapFont();
-
-  p.setFont(f);
-  p.setPen(Qt::black);
-  p.setBrush(Qt::NoBrush);
-
   quint8 bits = scale2bits(bufferScale);
 
   QVector<map_level_t>::const_iterator maplevel = maplevels.constEnd();
@@ -1150,63 +1285,81 @@ void CMapIMG::draw(IDrawContext::buffer_t& buf) /* override */
    */
   QPointF pp = buf.ref1;
   map->convertRad2Px(pp);
-  p.save();
-  p.translate(-pp);
 
-  if (map->needsRedraw()) {
-    p.restore();
-    return;
+  /*
+     The shared draw buffer is plain (non-premultiplied) ARGB32, but Blend2D only
+     renders into premultiplied ARGB. Convert the buffer in place for the duration
+     of this draw and restore the original format before returning, so the change
+     stays invisible to the rest of the map stack.
+   */
+  buf.image.convertTo(QImage::Format_ARGB32_Premultiplied);
+
+  bool ok = !map->needsRedraw();
+  {
+    BLImage blBuf;
+    if (blBuf.create_from_data(buf.image.width(), buf.image.height(), BL_FORMAT_PRGB32, buf.image.bits(),
+                               buf.image.bytesPerLine()) != BL_SUCCESS) {
+      buf.image.convertTo(QImage::Format_ARGB32);
+      return;
+    }
+
+    BLContext ctx(blBuf);
+    ctx.set_global_alpha(getOpacity() / 100.0);
+    /*
+       The buffer is allocated at device resolution (pixelRatio larger) and tagged with
+       QImage::setDevicePixelRatio(). QPainter applies that ratio implicitly, but Blend2D
+       renders into the raw pixels and knows nothing about it. Scale the context by the
+       pixel ratio so the logical coordinates produced by convertRad2Px() map to device
+       pixels exactly as the QPainter text phase (and the rest of the map stack) expect.
+     */
+    ctx.scale(buf.image.devicePixelRatio(), buf.image.devicePixelRatio());
+    ctx.translate(-pp.x(), -pp.y());
+
+    if (ok) {
+      try {
+        loadVisibleData(false, polygons, polylines, points, pois, maplevel->level, viewport, ctx);
+      } catch (const std::bad_alloc&) {
+        qWarning() << "GarminIMG: Allocation error. Abort map rendering.";
+        ok = false;
+      }
+    }
+
+    if (ok && !map->needsRedraw()) {
+      drawPolygons(ctx, polygons);
+    }
+    if (ok && !map->needsRedraw()) {
+      drawPolylines(ctx, polylines, bufferScale);
+    }
+    if (ok && !map->needsRedraw()) {
+      drawPoints(ctx, points, rectPois);
+    }
+    if (ok && !map->needsRedraw()) {
+      drawPois(ctx, pois, rectPois);
+    }
+
+    ctx.end();
   }
 
-  try {
-    loadVisibleData(false, polygons, polylines, points, pois, maplevel->level, viewport, p);
-  } catch (const std::bad_alloc&) {
-    qWarning() << "GarminIMG: Allocation error. Abort map rendering.";
-    p.restore();
-    return;
+  // Text and labels are drawn on top with QPainter (see drawText()/drawLabels()).
+  if (ok && !map->needsRedraw()) {
+    QPainter p(&buf.image);
+    p.setOpacity(getOpacity() / 100.0);
+    USE_ANTI_ALIASING(p, true);
+    p.setFont(CMainWindow::self().getMapFont());
+    p.translate(-pp);
+
+    drawText(p);
+
+    if (!map->needsRedraw()) {
+      drawLabels(p, labels);
+    }
   }
 
-  if (map->needsRedraw()) {
-    p.restore();
-    return;
-  }
-  drawPolygons(p, polygons);
-
-  if (map->needsRedraw()) {
-    p.restore();
-    return;
-  }
-  drawPolylines(p, polylines, bufferScale);
-
-  if (map->needsRedraw()) {
-    p.restore();
-    return;
-  }
-  drawPoints(p, points, rectPois);
-
-  if (map->needsRedraw()) {
-    p.restore();
-    return;
-  }
-  drawPois(p, pois, rectPois);
-
-  if (map->needsRedraw()) {
-    p.restore();
-    return;
-  }
-  drawText(p);
-
-  if (map->needsRedraw()) {
-    p.restore();
-    return;
-  }
-  drawLabels(p, labels);
-
-  p.restore();
+  buf.image.convertTo(QImage::Format_ARGB32);
 }
 
 void CMapIMG::loadVisibleData(bool fast, polytype_t& polygons, polytype_t& polylines, pointtype_t& points,
-                              pointtype_t& pois, unsigned level, const QRectF& viewport, QPainter& p) {
+                              pointtype_t& pois, unsigned level, const QRectF& viewport, BLContext& ctx) {
 #ifndef Q_OS_WIN32
   CFileExt file(filename);
   if (!file.open(QIODevice::ReadOnly)) {
@@ -1264,9 +1417,9 @@ void CMapIMG::loadVisibleData(bool fast, polytype_t& polygons, polytype_t& polyl
 
       map->convertRad2Px(poly);
 
-      p.setPen(QPen(Qt::magenta, 2));
-      p.setBrush(Qt::NoBrush);
-      p.drawPolygon(poly);
+      ctx.setStrokeWidth(2);
+      ctx.setStrokeStyle(BLRgba32(0xFFFF00FFu));  // magenta
+      ctx.strokePath(polyToPath(poly, true));
 #endif  // DEBUG_SHOW_SECTION_BORDERS
     }
 
@@ -1283,8 +1436,9 @@ void CMapIMG::loadVisibleData(bool fast, polytype_t& polygons, polytype_t& polyl
 
     QPolygonF poly;
     poly << p1 << p2 << p3 << p4;
-    p.setPen(Qt::black);
-    p.drawPolygon(poly);
+    ctx.setStrokeWidth(1);
+    ctx.setStrokeStyle(BLRgba32(0xFF000000u));  // black
+    ctx.strokePath(polyToPath(poly, true));
 #endif  // DEBUG_SHOW_SUBDIV_BORDERS
 
 #ifdef Q_OS_WIN32
@@ -1526,13 +1680,40 @@ void CMapIMG::loadSubDiv(CFileExt& file, const subdiv_desc_t& subdiv, IGarminStr
   }
 }
 
-void CMapIMG::drawPolygons(QPainter& p, polytype_t& lines) {
+void CMapIMG::drawPolygons(BLContext& ctx, polytype_t& lines) {
+  const bool night = CMainWindow::self().isNight();
+
+  // QPainter::drawPolygon fills using the odd-even rule; Blend2D defaults to non-zero.
+  ctx.set_fill_rule(BL_FILL_RULE_EVEN_ODD);
+
   const int N = polygonDrawOrder.size();
   for (int n = 0; n < N; ++n) {
     quint32 type = polygonDrawOrder[(N - 1) - n];
+    const CGarminTyp::polygon_property& property = polygonProperties[type];
+    const QBrush& brush = night ? property.brushNight : property.brushDay;
 
-    p.setPen(polygonProperties[type].pen);
-    p.setBrush(CMainWindow::self().isNight() ? polygonProperties[type].brushNight : polygonProperties[type].brushDay);
+    // Configure the fill style once per type. Solid colours map directly; texture
+    // images and hatch patterns are realised as a repeating BLPattern. The pattern's
+    // pixel data (tile) must outlive every fill that uses it, hence the outer scope.
+    QImage tile;
+    BLImage tileBL;
+    BLPattern pattern;
+    if (brush.style() == Qt::SolidPattern) {
+      ctx.set_fill_style(toBLColor(brush.color()));
+    } else {
+      tile = brushToTile(brush);
+      if (tileBL.create_from_data(tile.width(), tile.height(), BL_FORMAT_PRGB32, const_cast<uchar*>(tile.constBits()),
+                                  tile.bytesPerLine(), BL_DATA_ACCESS_READ) == BL_SUCCESS) {
+        pattern.set_image(tileBL);
+        pattern.set_extend_mode(BL_EXTEND_MODE_REPEAT);
+        ctx.set_fill_style(pattern);
+      } else {
+        ctx.set_fill_style(toBLColor(brush.color()));
+      }
+    }
+
+    const QPen& pen = property.pen;
+    const bool hasOutline = applyPen(ctx, pen);
 
     for (CGarminPolygon& line : lines) {
       if (line.type != type) {
@@ -1540,22 +1721,24 @@ void CMapIMG::drawPolygons(QPainter& p, polytype_t& lines) {
       }
 
       QPolygonF& poly = line.pixel;
-
       map->convertRad2Px(poly);
 
-      //            simplifyPolyline(line);
+      const BLPath path = polyToPath(poly, true);
+      ctx.fill_path(path);
+      if (hasOutline) {
+        ctx.stroke_path(path);
+      }
 
-      p.drawPolygon(poly);
-
-      if (!polygonProperties[type].known) {
+      if (!property.known) {
         qDebug() << "unknown polygon" << Qt::hex << type;
       }
     }
   }
 }
 
-void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale) {
+void CMapIMG::drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& scale) {
   textpaths.clear();
+  const bool night = CMainWindow::self().isNight();
   QFont font = CMainWindow::self().getMapFont();
 
   font.setPointSize(9);
@@ -1563,13 +1746,6 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
 
   QVector<qreal> lengths;
   lengths.reserve(100);
-  /*
-      int pixmapCount = 0;
-      int borderCount = 0;
-      int normalCount = 0;
-      int imageCount = 0;
-      int deletedCount = 0;
-   */
 
   QHash<quint32, QList<quint32> > dict;
   for (int i = 0; i < lines.count(); ++i) {
@@ -1582,165 +1758,129 @@ void CMapIMG::drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale
     const quint32& type = props.key();
     const CGarminTyp::polyline_property& property = props.value();
 
-    if (dict[type].isEmpty()) {
+    const QList<quint32>& indices = dict[type];
+    if (indices.isEmpty()) {
       continue;
     }
 
     if (property.hasPixmap) {
-      const QImage& pixmap = CMainWindow::self().isNight() ? property.imgNight : property.imgDay;
+      const QImage& pixmap = night ? property.imgNight : property.imgDay;
       const qreal h = pixmap.height();
 
-      QList<quint32>::const_iterator it = dict[type].constBegin();
-      for (; it != dict[type].constEnd(); ++it) {
-        CGarminPolygon& item = lines[*it];
-        {
-          // pixmapCount++;
+      for (quint32 idx : indices) {
+        CGarminPolygon& item = lines[idx];
+        QPolygonF& poly = item.pixel;
+        const int size = poly.size();
 
-          QPolygonF& poly = item.pixel;
-          int size = poly.size();
+        if (size < 2) {
+          continue;
+        }
 
-          if (size < 2) {
+        map->convertRad2Px(poly);
+
+        lengths.resize(0);
+        lengths.reserve(size);
+
+        qreal u1 = poly[0].x();
+        qreal v1 = poly[0].y();
+        for (int i = 1; i < size; ++i) {
+          qreal u2 = poly[i].x();
+          qreal v2 = poly[i].y();
+
+          qreal segLength = qSqrt((u2 - u1) * (u2 - u1) + (v2 - v1) * (v2 - v1));
+          lengths << segLength;
+
+          u1 = u2;
+          v1 = v2;
+        }
+
+        if (scale.x() < STREETNAME_THRESHOLD && property.labelType != CGarminTyp::eNone) {
+          QFont f(font);
+          switch (property.labelType) {
+            case CGarminTyp::eSmall:
+              f.setPointSize(font.pointSize() - 2);
+              break;
+            case CGarminTyp::eLarge:
+              f.setPointSize(font.pointSize() + 2);
+              break;
+            default:;
+          }
+
+          collectText(item, poly, f, h, night ? property.colorLabelNight : property.colorLabelDay);
+        }
+
+        // Lay the pixmap along each straight segment of the polyline. The arc-length
+        // breakpoints used to coincide with the polyline vertices, so we can index
+        // the vertices directly instead of re-walking a QPainterPath.
+        for (int i = 0; i + 1 < size; ++i) {
+          const qreal segLength = lengths.at(i);
+          if (segLength < 1.0) {
             continue;
           }
 
-          map->convertRad2Px(poly);
+          const QPointF& p1 = poly[i];
+          const QPointF& p2 = poly[i + 1];
+          const double angle = std::atan2(p2.y() - p1.y(), p2.x() - p1.x());
 
-          lengths.resize(0);
-
-          //                    deletedCount += line.size();
-          //                    simplifyPolyline(line);
-          //                    deletedCount -= line.size();
-          //                    size = line.size();
-
-          lengths.reserve(size);
-
-          QPainterPath path;
-          qreal totalLength = 0;
-
-          qreal u1 = poly[0].x();
-          qreal v1 = poly[0].y();
-
-          for (int i = 1; i < size; ++i) {
-            qreal u2 = poly[i].x();
-            qreal v2 = poly[i].y();
-
-            qreal segLength = qSqrt((u2 - u1) * (u2 - u1) + (v2 - v1) * (v2 - v1));
-            totalLength += segLength;
-            lengths << segLength;
-
-            u1 = u2;
-            v1 = v2;
+          const QImage seg = img2line(pixmap, segLength);
+          BLImage segBL;
+          if (segBL.create_from_data(seg.width(), seg.height(), BL_FORMAT_PRGB32, const_cast<uchar*>(seg.constBits()),
+                                     seg.bytesPerLine(), BL_DATA_ACCESS_READ) != BL_SUCCESS) {
+            continue;
           }
 
-          if (scale.x() < STREETNAME_THRESHOLD && property.labelType != CGarminTyp::eNone) {
-            QFont f(font);
-            switch (property.labelType) {
-              case CGarminTyp::eSmall:
-                f.setPointSize(font.pointSize() - 2);
-                break;
-              case CGarminTyp::eLarge:
-                f.setPointSize(font.pointSize() + 2);
-                break;
-              default:;
-            }
-
-            collectText(item, poly, f, h,
-                        CMainWindow::self().isNight() ? property.colorLabelNight : property.colorLabelDay);
-          }
-
-          path.addPolygon(poly);
-          const int nLength = lengths.count();
-
-          qreal curLength = 0;
-          QPointF p2 = path.pointAtPercent(curLength / totalLength);
-          for (int i = 0; i < nLength; ++i) {
-            qreal segLength = lengths.at(i);
-
-            //                         qDebug() << curLength << totalLength << curLength / totalLength;
-
-            QPointF p1 = p2;
-            p2 = path.pointAtPercent((curLength + segLength) / totalLength);
-            qreal angle = qAtan((p2.y() - p1.y()) / (p2.x() - p1.x())) * 180 / M_PI;
-
-            if (p2.x() - p1.x() < 0) {
-              angle += 180;
-            }
-
-            p.save();
-            p.translate(p1);
-            p.rotate(angle);
-            p.drawImage(0, -h / 2, img2line(pixmap, segLength));
-            // imageCount++;
-
-            p.restore();
-            curLength += segLength;
-          }
+          ctx.save();
+          ctx.translate(p1.x(), p1.y());
+          ctx.rotate(angle);
+          ctx.blit_image(BLPoint(0.0, -h / 2.0), segBL);
+          ctx.restore();
         }
       }
     } else {
-      if (property.hasBorder) {
-        // draw background line 1st
-        p.setPen(CMainWindow::self().isNight() ? property.penBorderNight : property.penBorderDay);
+      // First run: the background (border) line for bordered types, otherwise the
+      // line itself. Either way the labels are collected here.
+      const QPen& pen = property.hasBorder ? (night ? property.penBorderNight : property.penBorderDay)
+                                           : (night ? property.penLineNight : property.penLineDay);
+      const bool stroke = applyPen(ctx, pen);
+      const int lineWidth = pen.width();
 
-        QList<quint32>::const_iterator it = dict[type].constBegin();
-        for (; it != dict[type].constEnd(); ++it) {
-          // borderCount++;
-          drawLine(p, lines[*it], property, font, scale);
-        }
-        // draw foreground line in a second run for nicer borders
-      } else {
-        p.setPen(CMainWindow::self().isNight() ? property.penLineNight : property.penLineDay);
-
-        QList<quint32>::const_iterator it = dict[type].constBegin();
-        for (; it != dict[type].constEnd(); ++it) {
-          // normalCount++;
-          drawLine(p, lines[*it], property, font, scale);
-        }
+      for (quint32 idx : indices) {
+        drawLine(ctx, lines[idx], stroke, lineWidth, property, font, scale);
       }
     }
   }
 
-  // 2nd run to draw foreground lines.
-  props = polylineProperties.begin();
-  for (; props != end; ++props) {
+  // 2nd run to draw the foreground lines over their borders.
+  for (props = polylineProperties.begin(); props != end; ++props) {
     const quint32& type = props.key();
     const CGarminTyp::polyline_property& property = props.value();
 
-    if (dict[type].isEmpty()) {
+    const QList<quint32>& indices = dict[type];
+    if (indices.isEmpty()) {
       continue;
     }
 
     if (property.hasBorder && !property.hasPixmap) {
-      // draw foreground line 2nd
-      p.setPen(CMainWindow::self().isNight() ? property.penLineNight : property.penLineDay);
-
-      QList<quint32>::const_iterator it = dict[type].constBegin();
-      for (; it != dict[type].constEnd(); ++it) {
-        drawLine(p, lines[*it]);
+      const QPen& pen = night ? property.penLineNight : property.penLineDay;
+      if (applyPen(ctx, pen)) {
+        for (quint32 idx : indices) {
+          drawLine(ctx, lines[idx]);
+        }
       }
     }
   }
-
-  //    qDebug() << "pixmapCount:" << pixmapCount
-  //        << "borderCount:" << borderCount
-  //        << "normalCount:" << normalCount
-  //        << "imageCount:" << imageCount
-  //        << "deletedCount:" << deletedCount;
 }
 
-void CMapIMG::drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polyline_property& property, const QFont& font,
-                       const QPointF& scale) {
+void CMapIMG::drawLine(BLContext& ctx, CGarminPolygon& l, bool stroke, int lineWidth,
+                       const CGarminTyp::polyline_property& property, const QFont& font, const QPointF& scale) {
   QPolygonF& poly = l.pixel;
   const int size = poly.size();
-  const int lineWidth = p.pen().width();
 
   if (size < 2) {
     return;
   }
 
   map->convertRad2Px(poly);
-
-  //    simplifyPolyline(line);
 
   if (scale.x() < STREETNAME_THRESHOLD && property.labelType != CGarminTyp::eNone) {
     QFont f(font);
@@ -1758,20 +1898,18 @@ void CMapIMG::drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polylin
                 CMainWindow::self().isNight() ? property.colorLabelNight : property.colorLabelDay);
   }
 
-  p.drawPolyline(poly);
+  if (stroke) {
+    ctx.stroke_path(polyToPath(poly, false));
+  }
 }
 
-void CMapIMG::drawLine(QPainter& p, const CGarminPolygon& l) {
+void CMapIMG::drawLine(BLContext& ctx, const CGarminPolygon& l) {
   const QPolygonF& poly = l.pixel;
-  const int size = poly.size();
-
-  if (size < 2) {
+  if (poly.size() < 2) {
     return;
   }
 
-  //    simplifyPolyline(poly);
-
-  p.drawPolyline(poly);
+  ctx.stroke_path(polyToPath(poly, false));
 }
 
 void CMapIMG::collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font, qint32 lineWidth,
@@ -1830,32 +1968,30 @@ void CMapIMG::addLabel(const CGarminPoint& pt, const QRect& rect, const CGarminT
   strlbl.isNight = isNight;
 }
 
-void CMapIMG::drawPoints(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPois) {
+void CMapIMG::drawPoints(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois) {
+  const bool night = CMainWindow::self().isNight();
   pointtype_t::iterator pt = pts.begin();
   while (pt != pts.end()) {
     map->convertRad2Px(pt->pos);
 
     const CGarminTyp::point_property& property = pointProperties[pt->type];
 
-    const QImage& icon = CMainWindow::self().isNight() ? property.imgNight : property.imgDay;
+    const QImage& icon = night ? property.imgNight : property.imgDay;
     const QSizeF& size = icon.size();
 
     if (isCluttered(rectPois, QRectF(pt->pos, size))) {
       if (size.width() <= 8 && size.height() <= 8) {
-        p.drawImage(pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
+        blitQImage(ctx, pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
       } else {
-        p.drawPixmap(pt->pos.x() - 4, pt->pos.y() - 4, QPixmap(":/icons/8x8/bullet_blue.png"));
+        blitBullet(ctx, pt->pos.x() - 4, pt->pos.y() - 4);
       }
       ++pt;
       continue;
     }
 
-    bool showLabel = true;
+    blitQImage(ctx, pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
 
-    p.drawImage(pt->pos.x() - (size.width() / 2), pt->pos.y() - (size.height() / 2), icon);
-    showLabel = property.labelType != CGarminTyp::eNone;
-
-    if (CMainWindow::self().isPoiText() && showLabel) {
+    if (CMainWindow::self().isPoiText() && property.labelType != CGarminTyp::eNone) {
       // calculate bounding rectangle with a border of 2 px
       QRect rect = fm.boundingRect(pt->labels.join(" "));
       rect.adjust(0, 0, 4, 4);
@@ -1863,31 +1999,32 @@ void CMapIMG::drawPoints(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPoi
 
       // if no intersection was found, add label to list
       if (!intersectsWithExistingLabel(rect)) {
-        addLabel(*pt, rect, property, CMainWindow::self().isNight());
+        addLabel(*pt, rect, property, night);
       }
     }
     ++pt;
   }
 }
 
-void CMapIMG::drawPois(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPois) {
+void CMapIMG::drawPois(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois) {
+  const bool night = CMainWindow::self().isNight();
   for (CGarminPoint& pt : pts) {
     map->convertRad2Px(pt.pos);
 
     const CGarminTyp::point_property& property = pointProperties[pt.type];
-    const QImage& icon = CMainWindow::self().isNight() ? property.imgNight : property.imgDay;
+    const QImage& icon = night ? property.imgNight : property.imgDay;
     const QSizeF& size = icon.size();
 
     if (isCluttered(rectPois, QRectF(pt.pos, size))) {
       if (size.width() <= 8 && size.height() <= 8) {
-        p.drawImage(pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
+        blitQImage(ctx, pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
       } else {
-        p.drawPixmap(pt.pos.x() - 4, pt.pos.y() - 4, QPixmap(":/icons/8x8/bullet_blue.png"));
+        blitBullet(ctx, pt.pos.x() - 4, pt.pos.y() - 4);
       }
       continue;
     }
 
-    p.drawImage(pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
+    blitQImage(ctx, pt.pos.x() - (size.width() / 2), pt.pos.y() - (size.height() / 2), icon);
 
     if (CMainWindow::self().isPoiText()) {
       // calculate bounding rectangle with a border of 2 px
@@ -1897,7 +2034,7 @@ void CMapIMG::drawPois(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPois)
 
       // if no intersection was found, add label to list
       if (!intersectsWithExistingLabel(rect)) {
-        addLabel(pt, rect, property, CMainWindow::self().isNight());
+        addLabel(pt, rect, property, night);
       }
     }
   }

--- a/src/qmapshack/map/CMapIMG.cpp
+++ b/src/qmapshack/map/CMapIMG.cpp
@@ -1687,6 +1687,14 @@ void CMapIMG::drawPolygons(BLContext& ctx, polytype_t& lines) {
   // QPainter::drawPolygon fills using the odd-even rule; Blend2D defaults to non-zero.
   ctx.set_fill_rule(BL_FILL_RULE_EVEN_ODD);
 
+  // Anchor the pattern phase to a fixed geographic point so textures/hatches stay put
+  // when the map is panned. convertRad2Px() of a constant coordinate shifts by exactly
+  // the pan delta each frame, so the pattern phase (vertexPx - anchorPx) depends only on
+  // geography and zoom, not on the viewport offset. Without this the tile origin sits at
+  // user-space (0,0) — a viewport-fixed pixel — and the pattern slides under the polygons.
+  QPointF anchorPx(0.0, 0.0);  // lon/lat origin, radians
+  map->convertRad2Px(anchorPx);
+
   // Bucket the polygon indices by type once, so each draw-order pass visits only the
   // polygons of its type instead of scanning the whole list once per type.
   QHash<quint32, QVector<qsizetype> > byType;
@@ -1728,6 +1736,9 @@ void CMapIMG::drawPolygons(BLContext& ctx, polytype_t& lines) {
                                   tile.bytesPerLine(), BL_DATA_ACCESS_READ) == BL_SUCCESS) {
         pattern.set_image(tileBL);
         pattern.set_extend_mode(BL_EXTEND_MODE_REPEAT);
+        // REPEAT makes only the fractional offset matter; fmod keeps the translation small
+        // so we don't lose sub-pixel precision at high zoom.
+        pattern.translate(std::fmod(anchorPx.x(), tile.width()), std::fmod(anchorPx.y(), tile.height()));
         ctx.set_fill_style(pattern);
       } else {
         ctx.set_fill_style(toBLColor(brush.color()));

--- a/src/qmapshack/map/CMapIMG.h
+++ b/src/qmapshack/map/CMapIMG.h
@@ -30,6 +30,7 @@
 class CMapDraw;
 class CFileExt;
 class IGarminStrTbl;
+class BLContext;
 
 typedef QVector<CGarminPolygon> polytype_t;
 typedef QVector<CGarminPoint> pointtype_t;
@@ -161,24 +162,27 @@ class CMapIMG : public IMap {
   void processPrimaryMapData();
   void readFile(CFileExt& file, quint32 offset, quint32 size, QByteArray& data);
   void loadVisibleData(bool fast, polytype_t& polygons, polytype_t& polylines, pointtype_t& points, pointtype_t& pois,
-                       unsigned level, const QRectF& viewport, QPainter& p);
+                       unsigned level, const QRectF& viewport, BLContext& ctx);
   void loadSubDiv(CFileExt& file, const subdiv_desc_t& subdiv, IGarminStrTbl* strtbl, const QByteArray& rgndata,
                   bool fast, const QRectF& viewport, polytype_t& polylines, polytype_t& polygons, pointtype_t& points,
                   pointtype_t& pois);
   bool intersectsWithExistingLabel(const QRect& rect) const;
   void addLabel(const CGarminPoint& pt, const QRect& rect, const CGarminTyp::point_property& property, bool isDay);
-  void drawPolygons(QPainter& p, polytype_t& lines);
-  void drawPolylines(QPainter& p, polytype_t& lines, const QPointF& scale);
-  void drawPoints(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPois);
-  void drawPois(QPainter& p, pointtype_t& pts, QVector<QRectF>& rectPois);
+  void drawPolygons(BLContext& ctx, polytype_t& lines);
+  void drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& scale);
+  void drawPoints(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois);
+  void drawPois(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois);
+  // Text and labels stay on QPainter; Qt's font handling has no Blend2D equivalent
+  // and they are a negligible fraction of the total rendering time.
   void drawLabels(QPainter& p, const QVector<strlbl_t>& lbls);
   void drawText(QPainter& p);
 
-  void drawLine(QPainter& p, CGarminPolygon& l, const CGarminTyp::polyline_property& property, const QFont& font, const QPointF& scale);
-  void drawLine(QPainter& p, const CGarminPolygon& l);
+  void drawLine(BLContext& ctx, CGarminPolygon& l, bool stroke, int lineWidth,
+                const CGarminTyp::polyline_property& property, const QFont& font, const QPointF& scale);
+  void drawLine(BLContext& ctx, const CGarminPolygon& l);
 
-  void collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font,
-                   qint32 lineWidth, const QColor& color);
+  void collectText(const CGarminPolygon& item, const QPolygonF& line, const QFont& font, qint32 lineWidth,
+                   const QColor& color);
 
   void getInfoPoints(const pointtype_t& points, const QPoint& pt, QMultiMap<QString, QString>& dict) const;
   void getInfoPolylines(const QPoint& pt, QMultiMap<QString, QString>& dict) const;

--- a/src/qmapshack/map/CMapIMG.h
+++ b/src/qmapshack/map/CMapIMG.h
@@ -32,8 +32,8 @@ class CFileExt;
 class IGarminStrTbl;
 class BLContext;
 
-typedef QVector<CGarminPolygon> polytype_t;
-typedef QVector<CGarminPoint> pointtype_t;
+using polytype_t = QVector<CGarminPolygon>;
+using pointtype_t = QVector<CGarminPoint>;
 
 class CMapIMG : public IMap {
   Q_OBJECT
@@ -431,11 +431,7 @@ class CMapIMG : public IMap {
     bool useBaseMap;
 
     bool operator==(const map_level_t& ml) const {
-      if (ml.bits != bits || ml.level != level || ml.useBaseMap != useBaseMap) {
-        return false;
-      } else {
-        return true;
-      }
+      return ml.bits == bits && ml.level == level && ml.useBaseMap == useBaseMap;
     }
 
     static bool GreaterThan(const map_level_t& ml1, const map_level_t& ml2) { return ml1.bits < ml2.bits; }

--- a/src/qmapshack/map/CMapIMG.h
+++ b/src/qmapshack/map/CMapIMG.h
@@ -172,10 +172,10 @@ class CMapIMG : public IMap {
   void drawPolylines(BLContext& ctx, polytype_t& lines, const QPointF& scale);
   void drawPoints(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois);
   void drawPois(BLContext& ctx, pointtype_t& pts, QVector<QRectF>& rectPois);
-  // Text and labels stay on QPainter; Qt's font handling has no Blend2D equivalent
-  // and they are a negligible fraction of the total rendering time.
-  void drawLabels(QPainter& p, const QVector<strlbl_t>& lbls);
-  void drawText(QPainter& p);
+  // Text and labels are rendered through Blend2D as well: glyph outlines come from
+  // QRawFont (cmap-only mapping, no complex shaping) and are filled in the shared context.
+  void drawLabels(BLContext& ctx, const QVector<strlbl_t>& lbls);
+  void drawText(BLContext& ctx);
 
   void drawLine(BLContext& ctx, CGarminPolygon& l, bool stroke, int lineWidth,
                 const CGarminTyp::polyline_property& property, const QFont& font, const QPointF& scale);

--- a/src/qmapshack/map/garmin/CGarminPoint.h
+++ b/src/qmapshack/map/garmin/CGarminPoint.h
@@ -34,7 +34,6 @@ class CGarminTile;
 class CGarminPoint {
  public:
   CGarminPoint() = default;
-  virtual ~CGarminPoint() = default;
 
   quint32 decode(qint32 iCenterLon, qint32 iCenterLat, quint32 shift, const quint8* pData);
   quint32 decode2(qint32 iCenterLon, qint32 iCenterLat, quint32 shift, const quint8* pData, const quint8* pEnd);

--- a/src/qmapshack/map/garmin/CGarminPolygon.h
+++ b/src/qmapshack/map/garmin/CGarminPolygon.h
@@ -37,7 +37,6 @@ struct sign_info_t;
 class CGarminPolygon {
  public:
   CGarminPolygon() = default;
-  virtual ~CGarminPolygon() = default;
 
   quint32 decode(qint32 iCenterLon, qint32 iCenterLat, quint32 shift, bool line, const quint8* pData,
                  const quint8* pEnd);

--- a/src/qmapshack/map/garmin/CGarminStrTbl6.cpp
+++ b/src/qmapshack/map/garmin/CGarminStrTbl6.cpp
@@ -95,7 +95,7 @@ void CGarminStrTbl6::fill() {
   }
 }
 
-void CGarminStrTbl6::get(CFileExt& file, quint32 offset, type_e t, QStringList& labels) {
+void CGarminStrTbl6::decode(CFileExt& file, quint32 offset, type_e t, QStringList& labels) {
   labels.clear();
 
   offset = calcOffset(file, offset, t);

--- a/src/qmapshack/map/garmin/CGarminStrTbl6.h
+++ b/src/qmapshack/map/garmin/CGarminStrTbl6.h
@@ -25,7 +25,8 @@ class CGarminStrTbl6 : public IGarminStrTbl {
   CGarminStrTbl6(const quint16 codepage, const quint8 mask, QObject* parent);
   virtual ~CGarminStrTbl6();
 
-  void get(CFileExt& file, quint32 offset, type_e t, QStringList& info) override;
+ protected:
+  void decode(CFileExt& file, quint32 offset, type_e t, QStringList& info) override;
 
  private:
   static const char str6tbl1[];

--- a/src/qmapshack/map/garmin/CGarminStrTbl8.cpp
+++ b/src/qmapshack/map/garmin/CGarminStrTbl8.cpp
@@ -25,7 +25,7 @@ CGarminStrTbl8::CGarminStrTbl8(const quint16 codepage, const quint8 mask, QObjec
 
 CGarminStrTbl8::~CGarminStrTbl8() {}
 
-void CGarminStrTbl8::get(CFileExt& file, quint32 offset, type_e t, QStringList& info) {
+void CGarminStrTbl8::decode(CFileExt& file, quint32 offset, type_e t, QStringList& info) {
   info.clear();
   offset = calcOffset(file, offset, t);
 

--- a/src/qmapshack/map/garmin/CGarminStrTbl8.h
+++ b/src/qmapshack/map/garmin/CGarminStrTbl8.h
@@ -26,6 +26,7 @@ class CGarminStrTbl8 : public IGarminStrTbl {
   CGarminStrTbl8(const quint16 codepage, const quint8 mask, QObject* parent);
   virtual ~CGarminStrTbl8();
 
-  void get(CFileExt& file, quint32 offset, type_e t, QStringList& info) override;
+ protected:
+  void decode(CFileExt& file, quint32 offset, type_e t, QStringList& info) override;
 };
 #endif  // CGARMINSTRTBL8_H

--- a/src/qmapshack/map/garmin/CGarminStrTblUtf8.cpp
+++ b/src/qmapshack/map/garmin/CGarminStrTblUtf8.cpp
@@ -24,7 +24,7 @@ CGarminStrTblUtf8::CGarminStrTblUtf8(const quint16 codepage, const quint8 mask, 
 
 CGarminStrTblUtf8::~CGarminStrTblUtf8() {}
 
-void CGarminStrTblUtf8::get(CFileExt& file, quint32 offset, type_e t, QStringList& labels) {
+void CGarminStrTblUtf8::decode(CFileExt& file, quint32 offset, type_e t, QStringList& labels) {
   labels.clear();
   offset = calcOffset(file, offset, t);
 

--- a/src/qmapshack/map/garmin/CGarminStrTblUtf8.h
+++ b/src/qmapshack/map/garmin/CGarminStrTblUtf8.h
@@ -25,6 +25,7 @@ class CGarminStrTblUtf8 : public IGarminStrTbl {
   CGarminStrTblUtf8(const quint16 codepage, const quint8 mask, QObject* parent);
   virtual ~CGarminStrTblUtf8();
 
-  void get(CFileExt& file, quint32 offset, type_e t, QStringList& info) override;
+ protected:
+  void decode(CFileExt& file, quint32 offset, type_e t, QStringList& info) override;
 };
 #endif  // CGARMINSTRTBLUTF8_H

--- a/src/qmapshack/map/garmin/CGarminTyp.cpp
+++ b/src/qmapshack/map/garmin/CGarminTyp.cpp
@@ -29,6 +29,7 @@
 #include <QtCore>
 
 #include "CMainWindow.h"
+#include "map/Blend2dUtil.h"
 #include "units/IUnit.h"
 
 #undef DBG
@@ -515,6 +516,8 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
     quint8 ctyp, rows;
     quint8 r, g, b;
     quint8 langcode;
+    QImage pixmapDay;
+    QImage pixmapNight;
 
     in.device()->seek(sectPolylines.arrayOffset + (sectPolylines.arrayModulo * element));
 
@@ -565,8 +568,8 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
           in >> b >> g >> r;
           xpm.setColor(0, qRgb(r, g, b));
           decodeBitmap(in, xpm, 32, rows, 1);
-          property.imgDay = xpm;
-          property.imgNight = xpm;
+          pixmapDay = xpm;
+          pixmapNight = xpm;
           property.hasPixmap = true;
           property.known = true;
         } else {
@@ -604,8 +607,8 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
           xpm2.setColor(0, qRgb(r, g, b));
           decodeBitmap(in, xpm1, 32, rows, 1);
           memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
-          property.imgDay = xpm1;
-          property.imgNight = xpm2;
+          pixmapDay = xpm1;
+          pixmapNight = xpm2;
           property.hasPixmap = true;
           property.known = true;
         } else {
@@ -643,8 +646,8 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
           xpm2.setColor(0, qRgb(r, g, b));
           decodeBitmap(in, xpm1, 32, rows, 1);
           memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
-          property.imgDay = xpm1;
-          property.imgNight = xpm2;
+          pixmapDay = xpm1;
+          pixmapNight = xpm2;
           property.hasPixmap = true;
           property.known = true;
         } else {
@@ -682,8 +685,8 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
           xpm2.setColor(0, qRgba(255, 255, 255, 0));
           decodeBitmap(in, xpm1, 32, rows, 1);
           memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
-          property.imgDay = xpm1;
-          property.imgNight = xpm2;
+          pixmapDay = xpm1;
+          pixmapNight = xpm2;
           property.hasPixmap = true;
           property.known = true;
         } else {
@@ -712,8 +715,8 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
           xpm.setColor(1, qRgb(r, g, b));
           xpm.setColor(0, qRgba(255, 255, 255, 0));
           decodeBitmap(in, xpm, 32, rows, 1);
-          property.imgDay = xpm;
-          property.imgNight = xpm;
+          pixmapDay = xpm;
+          pixmapNight = xpm;
           property.hasPixmap = true;
           property.known = true;
         } else {
@@ -745,8 +748,8 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
           xpm2.setColor(0, qRgba(255, 255, 255, 0));
           decodeBitmap(in, xpm1, 32, rows, 1);
           memcpy(xpm2.bits(), xpm1.bits(), (32 * rows));
-          property.imgDay = xpm1;
-          property.imgNight = xpm2;
+          pixmapDay = xpm1;
+          pixmapNight = xpm2;
           property.hasPixmap = true;
           property.known = true;
         } else {
@@ -779,8 +782,6 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
         continue;
     }
 
-    property.imgDay = property.imgDay.convertToFormat(QImage::Format_ARGB32_Premultiplied);
-    property.imgNight = property.imgNight.convertToFormat(QImage::Format_ARGB32_Premultiplied);
     if (hasLocalization) {
       qint16 len;
       quint8 n = 1;
@@ -838,9 +839,11 @@ bool CGarminTyp::parsePolyline(QDataStream& in, QMap<quint32, polyline_property>
 #endif
     }
 
-    if (property.hasPixmap) {
-      property.imgDay = property.imgDay.mirrored(false, true);
-      property.imgNight = property.imgNight.mirrored(false, true);
+    // Skip an element that left the pixmaps empty: a previous element of the same type may
+    // already have filled the property, and flipping/converting that again would corrupt it.
+    if (property.hasPixmap && !pixmapDay.isNull()) {
+      property.imgDay = toOwnedBLImage(pixmapDay.mirrored(false, true));
+      property.imgNight = toOwnedBLImage(pixmapNight.mirrored(false, true));
     }
   }
   return true;
@@ -1069,7 +1072,8 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
       continue;
     } else {
       decodeBitmap(in, imgDay, w, h, bpp);
-      property.imgDay = imgDay;
+      // Snapshot now: the night variant below re-colours this very bitmap.
+      property.imgDay = toOwnedBLImage(imgDay);
     }
 
     if (t8_1 == 0x03) {
@@ -1081,7 +1085,7 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
         continue;
       }
       decodeBitmap(in, imgNight, w, h, bpp);
-      points[typ].imgNight = imgNight;
+      property.imgNight = toOwnedBLImage(imgNight);
     } else if (t8_1 == 0x02) {
       in >> ncolors >> ctyp;
       if (!decodeBppAndBytes(ncolors, w, ctyp, bpp, wbytes)) {
@@ -1090,9 +1094,11 @@ bool CGarminTyp::parsePoint(QDataStream& in, QMap<quint32, point_property>& poin
       if (!decodeColorTable(in, imgDay, ncolors, 1 << bpp, ctyp == 0x20)) {
         continue;
       }
-      property.imgNight = imgDay;
+      // imgDay now carries the night colour table, so this needs its own conversion.
+      property.imgNight = toOwnedBLImage(imgDay);
     } else {
-      property.imgNight = imgDay;
+      // Identical to the day icon: share the pixels instead of converting twice.
+      property.imgNight = property.imgDay;
     }
 
     if (hasLocalization) {

--- a/src/qmapshack/map/garmin/CGarminTyp.h
+++ b/src/qmapshack/map/garmin/CGarminTyp.h
@@ -19,6 +19,8 @@
 #ifndef CGARMINTYP_H
 #define CGARMINTYP_H
 
+#include <blend2d/blend2d.h>
+
 #include <QtGui>
 
 class QTextCodec;
@@ -84,8 +86,8 @@ class CGarminTyp {
     QPen penBorderNight;
 
     bool hasPixmap;
-    QImage imgDay;
-    QImage imgNight;
+    BLImage imgDay;
+    BLImage imgNight;
 
     QMap<int, QString> strings;
     label_type_e labelType;
@@ -142,8 +144,8 @@ class CGarminTyp {
 
   struct point_property {
     point_property() : labelType(eStandard) {}
-    QImage imgDay;
-    QImage imgNight;
+    BLImage imgDay;
+    BLImage imgNight;
 
     QMap<int, QString> strings;
     label_type_e labelType;

--- a/src/qmapshack/map/garmin/IGarminStrTbl.cpp
+++ b/src/qmapshack/map/garmin/IGarminStrTbl.cpp
@@ -59,6 +59,16 @@ IGarminStrTbl::IGarminStrTbl(const quint16 codepage, const quint8 mask, QObject*
 
 IGarminStrTbl::~IGarminStrTbl() {}
 
+void IGarminStrTbl::get(CFileExt& file, quint32 offset, type_e t, QStringList& info) {
+  const quint64 key = (static_cast<quint64>(t) << 32) | offset;
+  if (const QStringList* cached = labelCache.object(key)) {
+    info = *cached;
+    return;
+  }
+  decode(file, offset, t, info);
+  labelCache.insert(key, new QStringList(info));
+}
+
 void IGarminStrTbl::readFile(CFileExt& file, quint32 offset, quint32 size, QByteArray& data) {
   if (offset + size > file.size()) {
     //         throw exce_t(eErrOpen, tr("Failed to read: ") + file.filename());

--- a/src/qmapshack/map/garmin/IGarminStrTbl.h
+++ b/src/qmapshack/map/garmin/IGarminStrTbl.h
@@ -19,7 +19,9 @@
 #ifndef IGARMINSTRTBL_H
 #define IGARMINSTRTBL_H
 
+#include <QCache>
 #include <QObject>
+#include <QStringList>
 
 class CFileExt;
 class QByteArray;
@@ -47,9 +49,19 @@ class IGarminStrTbl : public QObject {
     addrshift2 = shift;
   }
 
-  virtual void get(CFileExt& file, quint32 offset, type_e t, QStringList& info) = 0;
+  /**
+     @brief Look up the decoded label(s) for @p offset in section @p t.
+
+     Results are served from a bounded LRU cache; since the underlying file is
+     immutable a cache hit is always valid. On a miss the work is delegated to
+     decode() and the result is cached.
+   */
+  void get(CFileExt& file, quint32 offset, type_e t, QStringList& info);
 
  protected:
+  /// Decode the label(s) at @p offset straight from the file (the cache-miss path).
+  virtual void decode(CFileExt& file, quint32 offset, type_e t, QStringList& info) = 0;
+
   void readFile(CFileExt& file, quint32 offset, quint32 size, QByteArray& data);
   quint32 calcOffset(CFileExt& file, const quint32 offset, type_e t);
 
@@ -73,5 +85,12 @@ class IGarminStrTbl : public QObject {
   quint64 mask64;
 
   char buffer[1025];
+
+ private:
+  /// Bounded LRU cache of decoded labels, keyed by (type << 32) | offset. File
+  /// content is immutable, so a hit is always valid; QCache evicts the least
+  /// recently used entries, bounding memory while panning very large maps.
+  static constexpr qsizetype labelCacheMaxEntries = 32768;
+  QCache<quint64, QStringList> labelCache{labelCacheMaxEntries};
 };
 #endif  // IGARMINSTRTBL_H


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1130

### What you have done:
[comment]: # (Describe roughly.)

Added Tracy as a profiler and instrumented the IMG rendering to look for where to focus my performance optimization efforts. That showed that Qt's rasterizer is the bottleneck that will dwarf any gains that could be made in the code. With the biggest bottlenecks being `drawPolylines` by and followed by `drawPolygons`.
So I decided to let Claude replace Qt's very slow rasterizer with Blend2D which is probably the fastest software rasterizer/vector graphics library in existence.

The new code seems to result in the same output but runs ~3 times faster!

##### Performance comparison

To make a comparison I recorded traces of me panning and zooming around the same area before and after the commit that switched to Blend2D and then used Tracy's compare feature.

`drawPolylines` saw a massive 5x improvement, dropping from 569ms mean to 117ms:

<img width="743" height="436" alt="image" src="https://github.com/user-attachments/assets/197fe106-e872-4949-b818-dceb0415c55d" />

`drawPolygons` saw a also impressive 2.5x improvement, from 170ms to 67ms:

<img width="740" height="437" alt="image" src="https://github.com/user-attachments/assets/22b57a4f-6f89-4adc-9477-72615247d285" />

Looking at `draw` is deceiving as the results of that are diluted by early exists from redraw requests.

#### Render output

I took comparison screenshots before of the same view before and after, map used is a Freizeitkarte IMG.

Before:

<img width="2441" height="1533" alt="qms-1130-kufstein-qt" src="https://github.com/user-attachments/assets/586f22dc-cccc-4b0c-b51a-44fdfbcdade7" />

After:

<img width="2441" height="1533" alt="qms-1130-kufstein-blend2d" src="https://github.com/user-attachments/assets/5dc078cf-80af-4873-915b-cfbad6a043dc" />

As you can see there is virtually no visible difference! The only thing I can notice on this view is the POIs shifting a little but they seem to shift by a similar amount with the previous renderer as well when panning minimally so I'm not sure if that is even a regression.

#### Next steps

Since this is a rather large change and I haven't checked if Claude did stupid things I made this just a draft for now. I do encourage people to try it out though!

I think now that the biggest bottleneck is gone I could also squeeze out probably at least another ~20% from optimizing the rest of the code.

Btw the massive amount of `ISO C++ prohibits anonymous structs` warnings comes from the fact that our CMakeLists.txt unfortunately sets global compile options with `add_compile_options` that then affects subprojects as well. The better thing would be to set them only for our own targets with `target_compile_options`. But we can fix that if we get close to merging this, for now I didn't want to bother with that.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Open a IMG.

#### Tracy

If anyone wants to play with Tracy:

1. Reconfigure QMS with `-DTRACY_ENABLE=1 -DTRACY_ON_DEMAND=1`
2. Build Tracy, in the QMS build dir do:
```
cd _deps/tracy-src
cmake -B profiler/build -S profiler -DCMAKE_BUILD_TYPE=Release
cmake --build profiler/build --config Release -j$(nproc)
```
3. Start Tracy from the same dir with `./profiler/build/tracy-profiler` and connect to the running QMS instance.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ ] yes, I didn't forget to change changelog.txt

No as only a draft for now.