### PR TITLE
[QMS-1142] Fix: Zoom fails to show complete track

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,17 @@ Do not run `cmake --build` or any build command — Oliver builds externally.
 
 Do not add `Co-Authored-By` lines to commit messages.
 
+### IDrawContext — logical vs device pixels (HiDPI)
+
+`convertRad2Px()`/`convertPx2Rad()` work in **logical** viewport pixels (built from `center` and
+`scale*zoomFactor`) so they match Qt mouse/widget coordinates. The draw **buffers** are **device**
+pixels: `bufWidth/bufHeight = viewWidth/viewHeight * pixelRatio + 2*BUFFER_BORDER`, and `draw()`
+divides the scale by `pixelRatio`. Never compare a `convertRad2Px()` result against `bufWidth`/
+`bufHeight` — they only agree at `pixelRatio == 1`. Use `viewWidth`/`viewHeight` for viewport-fit
+tests (this caused QMS-1142: zoom-to-track clipped on HiDPI). Test HiDPI paths on a normal screen
+with `QT_SCALE_FACTOR=2 build/bin/qmapshack` (add `QT_SCALE_FACTOR_ROUNDING_POLICY=PassThrough`
+for fractional factors like 1.5).
+
 ### CMapItemDelegate — forward declaration pitfall
 
 `animations_t` is defined after `getAnimations()` in the private section. The forward

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V1.XX.X
 [QMS-1132] Add action to move a map to the top in map list (macOS)
 [QMS-1140] Fix: Broken TMS map zooming
 [QMS-1141] Fix: Unchecking database item does not remove it from map
+[QMS-1142] Fix: Zoom fails to show complete track
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/canvas/IDrawContext.cpp
+++ b/src/qmapshack/canvas/IDrawContext.cpp
@@ -184,8 +184,10 @@ void IDrawContext::zoom(const QRectF& rect) {
     convertRad2Px(pt1);
     convertRad2Px(pt2);
 
+    // convertRad2Px() yields logical pixels, so compare against the logical
+    // viewport size, not the device-pixel buffer (bufWidth/bufHeight scale with pixelRatio)
     QPointF pt = pt2 - pt1;
-    if (qAbs(pt.x()) < (bufWidth - 2 * BUFFER_BORDER) && (qAbs(pt.y()) < (bufHeight - 2 * BUFFER_BORDER))) {
+    if (qAbs(pt.x()) < viewWidth && qAbs(pt.y()) < viewHeight) {
       break;
     }
   }


### PR DESCRIPTION
The zoom-to-fit test compared the track's logical-pixel extent against the device-pixel buffer size, so on displays with a pixel ratio > 1 it stopped zooming out too early and clipped the track. Compare against the logical viewport size instead.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1142

### What you have done:
[comment]: # (Describe roughly.)

Double-clicking a track picks the zoom level by checking, level by level, whether the track fits in the window. That check accidentally compared the track's size (in screen points) against the window size measured in physical pixels. On displays with scaling above 100% (e.g. Windows at 150%), the window looked bigger than it really is, so the app zoomed in one step too far and cut off part of the track. The check now uses the window's size in the same unit as the track, so the whole track fits at any display scaling.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket. 

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
