### PR TITLE
[QMS-1140] Fix: Broken TMS map zooming

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-1125] Use GDAL's warp and scale API to draw *.vrt maps
 [QMS-1128] Enhance VRT handling for maps and DEM
 [QMS-1132] Add action to move a map to the top in map list (macOS)
+[QMS-1140] Fix: Broken TMS map zooming
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/map/CMapTMS.cpp
+++ b/src/qmapshack/map/CMapTMS.cpp
@@ -343,8 +343,11 @@ void CMapTMS::draw(IDrawContext::buffer_t& buf) /* override */
     qreal diff = pt2.x() - pt1.x();
     qreal width = diff >= 0 ? diff : diff + 2 * C;
     qint32 z = std::round(std::log2(2 * C / (width / buf.image.width() * layer.tileSizePx)));
-    z = qMax(z, layer.minZoomLevel);
-    if (z > layer.maxZoomLevel) {
+    // min/maxZoomLevel are inverted (1 = slippy z 20); convert to slippy levels
+    const qint32 zMax = 21 - layer.minZoomLevel;
+    const qint32 zMin = 21 - layer.maxZoomLevel;
+    z = qMin(z, zMax);
+    if (z < zMin) {
       continue;
     }
     int n = (1 << z);


### PR DESCRIPTION
Convert the map definition's inverted min/maxZoomLevel to real slippy zoom levels before gating tile requests, so high zoom levels are no longer dropped.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1140

### What you have done:
[comment]: # (Describe roughly.)

Commit 184fd291 [QMS-902] Fix: HiDPI support for TMS rewrote CMapTMS::draw(). The old code selected the zoom level in QMS' inverted convention (internal 1 = slippy 20 = maximum detail), gated on min/maxZoomLevel in that same convention, and only then converted to a real slippy level via z = 21 - z.

The rewrite computes z directly as the true slippy zoom level — but still compared it against the unconverted min/maxZoomLevel from the TMS file:

```
z = qMax(z, layer.minZoomLevel);      // min=1  → no-op
if (z > layer.maxZoomLevel) continue; // max=17 → skips slippy 18,19,20
```

For the reporter's file (Min=1, Max=17), any view above slippy zoom 17 was dropped — matching the symptom exactly ("nearest zoom level requested is 17", raising MaxZoomLevel to 20 restored high-zoom tiles).

The fix

Map the inverted levels back to slippy levels before gating, mirroring the old 21 - level conversion:
```
// min/maxZoomLevel use QMS' inverted convention (1 = most detail = slippy z 20); map to slippy levels
const qint32 zMax = 21 - layer.minZoomLevel;
const qint32 zMin = 21 - layer.maxZoomLevel;
z = qMin(z, zMax);
if (z < zMin) {
  continue;
}
```

Now Min=1/Max=17 allows slippy [4, 20]: clamps to level 20 when zoomed in further, skips when zoomed out past level 4 — the pre-regression behavior. min/maxZoomLevel are only consumed here, so no other call sites are affected.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
