### PR TITLE
[QMS-1132] Add action to move a map to the top in map list (macOS)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V1.XX.X
 [QMS-1115] Improve performance for high resolution DEMs
 [QMS-1117] Suggest track name when converting routes
 [QMS-1125] Use GDAL's warp and scale API to draw *.vrt maps
+[QMS-1132] Add action to move a map to the top in map list (macOS)
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/dem/CDemList.cpp
+++ b/src/qmapshack/dem/CDemList.cpp
@@ -45,13 +45,17 @@ void CDemTreeWidget::slotUpdateItem(const QString& key) {
 
 void CDemTreeWidget::keyPressEvent(QKeyEvent* e) {
   const QKeyCombination keyCombination = e->keyCombination();
-  if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Home)) {
+  if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_Home) ||
+      keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_Home)) {
     emit sigMoveHome();
-  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Up)) {
+  } else if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_Up) ||
+             keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_Up)) {
     emit sigMoveUp();
-  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Down)) {
+  } else if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_Down) ||
+             keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_Down)) {
     emit sigMoveDown();
-  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_End)) {
+  } else if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_End) ||
+             keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_End)) {
     emit sigMoveEnd();
   } else {
     QTreeWidget::keyPressEvent(e);

--- a/src/qmapshack/map/CMapList.cpp
+++ b/src/qmapshack/map/CMapList.cpp
@@ -46,13 +46,17 @@ void CMapTreeWidget::slotUpdateItem(const QString& key) {
 
 void CMapTreeWidget::keyPressEvent(QKeyEvent* e) {
   const QKeyCombination keyCombination = e->keyCombination();
-  if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Home)) {
+  if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_Home) ||
+      keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_Home)) {
     emit sigMoveHome();
-  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Up)) {
+  } else if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_Up) ||
+             keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_Up)) {
     emit sigMoveUp();
-  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_Down)) {
+  } else if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_Down) ||
+             keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_Down)) {
     emit sigMoveDown();
-  } else if (keyCombination == QKeyCombination(Qt::SHIFT, Qt::Key_End)) {
+  } else if (keyCombination == QKeyCombination(Qt::ShiftModifier, Qt::Key_End) ||
+             keyCombination == QKeyCombination(Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_End)) {
     emit sigMoveEnd();
   } else {
     QTreeWidget::keyPressEvent(e);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1132

### What you have done:
[comment]: # (Describe roughly.)

In addition to check for key combinations Shift+Home, Shift+End, Shift+Up and Shift+Down,
now also check for key combinations Shift+Keypad_Home, Shift+Keypad_End, Shift+Keypad_Up and Shift+Keypad_Down.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Select item in map or DEM list
2. Hit key combination Shift+Home, Shift+End, Shift+Up, Shift+Down
or Shift+Keypad_Home, Shift+Keypad_End, Shift+Keypad_Up, Shift+Keypad_Down
3. Position of selected item always changes as expected

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
