### PR TITLE
[QMS-585] Preserve extra XML namespaces in GPX files

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 V1.XX.X
+[QMS-585] Preserve extra XML namespaces in GPX files
 [QMS-902] Add HiDPI support
 [QMS-963] Add action to move a map to the top in map list
 [QMS-1105] Fix: Context menu shortcuts not shown (macOS)

--- a/src/qmapshack/gis/gpx/CGpxProject.cpp
+++ b/src/qmapshack/gis/gpx/CGpxProject.cpp
@@ -18,6 +18,7 @@
 
 #include "gis/gpx/CGpxProject.h"
 
+#include <QSet>
 #include <QtWidgets>
 
 #include "CMainWindow.h"
@@ -128,6 +129,10 @@ void CGpxProject::loadGpx(QFile& file, const QString& filename, CGpxProject* pro
 
   // Read all attributes and find any registrations for actually known extensions.
   // This is used to properly detect valid .gpx files using uncommon namespaces.
+  QSet<QString> knownNamespaceUris = {gpx_ns, xsi_ns};
+  for (const namespace_decl_t& ns : extensionNamespaces()) {
+    knownNamespaceUris.insert(ns.uri);
+  }
   QDomNamedNodeMap attributes = xmlGpx.attributes();
   for (int i = 0; i < attributes.size(); ++i) {
     const QString xmlns("xmlns");
@@ -140,6 +145,10 @@ void CGpxProject::loadGpx(QFile& file, const QString& filename, CGpxProject* pro
         CKnownExtension::initGarminTPXv1(IUnit::self(), ns);
       } else if (att.value() == gpxdata_ns) {
         CKnownExtension::initClueTrustTPXv1(IUnit::self(), ns);
+      }
+
+      if (!knownNamespaceUris.contains(att.value())) {
+        project->extraNamespaces[ns] = att.value();
       }
     }
   }

--- a/src/qmapshack/gis/gpx/serialization.cpp
+++ b/src/qmapshack/gis/gpx/serialization.cpp
@@ -41,6 +41,19 @@ const QString IGisProject::gs_ns = "http://www.groundspeak.com/cache/1/0";
 const QString IGisProject::tp1_ns = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1";
 const QString IGisProject::gpxdata_ns = "http://www.cluetrust.com/XML/GPXDATA/1/0";
 
+const QList<IGisProject::namespace_decl_t>& IGisProject::extensionNamespaces() {
+  static const QList<namespace_decl_t> namespaces = {
+      {"gpxx", gpxx_ns},
+      {"gpxtpx", gpxtpx_ns},
+      {"wptx1", wptx1_ns},
+      {"rmc", rmc_ns},
+      {"ql", ql_ns},
+      {"tp1", tp1_ns},
+      {"gpxdata", gpxdata_ns},
+  };
+  return namespaces;
+}
+
 static void readXml(const QDomNode& xml, const QString& tag, qint32& value) {
   if (xml.namedItem(tag).isElement()) {
     bool ok = false;
@@ -387,13 +400,13 @@ QDomNode IGisProject::writeMetadata(QDomDocument& doc, bool strictGpx11) {
 
   QString schemaLocation;
   if (!strictGpx11) {
-    gpx.setAttribute("xmlns:gpxx", gpxx_ns);
-    gpx.setAttribute("xmlns:gpxtpx", gpxtpx_ns);
-    gpx.setAttribute("xmlns:wptx1", wptx1_ns);
-    gpx.setAttribute("xmlns:rmc", rmc_ns);
-    gpx.setAttribute("xmlns:ql", ql_ns);
-    gpx.setAttribute("xmlns:tp1", tp1_ns);
-    gpx.setAttribute("xmlns:gpxdata", gpxdata_ns);
+    for (const namespace_decl_t& ns : extensionNamespaces()) {
+      gpx.setAttribute("xmlns:" + ns.prefix, ns.uri);
+    }
+
+    for (auto it = extraNamespaces.cbegin(); it != extraNamespaces.cend(); ++it) {
+      gpx.setAttribute("xmlns:" + it.key(), it.value());
+    }
 
     schemaLocation = QString() + gpx_ns + " http://www.topografix.com/GPX/1/1/gpx.xsd " + gpxx_ns +
                      " http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd " + gpxtpx_ns +

--- a/src/qmapshack/gis/prj/IGisProject.h
+++ b/src/qmapshack/gis/prj/IGisProject.h
@@ -475,6 +475,16 @@ class IGisProject : public IWksItem {
   static const QString xsi_ns;
   static const QString gpxdata_ns;
 
+  struct namespace_decl_t {
+    QString prefix;  ///< without "xmlns:", e.g. "gpxx"
+    QString uri;
+  };
+
+  /**
+     @brief The extension namespaces (prefix + URI) writeMetadata() declares on a non-strict GPX file.
+   */
+  static const QList<namespace_decl_t>& extensionNamespaces();
+
   static QString keyUserFocus;
 
   QPointer<CDetailsPrj> dlgDetails;
@@ -491,6 +501,8 @@ class IGisProject : public IWksItem {
   bool autoSyncToDevPending = false;  ///< flag to show that a sync to device is already pending
 
   metadata_t metadata;
+  /// passthrough xmlns:* declarations (prefix -> URI) found on the loaded GPX root that are not one of the namespaces above
+  QMap<QString, QString> extraNamespaces;
   QString nameSuffix;
 
   sorting_roadbook_e sortingRoadbook = eSortRoadbookNone;


### PR DESCRIPTION


<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#585

### What you have done:
Previously, QMapShack would strip existing namespaces when saving a GPX file, but keep the XML tags using these namespaces, resulting in invalid XML.

This patch makes sure to retain these namespaces.



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open [the GPX file attached to QMS-#585](https://github.com/Maproom/qmapshack/files/10721190/prova.zip) in QMapShack
2. Save the GPX file
3. Compare the file with the old version: make sure all namespaces are retained (they might be in a different order). Look out for `xmlns:osmand="https://osmand.net"`  in the `<gpx>` tag.

Additional test:
1. run xmllint on the test file: `xmllint --noout prova.gpx`
2. Open the file in QMapShack, save it
3. run xmllint again, confirm there are no errors.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
