### PR TITLE
[QMS-1156] Fix shitty encoded VRT files automatically if possible

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ V1.XX.X
 [QMS-1142] Fix: Zoom fails to show complete track
 [QMS-1149] Fix: Build error on platform Windows
 [QMS-1153] Force QMS executables to run using UTF-8 code page on Windows too
+[QMS-1156] Fix shitty encoded VRT files automatically if possible
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/dem/CDemVRT.cpp
+++ b/src/qmapshack/dem/CDemVRT.cpp
@@ -37,11 +37,14 @@ CDemVRT::CDemVRT(const QString& filename, CDemDraw* parent, bool supportsOvervie
   qDebug() << "------------------------------";
   qDebug() << "VRT: try to open" << filename;
 
-  if (!CGdalVrtUtil::isFileUtf8(filename)) {
+  int checkUtf8 = CGdalVrtUtil::isFileUtf8(filename);
+  if (checkUtf8 < 0) {
     QMessageBox::warning(
         CMainWindow::getBestWidgetForParent(), tr("Error..."),
         tr("File is not UTF-8 encoded and cannot be loaded. Convert it to UTF-8 first:") % '\n' % filename);
     return;
+  } else if (checkUtf8 > 0) {
+    // refresh dem list(s) required
   }
 
   dataset = GDALDataset::FromHandle(GDALOpen(filename.toUtf8(), GA_ReadOnly));

--- a/src/qmapshack/helpers/CGdalVrtUtil.cpp
+++ b/src/qmapshack/helpers/CGdalVrtUtil.cpp
@@ -49,16 +49,55 @@ bool CGdalVrtUtil::allReferencedFilesExist(GDALDataset* dataset, QString& missin
   return allExist;
 }
 
-bool CGdalVrtUtil::isFileUtf8(const QString& filename) {
+int CGdalVrtUtil::isFileUtf8(const QString& filename) {
   QFile file(filename);
   if (!file.open(QIODevice::ReadOnly)) {
-    return true;  // unreadable: let GDALOpen() surface the failure
+    return 0;  // unreadable: let GDALOpen() surface the failure
   }
   QStringDecoder decoder(QStringConverter::Utf8);
   // Materialize into a QString: the decode is lazy and only sets hasError() once consumed.
-  const QString decoded = decoder(file.readAll());
+  const QByteArray byteArray = file.readAll();
+  const QString decoded = decoder(byteArray);
   Q_UNUSED(decoded)
-  return !decoder.hasError();
+  file.close();
+  if (!decoder.hasError()) {
+    return 0;
+  }
+  if (!QFileInfo(filename).isWritable()) {
+    // File not writable -> no transcoding possible
+    return -1;
+  }
+
+  QByteArray utf8ByteArray;
+#if defined(Q_OS_WIN32)
+  if (utf8ByteArray.isEmpty()) {
+    // Try Windows system-wide active code page (ACP)
+    const QString& codec("windows-" % QSettings("HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage",
+                                                QSettings::NativeFormat)
+                                          .value("ACP")
+                                          .toString());
+    QStringDecoder decoder(codec);
+    const QString& decoded = decoder(byteArray);
+    if (decoder.isValid() && !decoder.hasError()) {
+      utf8ByteArray = QStringEncoder(QStringEncoder::Utf8)(decoded);
+      qDebug() << "File" << filename << "is" << codec << "encoded";
+    }
+  }
+#endif  // defined(Q_OS_WIN32)
+  if (utf8ByteArray.isEmpty()) {
+    // Try next encoding (to be implemented!)
+  }
+
+  if (!utf8ByteArray.isEmpty() && file.copy(filename % ".bak") && file.open(QIODevice::WriteOnly)) {
+    // Preserve backup file .bak and replace original data by UTF-8 transcoded
+    file.write(utf8ByteArray);
+    file.close();
+    qDebug() << "File" << filename << "has been UTF-8 transcoded";
+    return 1;
+  }
+
+  // Transcoding failed
+  return -1;
 }
 
 namespace {

--- a/src/qmapshack/helpers/CGdalVrtUtil.h
+++ b/src/qmapshack/helpers/CGdalVrtUtil.h
@@ -65,10 +65,14 @@ class CGdalVrtUtil {
      GDAL passes a VRT's <SourceFilename> bytes to the OS verbatim - it ignores the XML
      encoding declaration - so a non-UTF-8 (e.g. legacy Latin-1) VRT resolves to broken
      paths. Rejecting it up front gives a clear message instead of a garbled
-     "file does not exist". Returns true if the file cannot be read; the caller's
+     "file does not exist". Returns 0 if the file cannot be read; the caller's
      GDALOpen() then reports that failure itself.
+
+     @return -1 file is not UTF-8 and cannot be transcoded
+     @return  0 file is UTF-8 or cannot be read
+     @return +1 file is UTF-8 after being transcoded
    */
-  static bool isFileUtf8(const QString& filename);
+  static int isFileUtf8(const QString& filename);
 
   /**
      @brief One referenced source file's own overview state; see overview_advice_t::perFileInfo.

--- a/src/qmapshack/map/CMapVRT.cpp
+++ b/src/qmapshack/map/CMapVRT.cpp
@@ -41,9 +41,12 @@ CMapVRT::CMapVRT(const QString& filename, CMapDraw* parent) : IMap(eFeatVisibili
   qDebug() << "------------------------------";
   qDebug() << "VRT: try to open" << filename;
 
-  if (!CGdalVrtUtil::isFileUtf8(filename)) {
+  int checkUtf8 = CGdalVrtUtil::isFileUtf8(filename);
+  if (checkUtf8 < 0) {
     fail(tr("File is not UTF-8 encoded and cannot be loaded. Convert it to UTF-8 first:") % '\n' % filename);
     return;
+  } else if (checkUtf8 > 0) {
+    // refresh map list(s) required
   }
 
   dataset = GDALDataset::FromHandle(GDALOpen(filename.toUtf8(), GA_ReadOnly));


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1156

### What you have done:
[comment]: # (Describe roughly.)

Transcode ANSI encoded VRT file (i.e. file encoded using Windows active code page) silently to UTF-8 if possible.
Preserve a backup of original file with suffix .bak.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Create an ANSI encoded VRT file containing non UTF-8 characters
VRT file and VRT file's parent folder must be writable! 
2. Try to enable DEM from VRT file
3. See that DEM successfully becomes active without warnings
4. See backup with suffix .bak beside VRT file
5. See debug output of kind
   ```
   [debug] File "D:/Höhendaten/Höhendaten Schweiz.ANSI.vrt" is "windows-1252" encoded
   [debug] File "D:/Höhendaten/Höhendaten Schweiz.ANSI.vrt" has been UTF-8 transcoded
   ```

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
