### PR TITLE
[QMS-1139] Fix: Endless loop with non-ASCII characters in VRT path(s)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,3 +447,25 @@ handful of large, compressed/tiled GeoTIFFs instead of its many small source fil
 `IAppSetup::getPlatformInstance()->findExecutable("toolname")` — never hard-code a bare name.
 `CAppSetupWin` restricts `PATH` to the app directory to prevent DLL conflicts, so a bare name
 silently produces `QProcess::FailedToStart` on Windows if the binary isn't co-located with the app.
+
+### Follow-up (QMS-1156): convert non-UTF-8 VRT files to UTF-8 on load
+
+Since QMS-1153 (UTF-8 process manifest) + QMS-1139 (removed the encoding workarounds), GDAL
+receives filenames as UTF-8 everywhere. A guard rejects `.vrt` files whose bytes aren't valid
+UTF-8, but that dead-ends users with legacy Windows-1252/Latin-1 VRTs. Follow-up ticket QMS-1156:
+offer a confirmed, `.bak`-backed one-click conversion instead of just rejecting.
+
+Verified GDAL facts (tested on 3.12) behind the design:
+- GDAL's CPL XML parser **ignores the VRT `<?xml encoding?>` declaration** — `<SourceFilename>`
+  bytes go to `open()` verbatim. Even a correctly-declared `ISO-8859-1` VRT fails. Only raw bytes
+  matter, so a byte-level UTF-8 check has no false-rejection risk.
+- On-disk source names are UTF-8, so transcoding a Latin-1 VRT reproduces the real names.
+- GDAL doesn't hard-fail a bad path (exit 0, checksum -1, `ERROR 4` on stderr) — a quietly-broken
+  dataset, which is what feeds the missing-file advisory / endless loop.
+
+Design: transcode from candidate encodings (Windows-1252 → ISO-8859-1 → system ANSI), then
+**verify by resolution** (every `<SourceFilename>` must now exist on disk) — never a blind guess;
+first candidate that resolves all sources wins, else fall back to plain rejection. Trigger at load
+time in `CMapVRT`/`CDemVRT` construction (a non-UTF-8 VRT never constructs, so the advisory dialog
+can't be the entry point), reusing the advisory `.bak`/rewrite scaffolding. Non-platform-gated
+(failure reproduced on Linux). Also rewrite the `<?xml encoding?>` declaration to UTF-8 for hygiene.

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V1.XX.X
 [QMS-1128] Enhance VRT handling for maps and DEM
 [QMS-1132] Add action to move a map to the top in map list (macOS)
 [QMS-1135] Add guidance to improve overviews for DEM and map VRT
+[QMS-1139] Reject non-UTF-8 encoded VRT files with a clear error message
 [QMS-1140] Fix: Broken TMS map zooming
 [QMS-1141] Fix: Unchecking database item does not remove it from map
 [QMS-1142] Fix: Zoom fails to show complete track

--- a/src/qmapshack/dem/CDemItem.cpp
+++ b/src/qmapshack/dem/CDemItem.cpp
@@ -177,6 +177,9 @@ void CDemItem::deactivate() {
   QSettings cfg(file.fileName(), QSettings::IniFormat);
   demfile->saveConfig(cfg);
   configToShadowConfig(cfg);
+  // Record the deactivated intent: the DEM's own saveConfig() writes no isActive key,
+  // so without this a reload keeps the stale on-disk isActive=true and re-activates.
+  shadowConfig["isActive"] = false;
 
   // remove demfile setup dialog as child of this item
   showChildren(false);
@@ -207,6 +210,9 @@ bool CDemItem::activate() {
 
   // no demfile loaded? Bad.
   if (demfile.isNull()) {
+    // Present file that failed to load: clear the re-arm flag so it isn't retried
+    // (and re-warned) on every restart. The missing-drive case exits earlier via QFile::exists().
+    shadowConfig["isActive"] = false;
     setStatus(eStatus::Inactive);
     return false;
   }
@@ -215,6 +221,7 @@ bool CDemItem::activate() {
   // else delete all previous loaded DEMs and abort
   if (!demfile->activated()) {
     delete demfile;
+    shadowConfig["isActive"] = false;
     setStatus(eStatus::Inactive);
     return false;
   }

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -37,6 +37,13 @@ CDemVRT::CDemVRT(const QString& filename, CDemDraw* parent, bool supportsOvervie
   qDebug() << "------------------------------";
   qDebug() << "VRT: try to open" << filename;
 
+  if (!CGdalVrtUtil::isFileUtf8(filename)) {
+    QMessageBox::warning(
+        CMainWindow::getBestWidgetForParent(), tr("Error..."),
+        tr("File is not UTF-8 encoded and cannot be loaded. Convert it to UTF-8 first:") % '\n' % filename);
+    return;
+  }
+
   dataset = GDALDataset::FromHandle(GDALOpen(filename.toUtf8(), GA_ReadOnly));
   if (nullptr == dataset) {
     QMessageBox::warning(CMainWindow::getBestWidgetForParent(), tr("Error..."),

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -32,12 +32,6 @@
 #include "helpers/CSettings.h"
 #include "setup/IAppSetup.h"
 
-#ifdef Q_OS_WIN
-#define ROUTINO_PATH_ENCODING toLocal8Bit()
-#else
-#define ROUTINO_PATH_ENCODING toUtf8()
-#endif
-
 QPointer<CProgressDialog> CRouterRoutino::progress;
 
 int ProgressFunc(double complete) {
@@ -76,7 +70,7 @@ CRouterRoutino::CRouterRoutino(QWidget* parent) : IRouter(true, parent) {
 
   int res = 0;
   IAppSetup* setup = IAppSetup::getPlatformInstance();
-  res = Routino_ParseXMLTranslations(setup->routinoPath("translations.xml").ROUTINO_PATH_ENCODING);
+  res = Routino_ParseXMLTranslations(setup->routinoPath("translations.xml").toUtf8());
   if (res) {
     QMessageBox::critical(this, "Routino...", xlateRoutinoError(Routino_errno), QMessageBox::Abort);
     return;
@@ -249,7 +243,7 @@ void CRouterRoutino::buildDatabaseList() {
 
       // qDebug() << "buildDatabase Prefix" << prefix;
 
-      Routino_Database* data = Routino_LoadDatabase(dir.absolutePath().ROUTINO_PATH_ENCODING, prefix.ROUTINO_PATH_ENCODING);
+      Routino_Database* data = Routino_LoadDatabase(dir.absolutePath().toUtf8(), prefix.toUtf8());
       qDebug() << "Loaded Routino DB" << dir.absolutePath().toUtf8().data() << "  " << prefix.toUtf8().data();
 
       if (data == nullptr) {
@@ -316,7 +310,7 @@ int CRouterRoutino::loadProfiles(const QString& profilesPath) {
   int res = 0;
   if (currentProfilesPath != profilesPath) {
     currentProfilesPath = profilesPath;
-    res = Routino_ParseXMLProfiles(profilesPath.ROUTINO_PATH_ENCODING);
+    res = Routino_ParseXMLProfiles(profilesPath.toUtf8());
   }
   return res;
 }
@@ -355,11 +349,11 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key) {
     QString strProfile = comboProfile->currentData(Qt::UserRole).toString();
     QString strLanguage = comboLanguage->currentData(Qt::UserRole).toString();
 
-    Routino_Profile* profile = Routino_GetProfile(strProfile.ROUTINO_PATH_ENCODING);
+    Routino_Profile* profile = Routino_GetProfile(strProfile.toUtf8());
     if (profile == NULL) {
       throw tr("Required profile '%1' is not in the current profiles file.").arg(strProfile);
     }
-    Routino_Translation* translation = Routino_GetTranslation(strLanguage.ROUTINO_PATH_ENCODING);
+    Routino_Translation* translation = Routino_GetTranslation(strLanguage.toUtf8());
 
     int res = Routino_ValidateProfile(data, profile);
     if (res != 0) {
@@ -395,7 +389,8 @@ void CRouterRoutino::calcRoute(const IGisItem::key_t& key) {
     delete progress;
 
     if (nullptr != route) {
-      rte->setResultFromRoutino(route, getOptions() + tr("<br/>Calculation time: %1s").arg(time.elapsed() / 1000.0, 0, 'f', 2));
+      rte->setResultFromRoutino(
+          route, getOptions() + tr("<br/>Calculation time: %1s").arg(time.elapsed() / 1000.0, 0, 'f', 2));
       Routino_DeleteRoute(route);
     } else {
       if (Routino_errno != ROUTINO_ERROR_PROGRESS_ABORTED) {
@@ -430,11 +425,11 @@ int CRouterRoutino::calcRoute(const QPointF& p1, const QPointF& p2, QPolygonF& c
     QString strProfile = comboProfile->currentData(Qt::UserRole).toString();
     QString strLanguage = comboLanguage->currentData(Qt::UserRole).toString();
 
-    Routino_Profile* profile = Routino_GetProfile(strProfile.ROUTINO_PATH_ENCODING);
+    Routino_Profile* profile = Routino_GetProfile(strProfile.toUtf8());
     if (profile == NULL) {
       throw tr("Required profile '%1' is not in the current profiles file.").arg(strProfile);
     }
-    Routino_Translation* translation = Routino_GetTranslation(strLanguage.ROUTINO_PATH_ENCODING);
+    Routino_Translation* translation = Routino_GetTranslation(strLanguage.toUtf8());
 
     int res = Routino_ValidateProfile(data, profile);
     if (res != 0) {

--- a/src/qmapshack/helpers/CGdalVrtUtil.cpp
+++ b/src/qmapshack/helpers/CGdalVrtUtil.cpp
@@ -34,18 +34,11 @@ bool CGdalVrtUtil::allReferencedFilesExist(GDALDataset* dataset, QString& missin
   char** fileList = dataset->GetFileList();
   bool allExist = true;
   for (qint32 n = 0; fileList != nullptr && fileList[n] != nullptr; ++n) {
-#if defined(Q_OS_WIN32)
-    missingFile = QString::fromLocal8Bit(fileList[n]);
-    if (QFileInfo::exists(missingFile)) {
-      continue;
-    }
-#endif  // defined(Q_OS_WIN32)
     missingFile = QString::fromUtf8(fileList[n]);
-    if (QFileInfo::exists(missingFile)) {
-      continue;
+    if (!QFileInfo::exists(missingFile)) {
+      allExist = false;
+      break;
     }
-    allExist = false;
-    break;
   }
   CSLDestroy(fileList);
   return allExist;
@@ -88,12 +81,17 @@ struct probed_source_t {
   QVector<qint32> sizes;
 };
 
+/// @brief Open a path read-only. GDAL filenames are UTF-8.
+GDALDatasetUniquePtr openReadOnly(const QString& path) {
+  return GDALDatasetUniquePtr(GDALDataset::FromHandle(GDALOpen(path.toUtf8().constData(), GA_ReadOnly)));
+}
+
 /// @brief Open path and probe its own overview sizes (native to path's own pixel grid -
 ///        no rescaling into the container's pixel grid is needed; GDAL matches overviews
 ///        to the requested read resolution itself, gdalwarp's "-ovr AUTO"). Also records
 ///        the source's own width (for meetsTarget()).
-probed_source_t probeSource(const char* path) {
-  GDALDatasetUniquePtr sub(GDALDataset::FromHandle(GDALOpen(path, GA_ReadOnly)));
+probed_source_t probeSource(const QString& path) {
+  GDALDatasetUniquePtr sub = openReadOnly(path);
   GDALRasterBand* subBand = sub ? sub->GetRasterBand(1) : nullptr;
   if (subBand == nullptr) {
     return {};
@@ -219,7 +217,7 @@ CGdalVrtUtil::overview_advice_t CGdalVrtUtil::buildOverviewAdvice(GDALDataset* d
         continue;
       }
       sawAnySource = true;
-      const probed_source_t probed = probeSource(file.toUtf8().constData());
+      const probed_source_t probed = probeSource(file);
       if (probed.sizes.isEmpty()) {
         allSourcesHaveOverviews = false;
       }

--- a/src/qmapshack/helpers/CGdalVrtUtil.cpp
+++ b/src/qmapshack/helpers/CGdalVrtUtil.cpp
@@ -22,18 +22,23 @@
 #include <gdal_priv.h>
 
 #include <QDebug>
+#include <QFile>
 #include <QFileInfo>
 #include <QGuiApplication>
 #include <QScreen>
+#include <QStringConverter>
 #include <QStringList>
 #include <algorithm>
 
 #include "canvas/IDrawContext.h"
 
 bool CGdalVrtUtil::allReferencedFilesExist(GDALDataset* dataset, QString& missingFile) {
-  char** fileList = dataset->GetFileList();
   bool allExist = true;
-  for (qint32 n = 0; fileList != nullptr && fileList[n] != nullptr; ++n) {
+  char** fileList = dataset->GetFileList();
+  if (fileList == nullptr) {
+    return allExist;
+  }
+  for (qint32 n = 0; fileList[n] != nullptr; ++n) {
     missingFile = QString::fromUtf8(fileList[n]);
     if (!QFileInfo::exists(missingFile)) {
       allExist = false;
@@ -42,6 +47,18 @@ bool CGdalVrtUtil::allReferencedFilesExist(GDALDataset* dataset, QString& missin
   }
   CSLDestroy(fileList);
   return allExist;
+}
+
+bool CGdalVrtUtil::isFileUtf8(const QString& filename) {
+  QFile file(filename);
+  if (!file.open(QIODevice::ReadOnly)) {
+    return true;  // unreadable: let GDALOpen() surface the failure
+  }
+  QStringDecoder decoder(QStringConverter::Utf8);
+  // Materialize into a QString: the decode is lazy and only sets hasError() once consumed.
+  const QString decoded = decoder(file.readAll());
+  Q_UNUSED(decoded)
+  return !decoder.hasError();
 }
 
 namespace {

--- a/src/qmapshack/helpers/CGdalVrtUtil.h
+++ b/src/qmapshack/helpers/CGdalVrtUtil.h
@@ -60,6 +60,17 @@ class CGdalVrtUtil {
   static bool allReferencedFilesExist(GDALDataset* dataset, QString& missingFile);
 
   /**
+     @brief Check that a VRT file's bytes are valid UTF-8.
+
+     GDAL passes a VRT's <SourceFilename> bytes to the OS verbatim - it ignores the XML
+     encoding declaration - so a non-UTF-8 (e.g. legacy Latin-1) VRT resolves to broken
+     paths. Rejecting it up front gives a clear message instead of a garbled
+     "file does not exist". Returns true if the file cannot be read; the caller's
+     GDALOpen() then reports that failure itself.
+   */
+  static bool isFileUtf8(const QString& filename);
+
+  /**
      @brief One referenced source file's own overview state; see overview_advice_t::perFileInfo.
    */
   struct file_overview_info_t {

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -178,6 +178,9 @@ void CMapItem::deactivate() {
   QSettings cfg(file.fileName(), QSettings::IniFormat);
   mapfile->saveConfig(cfg);
   configToShadowConfig(cfg);
+  // Record the deactivated intent: the map's own saveConfig() writes no isActive key,
+  // so without this a reload keeps the stale on-disk isActive=true and re-activates.
+  shadowConfig["isActive"] = false;
 
   // remove mapfile setup dialog as child of this item
   showChildren(false);
@@ -220,6 +223,9 @@ bool CMapItem::activate() {
 
   // no mapfiles loaded? Bad.
   if (mapfile.isNull()) {
+    // Present file that failed to load: clear the re-arm flag so it isn't retried
+    // (and re-warned) on every restart. The missing-drive case exits earlier via QFile::exists().
+    shadowConfig["isActive"] = false;
     setStatus(IMapItem::eStatus::Inactive);
     return false;
   }
@@ -228,6 +234,7 @@ bool CMapItem::activate() {
   // else delete all previous loaded maps and abort
   if (!mapfile->activated()) {
     delete mapfile;
+    shadowConfig["isActive"] = false;
     setStatus(IMapItem::eStatus::Inactive);
     return false;
   }

--- a/src/qmapshack/map/CMapItemDelegate.cpp
+++ b/src/qmapshack/map/CMapItemDelegate.cpp
@@ -305,12 +305,15 @@ bool CMapItemDelegate::editorEvent(QEvent* event, QAbstractItemModel* model, con
       }
       if (item->getStatus() != IMapItem::eStatus::Missing) {
         const bool activate = item->getStatus() != IMapItem::eStatus::Active;
-        if (activate) {
+        item->activate(activate);
+        // Reconcile the indicator with the real outcome: activation can fail (e.g. a
+        // rejected VRT) and leave the item inactive, so the bar must follow the final
+        // status rather than the optimistic click intent.
+        if (item->getStatus() == IMapItem::eStatus::Active) {
           showIndicator(index);
         } else {
           hideIndicator(index);
         }
-        item->activate(activate);
       }
       return true;
     }

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -41,6 +41,11 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibili
   qDebug() << "------------------------------";
   qDebug() << "VRT: try to open" << filename;
 
+  if (!CGdalVrtUtil::isFileUtf8(filename)) {
+    fail(tr("File is not UTF-8 encoded and cannot be loaded. Convert it to UTF-8 first:") % '\n' % filename);
+    return;
+  }
+
   dataset = GDALDataset::FromHandle(GDALOpen(filename.toUtf8(), GA_ReadOnly));
   if (nullptr == dataset) {
     fail(tr("Failed to load file:") % '\n' % filename);

--- a/src/qmt_map2jnx/argv.cpp
+++ b/src/qmt_map2jnx/argv.cpp
@@ -16,29 +16,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef Q_OS_WIN64
-#include <windows.h>
-#endif
-
 char* get_argv(const int index, char** argv) {
-  char* result = NULL;
-  int len;
-
-#ifdef Q_OS_WIN64
-  int numargs;
-  wchar_t** argw = CommandLineToArgvW(GetCommandLineW(), &numargs);
-
-  // determine the buffer length first (including the trailing null)
-  len = WideCharToMultiByte(CP_UTF8, 0, argw[index], -1, NULL, 0, NULL, NULL);
-  result = (char*)calloc(len, 1);
-  WideCharToMultiByte(CP_UTF8, 0, argw[index], -1, result, len, NULL, NULL);
-
-  GlobalFree(argw);
-#else
-  len = strlen(argv[index]) + 1;
-  result = (char*)calloc(len, 1);
+  // argv arrives as UTF-8 on every platform (the executable runs with a UTF-8 active
+  // code page on Windows), so a plain copy is enough.
+  const int len = strlen(argv[index]) + 1;
+  char* result = (char*)calloc(len, 1);
   strcpy(result, argv[index]);
-#endif
-
   return result;
 }


### PR DESCRIPTION
GetFileList()/GetDescription() return filenames in the platform encoding (ANSI or UTF-8 on Windows). allReferencedFilesExist() decoded both ways, but buildOverviewAdvice() used QString::fromUtf8() unconditionally, so on ANSI Windows a non-ASCII path passed validation and then failed source probing/comparison. Centralize the decode in decodeGdalPath() and use it for the file list and ownPath; open probed sources trying UTF-8 (and local-8-bit as a fallback).

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1139

### What you have done:
[comment]: # (Describe roughly.)

- Added decodeGdalPath() helper and used it consistently for GetFileList()/GetDescription() decoding in CGdalVrtUtil.
- Encoding-robust source open in probeSource().

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

saee ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
