### PR TITLE
[QMS-1123] Build error on platform Linux Ubuntu 24.04.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,8 +202,20 @@ qt_standard_project_setup(
     I18N_TRANSLATED_LANGUAGES ca cs de es fr it nl ru
 )
 
-if(${PROJ_VERSION} VERSION_LESS 8.0.0)
-    message( SEND_ERROR "You need at least PROJ 8.0.0 or newer.")
+# Minimum dependency versions (see issue #1123). The floor is the newest release
+# available on Nov 6, 2024 (GDAL 3.10.0's date): GDAL 3.10 is a hard requirement -
+# CDemVRT uses OGRSpatialReference::exportToWkt() (GDAL 3.9) and
+# GDALRasterBand::ReadRaster() (GDAL 3.10). PROJ 9.4 predates that date and is
+# required for consistency. Qt stays at 6.8 (6.9/6.10 are newer than the cutoff, so
+# not required). Routino has no configure-time release version - only its API
+# version in routino.h - so its 3.4 floor is left to the existing runtime API check
+# (CRouterRoutino.cpp).
+if(${GDAL_VERSION} VERSION_LESS 3.10.0)
+    message( SEND_ERROR "You need at least GDAL 3.10.0 or newer.")
+endif()
+
+if(${PROJ_VERSION} VERSION_LESS 9.4.0)
+    message( SEND_ERROR "You need at least PROJ 9.4.0 or newer.")
 endif()
 
 if(USE_QT6DBus)

--- a/MacOSX/config.sh
+++ b/MacOSX/config.sh
@@ -169,7 +169,7 @@ else
     export ROUTINO_RELEASE="3.4.3"
     export ROUTINO_DEV_PATH=$LOCAL_ENV
     if [ "$BUILD_GDAL" = "x" ]; then
-        export GDAL_RELEASE="3.12"
+        export GDAL_RELEASE="3.13"
         export GDAL=$LOCAL_ENV
     else
         export GDAL=$PACKAGES_PATH

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@
 | Library | Minimum version | Purpose |
 |---|---|---|
 | [Qt6](https://www.qt.io/) | 6.8 | Core, Widgets, Network, SQL, PrintSupport, WebEngineWidgets |
-| [GDAL](https://gdal.org/) | 3.0.0 | Map and raster data I/O |
-| [PROJ](https://proj.org/) | 9.1.0 | Coordinate reference system transformations |
-| [Routino](http://www.routino.org/) | 3.1 | Offline routing |
+| [GDAL](https://gdal.org/) | 3.10.0 | Map and raster data I/O |
+| [PROJ](https://proj.org/) | 9.4.0 | Coordinate reference system transformations |
+| [Routino](http://www.routino.org/) | 3.4 | Offline routing |
 | [QuaZip](https://github.com/stachenov/quazip) | 1.x (Qt6 build) | ZIP archive support |
 | CMake | 3.20 | Build system |
 | C++20 compiler | — | GCC ≥ 10, Clang ≥ 12, MSVC 2019 |

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-1111] Add percentage values to track range
 [QMS-1115] Improve performance for high resolution DEMs
 [QMS-1117] Suggest track name when converting routes
+[QMS-1123] Build error on platform Linux Ubuntu 24.04.4
 [QMS-1125] Use GDAL's warp and scale API to draw *.vrt maps
 [QMS-1128] Enhance VRT handling for maps and DEM
 [QMS-1132] Add action to move a map to the top in map list (macOS)


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1123

### What you have done:
[comment]: # (Describe roughly.)

- Update GDAL, PROJ and Routino minimum requirements in Wiki page [DocGetQMapShack](https://github.com/Maproom/qmapshack/wiki/DocGetQMapShack) for successful building QMS 1.20.3
- Mentioned Ubuntu repo [ubuntugis-unstable](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable) providing GDAL and PROJ versions suitable for successful building QMS 1.20.3 on Ubuntu 24.04.4

In addition:
In file _MacOSX/config.sh_, raised GDAL version required for successful building QMS 1.20.3 on macOS from 3.12 to 3.13 
due to the dependency on the PDF driver _poppler_ version 26.06.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Verify successful building QMS 1.20.3 on Ubuntu 24.04.4 after installing GDAL and PROJ from repo [ubuntugis-unstable](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable)
2. Verify successful building QMS 1.20.3 on macOS

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
