### PR TITLE
Revert "Enable multithreaded GDAL warp/decompression for VRT maps and…

### DIFF
--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -113,11 +113,6 @@ CDemVRT::CDemVRT(const QString& filename, CDemDraw* parent, bool supportsOvervie
     psOptions->pProgressArg = dem;
     psOptions->pfnProgress = &CGdalVrtUtil::progressCallback;
 
-    // warp resampling is CPU-bound and parallelizes across chunks; without this it runs
-    // single-threaded (matches gdalwarp -multi -wo NUM_THREADS=ALL_CPUS). The parallelism
-    // stays inside a single ReadRaster() call, so it doesn't conflict with the read mutex.
-    psOptions->papszWarpOptions = CSLSetNameValue(psOptions->papszWarpOptions, "NUM_THREADS", "ALL_CPUS");
-
     dataset = GDALDataset::FromHandle(GDALAutoCreateWarpedVRT(
         GDALDataset::ToHandle(srcDataset), nullptr, targetSRS.exportToWkt().c_str(), GRA_Bilinear, 0.1, psOptions));
 

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -149,11 +149,6 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibili
     psOptions->pProgressArg = map;
     psOptions->pfnProgress = &CGdalVrtUtil::progressCallback;
 
-    // warp resampling is CPU-bound and parallelizes across chunks; without this it runs
-    // single-threaded (matches gdalwarp -multi -wo NUM_THREADS=ALL_CPUS). The parallelism
-    // stays inside a single ReadRaster() call, so it doesn't conflict with the read mutex.
-    psOptions->papszWarpOptions = CSLSetNameValue(psOptions->papszWarpOptions, "NUM_THREADS", "ALL_CPUS");
-
     if (addDstAlphaBand) {
       GDALWarpInitDefaultBandMapping(psOptions, rasterBandCount);
       psOptions->nDstAlphaBand = psOptions->nBandCount + 1;

--- a/src/qmapshack/setup/IAppSetup.cpp
+++ b/src/qmapshack/setup/IAppSetup.cpp
@@ -18,10 +18,9 @@
 
 #include "setup/IAppSetup.h"
 
-#include <cpl_conv.h>
-#include <gdal.h>
-
 #include <QFont>
+
+#include <gdal.h>
 
 #if defined(Q_OS_MAC)
 #include "setup/CAppSetupMac.h"
@@ -67,10 +66,6 @@ void IAppSetup::prepareGdal(QString gdalDataDir, QString gdalPluginsDir, QString
   }
 
   GDALAllRegister();
-
-  // multithreaded block decompression (GTiff etc.) for direct reads, and the default
-  // thread count for the warp engine (CMapVRT/CDemVRT set NUM_THREADS explicitly too)
-  CPLSetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS");
 }
 
 QString IAppSetup::path(QString path, QString subdir, bool mkdir, QString debugName) {
@@ -129,4 +124,5 @@ void IAppSetup::processArguments() {
     if (fontSize > 0.) appFont.setPointSizeF(fontSize);
   }
   qApp->setFont(appFont);
+
 }


### PR DESCRIPTION
… DEMs"

This reverts commit b45510637605d26a3f365b49dd2f9392bce2041f.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#

### What you have done:
[comment]: # (Describe roughly.)



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open whatever
2. Click here

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [ ] yes

### Is every user facing string in a tr() macro?

- [ ] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ ] yes, I didn't forget to change changelog.txt
