### PR TITLE
[QMS-1141] Fix: Unchecking database item does not remove it from map

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V1.XX.X
 [QMS-1128] Enhance VRT handling for maps and DEM
 [QMS-1132] Add action to move a map to the top in map list (macOS)
 [QMS-1140] Fix: Broken TMS map zooming
+[QMS-1141] Fix: Unchecking database item does not remove it from map
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/canvas/IDrawContext.cpp
+++ b/src/qmapshack/canvas/IDrawContext.cpp
@@ -54,9 +54,23 @@ IDrawContext::IDrawContext(const QString& name, CCanvas::redraw_e maskRedraw, CC
   resize(canvas->size());
   connect(this, &IDrawContext::finished, canvas, static_cast<void (CCanvas::*)()>(&CCanvas::update));
   connect(this, &IDrawContext::finished, this, &IDrawContext::sigStopThread);
+  connect(this, &IDrawContext::finished, this, &IDrawContext::slotRestartIfNeeded);
 }
 
 IDrawContext::~IDrawContext() {}
+
+void IDrawContext::slotRestartIfNeeded() {
+  mutex.lock();
+  const bool needed = intNeedsRedraw;
+  mutex.unlock();
+
+  // draw() skips start() while the thread is still running, so a redraw requested
+  // right as run() exited would be lost. Pick it up once the thread has stopped.
+  if (needed && !isRunning()) {
+    emit sigStartThread();
+    start();
+  }
+}
 
 void IDrawContext::emitSigCanvasUpdate() { emit sigCanvasUpdate(maskRedraw); }
 

--- a/src/qmapshack/canvas/IDrawContext.h
+++ b/src/qmapshack/canvas/IDrawContext.h
@@ -152,6 +152,10 @@ class IDrawContext : public QThread {
  public slots:
   void emitSigCanvasUpdate();
 
+ private slots:
+  /// Restart the draw thread if a redraw was requested while it was exiting.
+  void slotRestartIfNeeded();
+
  protected:
   void run() override;
   /**

--- a/src/qmapshack/gis/prj/IGisProject.cpp
+++ b/src/qmapshack/gis/prj/IGisProject.cpp
@@ -23,6 +23,7 @@
 #include <QtWidgets>
 
 #include "CMainWindow.h"
+#include "canvas/CCanvas.h"
 #include "device/CDeviceGarminMtp.h"
 #include "device/CDeviceGenericMtp.h"
 #include "device/IDevice.h"
@@ -116,8 +117,12 @@ void IGisProject::destroyLater() {
   QMetaObject::invokeMethod(
       &CGisWorkspace::self(),
       [this]() {
-        QMutexLocker lock(&IGisItem::mutexItems);
-        delete this;
+        {
+          QMutexLocker lock(&IGisItem::mutexItems);
+          delete this;
+        }
+        // The project's items are gone only now. Redraw so they leave the map.
+        CCanvas::triggerCompleteUpdate(CCanvas::eRedrawGis);
       },
       Qt::QueuedConnection);
 }


### PR DESCRIPTION
A redraw requested while the draw thread was exiting could be lost: draw() sees the thread still running and skips the restart, but run() had already passed its redraw check. Restart the thread on finished() if a redraw is still pending so the canvas reflects the change.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1141

### What you have done:
[comment]: # (Describe roughly.)

The setup: The map's GIS layer is drawn by a background worker thread. A bool intNeedsRedraw flag means "someone asked for a fresh redraw." The thread's loop keeps drawing while (intNeedsRedraw), then exits when it's false. The GUI side, when it wants a redraw, sets the flag true and starts the thread — but only if the thread isn't already running.

Root cause — a timing gap:

1. The worker checks intNeedsRedraw, sees false, and begins shutting down — but for a brief moment it's still technically "running."
2. Right then you uncheck a DB item → GUI sets intNeedsRedraw = true, but sees the thread is still running, so it skips starting it (assuming the running thread will pick it up).
3. The thread finishes anyway — it had already passed its check. Nobody picks up the request.

Result: the flag says "redraw needed," but no thread is running and none gets started. The map keeps showing the removed tracks until the next redraw (e.g. a pan). Because it's a tiny timing window, it shows up on the reporter's machine but not yours.

The fix: When the thread finishes, check the flag one more time. If a redraw is still pending, start the thread again — now safely, because the thread has truly stopped. That plugs the gap, and the !isRunning() guard keeps it from colliding with the normal restart path.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
