### PR TITLE
[QMS-1166] Improve custom keyboard shortcuts

### DIFF
--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -510,7 +510,9 @@ CMainWindow::CMainWindow() : id(QRandomGenerator::global()->generate()) {
   toolBarConfig = new CToolBarConfig(this, toolBar, availableActions, defaultActions);
   toolBarConfig->loadSettings();
 
-  shortcutConfig = new CShortcutConfig(this, availableActions);
+  QList<QAction*> shortcutableActions = availableActions;
+  shortcutableActions << widgetGisWorkspace->getWksList().shortcutActions();
+  shortcutConfig = new CShortcutConfig(this, shortcutableActions);
   shortcutConfig->loadSettings();
 
   geoSearchConfig = new CGeoSearchConfig(this);

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -110,10 +110,6 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
   configDB();
 
   // workspace project related actions
-  actionEditPrj =
-      addAction("actionEditPrj", QIcon("://icons/EditDetails.svgt"), tr("Edit.."), this, &CGisListWks::slotEditPrj);
-  actionCopyPrj =
-      addAction("actionCopyPrj", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopyProject);
   actionShowOnMap = addAction("actionShowOnMap", QIcon("://icons/ShowAll.svgt"), tr("Show on Map"), this,
                               &CGisListWks::slotShowOnMap);
   actionHideFrMap = addAction("actionHideFrMap", QIcon("://icons/ShowNone.svgt"), tr("Hide from Map"), this,
@@ -154,18 +150,19 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
   // device project related actions
   actionSyncDevWks = addAction("actionSyncDevWks", QIcon("://icons/Device.svgt"), tr("Update Project on Device"), this,
                                &CGisListWks::slotSyncDevWks);
-  actionDelProj =
-      addAction("actionDelProj", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDeleteProject);
 
   // common to all items actions
   actionEditDetails = addAction("actionEditDetails", QIcon("://icons/EditDetails.svgt"), tr("Edit..."), this,
                                 &CGisListWks::slotEditItem);
+  connect(actionEditDetails, &QAction::triggered, this, &CGisListWks::slotEditPrj);
   actionTagItem =
       addAction("actionTagItem", QIcon("://icons/Tag.svgt"), tr("Set Tags"), this, &CGisListWks::slotTagItem);
   actionCopyItem =
       addAction("actionCopyItem", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopyItem);
+  connect(actionCopyItem, &QAction::triggered, this, &CGisListWks::slotCopyProject);
   actionDelete =
       addAction("actionDelete", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDeleteItem);
+  connect(actionDelete, &QAction::triggered, this, &CGisListWks::slotDeleteProject);
 
   // track related actions
   actionFocusTrk = addAction("actionFocusTrk", QIcon("://icons/TrkProfile.svgt"), tr("Track Information"), this,
@@ -203,9 +200,6 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
                                   &CGisListWks::slotEditRadiusWpt);
   actionDelRadiusWpt = addAction("actionDelRadiusWpt", QIcon("://icons/WptDelProx.svgt"), tr("Delete Radius"), this,
                                  &CGisListWks::slotDelRadiusWpt);
-  actionNogoWpt =
-      addAction("actionNogoWpt", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Area"), this, &CGisListWks::slotNogoItem);
-  actionNogoWpt->setCheckable(true);
   actionCopyCoordWpt = addAction("actionCopyCoordWpt", QIcon("://icons/CopyCoord.svgt"), tr("Copy position"), this,
                                  &CGisListWks::slotCopyCoordWpt);
 
@@ -223,9 +217,6 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
                                &CGisListWks::slotReverseRte);
   actionRte2Trk =
       addAction("actionRte2Trk", QIcon("://icons/Track.svgt"), tr("Convert to Track"), this, &CGisListWks::slotRte2Trk);
-  actionNogoRte =
-      addAction("actionNogoRte", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Line"), this, &CGisListWks::slotNogoItem);
-  actionNogoRte->setCheckable(true);
 
   // area related actions
   actionEditArea = addAction("actionEditArea", QIcon("://icons/AreaMove.svgt"), tr("Edit Area Points"), this,
@@ -457,16 +448,15 @@ QAction* CGisListWks::addSortAction(const QString& objName, QObject* parent, QAc
 }
 
 QList<QAction*> CGisListWks::shortcutActions() const {
-  return {actionEditPrj,       actionCopyPrj,       actionShowOnMap,     actionHideFrMap,    actionSortByTime,
-          actionSortByName,    actionSortByRating,  actionFilterProject, actionAutoSave,     actionUserFocusPrj,
-          actionAutoSyncToDev, actionSave,          actionSaveAs,        actionSaveAsStrict, actionSyncWksDev,
-          actionSyncDB,        actionCloseProj,     actionSyncDevWks,    actionDelProj,      actionEditDetails,
-          actionTagItem,       actionCopyItem,      actionDelete,        actionFocusTrk,     actionRangeTrk,
-          actionEditTrk,       actionReverseTrk,    actionCombineTrk,    actionEleWptTrk,    actionCopyTrkWithWpt,
-          actionToRoute,       actionToArea,        actionNogoTrk,       actionBubbleWpt,    actionMoveWpt,
-          actionProjWpt,       actionEditRadiusWpt, actionDelRadiusWpt,  actionNogoWpt,      actionCopyCoordWpt,
-          actionFocusRte,      actionCalcRte,       actionResetRte,      actionEditRte,      actionReverseRte,
-          actionRte2Trk,       actionNogoRte,       actionEditArea,      actionNogoArea,     actionRteFromWpt,
+  return {actionShowOnMap,     actionHideFrMap,      actionSortByTime,   actionSortByName,    actionSortByRating,
+          actionFilterProject, actionAutoSave,       actionUserFocusPrj, actionAutoSyncToDev, actionSave,
+          actionSaveAs,        actionSaveAsStrict,   actionSyncWksDev,   actionSyncDB,        actionCloseProj,
+          actionSyncDevWks,    actionEditDetails,    actionTagItem,      actionCopyItem,      actionDelete,
+          actionFocusTrk,      actionRangeTrk,       actionEditTrk,      actionReverseTrk,    actionCombineTrk,
+          actionEleWptTrk,     actionCopyTrkWithWpt, actionToRoute,      actionToArea,        actionNogoTrk,
+          actionBubbleWpt,     actionMoveWpt,        actionProjWpt,      actionEditRadiusWpt, actionDelRadiusWpt,
+          actionCopyCoordWpt,  actionFocusRte,       actionCalcRte,      actionResetRte,      actionEditRte,
+          actionReverseRte,    actionRte2Trk,        actionEditArea,     actionNogoArea,      actionRteFromWpt,
           actionEditPrxWpt,    actionChangeIconWpt};
 }
 
@@ -989,8 +979,8 @@ void CGisListWks::slotLoadWorkspace() {
 
 void CGisListWks::showMenuProjectWks(const QPoint& p) {
   QMenu menu(this);
-  menu.addAction(actionEditPrj);
-  menu.addAction(actionCopyPrj);
+  menu.addAction(actionEditDetails);
+  menu.addAction(actionCopyItem);
   menu.addAction(actionShowOnMap);
   menu.addAction(actionHideFrMap);
   menu.addSeparator();
@@ -1016,14 +1006,14 @@ void CGisListWks::showMenuProjectWks(const QPoint& p) {
 
 void CGisListWks::showMenuProjectDev(const QPoint& p) {
   QMenu menu(this);
-  menu.addAction(actionEditPrj);
-  menu.addAction(actionCopyPrj);
+  menu.addAction(actionEditDetails);
+  menu.addAction(actionCopyItem);
   menu.addAction(actionShowOnMap);
   menu.addAction(actionHideFrMap);
   menu.addSeparator();
   menu.addAction(actionSyncDevWks);
   menu.addSeparator();
-  menu.addAction(actionDelProj);
+  menu.addAction(actionDelete);
   menu.exec(p);
 }
 
@@ -1075,7 +1065,7 @@ void CGisListWks::showMenuItemWpt(const QPoint& p, CGisItemWpt* wpt) {
   menu.addSeparator();
   menu.addAction(actionEditRadiusWpt);
   menu.addAction(actionDelRadiusWpt);
-  menu.addAction(actionNogoWpt);
+  menu.addAction(actionNogoArea);
   menu.addSeparator();
   menu.addMenu(CGeoSearchWeb::self().getMenu(wpt->getPosition(), &menu));
   menu.addAction(actionCopyCoordWpt);
@@ -1098,7 +1088,7 @@ void CGisListWks::showMenuItemRte(const QPoint& p) {
   menu.addAction(actionEditRte);
   menu.addAction(actionReverseRte);
   menu.addAction(actionRte2Trk);
-  menu.addAction(actionNogoRte);
+  menu.addAction(actionNogoTrk);
   menu.addSeparator();
   menu.addAction(actionDelete);
   menu.exec(p);
@@ -1327,8 +1317,8 @@ void CGisListWks::slotContextMenu(const QPoint& point) {
           actionEditRadiusWpt->setEnabled(isProjectVisible);
           bool radius = wpt->hasRadius();
           actionDelRadiusWpt->setEnabled(isProjectVisible && radius);
-          actionNogoWpt->setEnabled(isProjectVisible && radius);
-          actionNogoWpt->setChecked(radius && wpt->isNogo());
+          actionNogoArea->setEnabled(isProjectVisible && radius);
+          actionNogoArea->setChecked(radius && wpt->isNogo());
           actionMoveWpt->setEnabled(isProjectVisible && !isOnDevice);
           actionProjWpt->setDisabled(isOnDevice);
           showMenuItemWpt(p, wpt);
@@ -1345,8 +1335,8 @@ void CGisListWks::slotContextMenu(const QPoint& point) {
           actionFocusRte->setEnabled(isProjectVisible && rte->isCalculated());
           actionCalcRte->setEnabled(isProjectVisible);
           actionEditRte->setEnabled(isProjectVisible);
-          actionNogoRte->setEnabled(isProjectVisible);
-          actionNogoRte->setChecked(gisItem->isNogo());
+          actionNogoTrk->setEnabled(isProjectVisible);
+          actionNogoTrk->setChecked(gisItem->isNogo());
           actionResetRte->setEnabled(isProjectVisible);
           showMenuItemRte(p);
           break;

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -1977,8 +1977,12 @@ void CGisListWks::slotSyncDevWks() {
 void CGisListWks::slotAddProjectFilter() {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  // Since we only allow one Item to be selected at a time
-  IGisProject* project = dynamic_cast<IGisProject*>(selectedItems()[0]);
+  const QList<QTreeWidgetItem*>& items = selectedItems();
+  if (items.count() != 1) {
+    return;
+  }
+
+  IGisProject* project = dynamic_cast<IGisProject*>(items.first());
   if (project != nullptr) {
     project->filterProject(actionFilterProject->isChecked());
   }

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -233,6 +233,26 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
   actionChangeIconWpt = addAction("actionChangeIconWpt", QIcon("://icons/waypoints/PinBlue.svg"), tr("Change Icon..."),
                                   this, &CGisListWks::slotSymWpt);
 
+  const auto tagCategory = [](const QString& category, std::initializer_list<QAction*> actions) {
+    for (QAction* const action : actions) {
+      action->setProperty("shortcutCategory", category);
+    }
+  };
+  tagCategory(tr("Workspace: Project"),
+              {actionShowOnMap, actionHideFrMap, actionSortByTime, actionSortByName, actionSortByRating,
+               actionFilterProject, actionAutoSave, actionUserFocusPrj, actionAutoSyncToDev, actionSave, actionSaveAs,
+               actionSaveAsStrict, actionSyncWksDev, actionSyncDB, actionCloseProj, actionSyncDevWks});
+  tagCategory(tr("Workspace: Item"), {actionEditDetails, actionTagItem, actionCopyItem, actionDelete});
+  tagCategory(tr("Workspace: Track"),
+              {actionFocusTrk, actionRangeTrk, actionEditTrk, actionReverseTrk, actionCombineTrk, actionEleWptTrk,
+               actionCopyTrkWithWpt, actionToRoute, actionToArea, actionNogoTrk});
+  tagCategory(tr("Workspace: Waypoint"),
+              {actionBubbleWpt, actionMoveWpt, actionProjWpt, actionEditRadiusWpt, actionDelRadiusWpt,
+               actionCopyCoordWpt, actionRteFromWpt, actionEditPrxWpt, actionChangeIconWpt});
+  tagCategory(tr("Workspace: Route"),
+              {actionFocusRte, actionCalcRte, actionResetRte, actionEditRte, actionReverseRte, actionRte2Trk});
+  tagCategory(tr("Workspace: Area"), {actionEditArea, actionNogoArea});
+
   connect(qApp, &QApplication::aboutToQuit, this, &CGisListWks::slotSaveWorkspace);
   connect(this, &CGisListWks::customContextMenuRequested, this, &CGisListWks::slotContextMenu);
   connect(this, &CGisListWks::itemDoubleClicked, this, &CGisListWks::slotItemDoubleClicked);

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -111,144 +111,128 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
 
   // workspace project related actions
   actionShowOnMap = addAction("actionShowOnMap", QIcon("://icons/ShowAll.svgt"), tr("Show on Map"), this,
-                              &CGisListWks::slotShowOnMap);
+                              &CGisListWks::slotShowOnMap, eCategoryProject);
   actionHideFrMap = addAction("actionHideFrMap", QIcon("://icons/ShowNone.svgt"), tr("Hide from Map"), this,
-                              &CGisListWks::slotHideFrMap);
+                              &CGisListWks::slotHideFrMap, eCategoryProject);
   actionGroupSort = new QActionGroup(this);
   actionGroupSort->setExclusive(true);
   actionSortByTime = addSortAction("actionSortByTime", this, actionGroupSort, "://icons/Time.svgt", tr("Sort by Time"),
-                                   IGisProject::eSortFolderTime);
+                                   IGisProject::eSortFolderTime, eCategoryProject);
   actionSortByName = addSortAction("actionSortByName", this, actionGroupSort, "://icons/SortName.svgt",
-                                   tr("Sort by Name"), IGisProject::eSortFolderName);
+                                   tr("Sort by Name"), IGisProject::eSortFolderName, eCategoryProject);
   actionSortByRating = addSortAction("actionSortByRating", this, actionGroupSort, "://icons/Tag.svgt",
-                                     tr("Sort by Rating"), IGisProject::eSortFolderRating);
+                                     tr("Sort by Rating"), IGisProject::eSortFolderRating, eCategoryProject);
   actionFilterProject = addAction("actionFilterProject", QIcon("://icons/Filter.svgt"), tr("Filter Project"), this,
-                                  &CGisListWks::slotAddProjectFilter);
+                                  &CGisListWks::slotAddProjectFilter, eCategoryProject);
   actionFilterProject->setCheckable(true);
   actionAutoSave = addAction("actionAutoSave", QIcon("://icons/AutoSaveNoA.svgt"), tr("Autom. Save"), this,
-                             &CGisListWks::slotAutoSaveProject);
+                             &CGisListWks::slotAutoSaveProject, eCategoryProject);
   actionAutoSave->setCheckable(true);
   actionUserFocusPrj = addAction("actionUserFocusPrj", QIcon("://icons/Focus.svgt"), tr("Active Project"), this,
-                                 &CGisListWks::slotUserFocusPrj);
+                                 &CGisListWks::slotUserFocusPrj, eCategoryProject);
   actionUserFocusPrj->setCheckable(true);
-  actionAutoSyncToDev = addAction("actionAutoSyncToDev", QIcon("://icons/DeviceNoSync.svgt"),
-                                  tr("Autom. Sync. w. Device"), this, &CGisListWks::slotAutoSyncProject);
+  actionAutoSyncToDev =
+      addAction("actionAutoSyncToDev", QIcon("://icons/DeviceNoSync.svgt"), tr("Autom. Sync. w. Device"), this,
+                &CGisListWks::slotAutoSyncProject, eCategoryProject);
   actionAutoSyncToDev->setCheckable(true);
 
-  actionSave = addAction("actionSave", QIcon("://icons/SaveGIS.svgt"), tr("Save"), this, &CGisListWks::slotSaveProject);
+  actionSave = addAction("actionSave", QIcon("://icons/SaveGIS.svgt"), tr("Save"), this, &CGisListWks::slotSaveProject,
+                         eCategoryProject);
   actionSaveAs = addAction("actionSaveAs", QIcon("://icons/SaveGISAs.svgt"), tr("Save as..."), this,
-                           &CGisListWks::slotSaveAsProject);
-  actionSaveAsStrict = addAction("actionSaveAsStrict", QIcon("://icons/SaveGISAsGpx11.svgt"),
-                                 tr("Save as GPX 1.1 w/o ext..."), this, &CGisListWks::slotSaveAsStrictGpx11Project);
+                           &CGisListWks::slotSaveAsProject, eCategoryProject);
+  actionSaveAsStrict =
+      addAction("actionSaveAsStrict", QIcon("://icons/SaveGISAsGpx11.svgt"), tr("Save as GPX 1.1 w/o ext..."), this,
+                &CGisListWks::slotSaveAsStrictGpx11Project, eCategoryProject);
   actionSyncWksDev = addAction("actionSyncWksDev", QIcon("://icons/Device.svgt"), tr("Send to Devices"), this,
-                               &CGisListWks::slotSyncWksDev);
+                               &CGisListWks::slotSyncWksDev, eCategoryProject);
   actionSyncDB = addAction("actionSyncDB", QIcon("://icons/DatabaseSync.svgt"), tr("Sync. with Database"), this,
-                           &CGisListWks::slotSyncDB);
-  actionCloseProj =
-      addAction("actionCloseProj", QIcon("://icons/Close.svgt"), tr("Close"), this, &CGisListWks::slotCloseProject);
+                           &CGisListWks::slotSyncDB, eCategoryProject);
+  actionCloseProj = addAction("actionCloseProj", QIcon("://icons/Close.svgt"), tr("Close"), this,
+                              &CGisListWks::slotCloseProject, eCategoryProject);
 
   // device project related actions
   actionSyncDevWks = addAction("actionSyncDevWks", QIcon("://icons/Device.svgt"), tr("Update Project on Device"), this,
-                               &CGisListWks::slotSyncDevWks);
+                               &CGisListWks::slotSyncDevWks, eCategoryProject);
 
   // common to all items actions
-  actionEditDetails =
-      addAction("actionEditDetails", QIcon("://icons/EditDetails.svgt"), tr("Edit..."), this, &CGisListWks::slotEdit);
-  actionTagItem =
-      addAction("actionTagItem", QIcon("://icons/Tag.svgt"), tr("Set Tags"), this, &CGisListWks::slotTagItem);
-  actionCopyItem =
-      addAction("actionCopyItem", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopy);
-  actionDelete =
-      addAction("actionDelete", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDelete);
+  actionEditDetails = addAction("actionEditDetails", QIcon("://icons/EditDetails.svgt"), tr("Edit..."), this,
+                                &CGisListWks::slotEdit, eCategoryItem);
+  actionTagItem = addAction("actionTagItem", QIcon("://icons/Tag.svgt"), tr("Set Tags"), this,
+                            &CGisListWks::slotTagItem, eCategoryItem);
+  actionCopyItem = addAction("actionCopyItem", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this,
+                             &CGisListWks::slotCopy, eCategoryItem);
+  actionDelete = addAction("actionDelete", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this,
+                           &CGisListWks::slotDelete, eCategoryItem);
 
   // track related actions
   actionFocusTrk = addAction("actionFocusTrk", QIcon("://icons/TrkProfile.svgt"), tr("Track Information"), this,
-                             &CGisListWks::slotFocusTrk);
+                             &CGisListWks::slotFocusTrk, eCategoryTrack);
   actionFocusTrk->setCheckable(true);
   actionRangeTrk = addAction("actionRangeTrk", QIcon("://icons/SelectRange.svgt"), tr("Select Range"), this,
-                             &CGisListWks::slotRangeTrk);
+                             &CGisListWks::slotRangeTrk, eCategoryTrack);
   actionEditTrk = addAction("actionEditTrk", QIcon("://icons/LineMove.svgt"), tr("Edit Track Points"), this,
-                            &CGisListWks::slotEditTrk);
+                            &CGisListWks::slotEditTrk, eCategoryTrack);
   actionReverseTrk = addAction("actionReverseTrk", QIcon("://icons/Reverse.svgt"), tr("Reverse Track"), this,
-                               &CGisListWks::slotReverseTrk);
+                               &CGisListWks::slotReverseTrk, eCategoryTrack);
   actionCombineTrk = addAction("actionCombineTrk", QIcon("://icons/Combine.svgt"), tr("Combine Tracks"), this,
-                               &CGisListWks::slotCombineTrk);
+                               &CGisListWks::slotCombineTrk, eCategoryTrack);
   actionEleWptTrk = addAction("actionEleWptTrk", QIcon("://icons/SetEle.svgt"), tr("Replace Elevation by DEM"), this,
-                              &CGisListWks::slotEleWptTrk);
-  actionCopyTrkWithWpt = addAction("actionCopyTrkWithWpt", QIcon("://icons/CopyTrkWithWpt.svgt"),
-                                   tr("Copy Track with Waypoints"), this, &CGisListWks::slotCopyTrkWithWpt);
-  actionToRoute =
-      addAction("actionToRoute", QIcon("://icons/Route.svgt"), tr("Convert to Route"), this, &CGisListWks::slotToRoute);
-  actionToArea =
-      addAction("actionToArea", QIcon("://icons/Area.svgt"), tr("Convert to Area"), this, &CGisListWks::slotToArea);
-  actionNogoTrk =
-      addAction("actionNogoTrk", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Line"), this, &CGisListWks::slotNogoItem);
+                              &CGisListWks::slotEleWptTrk, eCategoryItem);
+  actionCopyTrkWithWpt =
+      addAction("actionCopyTrkWithWpt", QIcon("://icons/CopyTrkWithWpt.svgt"), tr("Copy Track with Waypoints"), this,
+                &CGisListWks::slotCopyTrkWithWpt, eCategoryTrack);
+  actionToRoute = addAction("actionToRoute", QIcon("://icons/Route.svgt"), tr("Convert to Route"), this,
+                            &CGisListWks::slotToRoute, eCategoryTrack);
+  actionToArea = addAction("actionToArea", QIcon("://icons/Area.svgt"), tr("Convert to Area"), this,
+                           &CGisListWks::slotToArea, eCategoryTrack);
+  actionNogoTrk = addAction("actionNogoTrk", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Line"), this,
+                            &CGisListWks::slotNogoItem, eCategoryItem);
   actionNogoTrk->setCheckable(true);
 
   // waypoint related actions
-  actionBubbleWpt =
-      addAction("actionBubbleWpt", QIcon("://icons/Bubble.svgt"), tr("Show Bubble"), this, &CGisListWks::slotBubbleWpt);
+  actionBubbleWpt = addAction("actionBubbleWpt", QIcon("://icons/Bubble.svgt"), tr("Show Bubble"), this,
+                              &CGisListWks::slotBubbleWpt, eCategoryWaypoint);
   actionBubbleWpt->setCheckable(true);
-  actionMoveWpt =
-      addAction("actionMoveWpt", QIcon("://icons/WptMove.svgt"), tr("Move Waypoint"), this, &CGisListWks::slotMoveWpt);
+  actionMoveWpt = addAction("actionMoveWpt", QIcon("://icons/WptMove.svgt"), tr("Move Waypoint"), this,
+                            &CGisListWks::slotMoveWpt, eCategoryWaypoint);
   actionProjWpt = addAction("actionProjWpt", QIcon("://icons/WptProj.svgt"), tr("Proj. Waypoint..."), this,
-                            &CGisListWks::slotProjWpt);
+                            &CGisListWks::slotProjWpt, eCategoryWaypoint);
   actionEditRadiusWpt = addAction("actionEditRadiusWpt", QIcon("://icons/WptEditProx.svgt"), tr("Change Radius"), this,
-                                  &CGisListWks::slotEditRadiusWpt);
+                                  &CGisListWks::slotEditRadiusWpt, eCategoryWaypoint);
   actionDelRadiusWpt = addAction("actionDelRadiusWpt", QIcon("://icons/WptDelProx.svgt"), tr("Delete Radius"), this,
-                                 &CGisListWks::slotDelRadiusWpt);
+                                 &CGisListWks::slotDelRadiusWpt, eCategoryWaypoint);
   actionCopyCoordWpt = addAction("actionCopyCoordWpt", QIcon("://icons/CopyCoord.svgt"), tr("Copy position"), this,
-                                 &CGisListWks::slotCopyCoordWpt);
+                                 &CGisListWks::slotCopyCoordWpt, eCategoryWaypoint);
 
   // route related actions
   actionFocusRte = addAction("actionFocusRte", QIcon("://icons/RteInstr.svgt"), tr("Route Instructions"), this,
-                             &CGisListWks::slotFocusRte);
+                             &CGisListWks::slotFocusRte, eCategoryRoute);
   actionFocusRte->setCheckable(true);
-  actionCalcRte =
-      addAction("actionCalcRte", QIcon("://icons/Apply.svgt"), tr("Calculate Route"), this, &CGisListWks::slotCalcRte);
-  actionResetRte =
-      addAction("actionResetRte", QIcon("://icons/Reset.svgt"), tr("Reset Route"), this, &CGisListWks::slotResetRte);
-  actionEditRte =
-      addAction("actionEditRte", QIcon("://icons/LineMove.svgt"), tr("Edit Route"), this, &CGisListWks::slotEditRte);
+  actionCalcRte = addAction("actionCalcRte", QIcon("://icons/Apply.svgt"), tr("Calculate Route"), this,
+                            &CGisListWks::slotCalcRte, eCategoryRoute);
+  actionResetRte = addAction("actionResetRte", QIcon("://icons/Reset.svgt"), tr("Reset Route"), this,
+                             &CGisListWks::slotResetRte, eCategoryRoute);
+  actionEditRte = addAction("actionEditRte", QIcon("://icons/LineMove.svgt"), tr("Edit Route"), this,
+                            &CGisListWks::slotEditRte, eCategoryRoute);
   actionReverseRte = addAction("actionReverseRte", QIcon("://icons/Reverse.svgt"), tr("Reverse Route"), this,
-                               &CGisListWks::slotReverseRte);
-  actionRte2Trk =
-      addAction("actionRte2Trk", QIcon("://icons/Track.svgt"), tr("Convert to Track"), this, &CGisListWks::slotRte2Trk);
+                               &CGisListWks::slotReverseRte, eCategoryRoute);
+  actionRte2Trk = addAction("actionRte2Trk", QIcon("://icons/Track.svgt"), tr("Convert to Track"), this,
+                            &CGisListWks::slotRte2Trk, eCategoryRoute);
 
   // area related actions
   actionEditArea = addAction("actionEditArea", QIcon("://icons/AreaMove.svgt"), tr("Edit Area Points"), this,
-                             &CGisListWks::slotEditArea);
+                             &CGisListWks::slotEditArea, eCategoryArea);
   actionNogoArea = addAction("actionNogoArea", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Area"), this,
-                             &CGisListWks::slotNogoItem);
+                             &CGisListWks::slotNogoItem, eCategoryItem);
   actionNogoArea->setCheckable(true);
 
   // several GIS items related actions
   actionRteFromWpt = addAction("actionRteFromWpt", QIcon("://icons/Route.svgt"), tr("Create Route..."), this,
-                               &CGisListWks::slotRteFromWpt);
+                               &CGisListWks::slotRteFromWpt, eCategoryWaypoint);
   actionEditPrxWpt = addAction("actionEditPrxWpt", QIcon("://icons/WptEditProx.svgt"), tr("Change Proximity..."), this,
-                               &CGisListWks::slotEditPrxWpt);
+                               &CGisListWks::slotEditPrxWpt, eCategoryWaypoint);
   actionChangeIconWpt = addAction("actionChangeIconWpt", QIcon("://icons/waypoints/PinBlue.svg"), tr("Change Icon..."),
-                                  this, &CGisListWks::slotSymWpt);
-
-  const auto tagCategory = [](const QString& category, std::initializer_list<QAction*> actions) {
-    for (QAction* const action : actions) {
-      action->setProperty("shortcutCategory", category);
-    }
-  };
-  tagCategory(tr("Workspace: Project"),
-              {actionShowOnMap, actionHideFrMap, actionSortByTime, actionSortByName, actionSortByRating,
-               actionFilterProject, actionAutoSave, actionUserFocusPrj, actionAutoSyncToDev, actionSave, actionSaveAs,
-               actionSaveAsStrict, actionSyncWksDev, actionSyncDB, actionCloseProj, actionSyncDevWks});
-  tagCategory(tr("Workspace: Item"), {actionEditDetails, actionTagItem, actionCopyItem, actionDelete, actionNogoTrk,
-                                      actionNogoArea, actionEleWptTrk});
-  tagCategory(tr("Workspace: Track"), {actionFocusTrk, actionRangeTrk, actionEditTrk, actionReverseTrk,
-                                       actionCombineTrk, actionCopyTrkWithWpt, actionToRoute, actionToArea});
-  tagCategory(tr("Workspace: Waypoint"),
-              {actionBubbleWpt, actionMoveWpt, actionProjWpt, actionEditRadiusWpt, actionDelRadiusWpt,
-               actionCopyCoordWpt, actionRteFromWpt, actionEditPrxWpt, actionChangeIconWpt});
-  tagCategory(tr("Workspace: Route"),
-              {actionFocusRte, actionCalcRte, actionResetRte, actionEditRte, actionReverseRte, actionRte2Trk});
-  tagCategory(tr("Workspace: Area"), {actionEditArea});
+                                  this, &CGisListWks::slotSymWpt, eCategoryWaypoint);
 
   connect(qApp, &QApplication::aboutToQuit, this, &CGisListWks::slotSaveWorkspace);
   connect(this, &CGisListWks::customContextMenuRequested, this, &CGisListWks::slotContextMenu);
@@ -455,7 +439,8 @@ void CGisListWks::setExternalMenu(QMenu* project) {
 }
 
 QAction* CGisListWks::addSortAction(const QString& objName, QObject* parent, QActionGroup* actionGroup,
-                                    const QString& icon, const QString& text, IGisProject::sorting_folder_e mode) {
+                                    const QString& icon, const QString& text, IGisProject::sorting_folder_e mode,
+                                    category_e category) {
   QAction* action = new QAction(QIcon(icon), text, parent);
   action->setObjectName(objName);
   action->setCheckable(true);
@@ -464,8 +449,32 @@ QAction* CGisListWks::addSortAction(const QString& objName, QObject* parent, QAc
   connect(action, &QAction::toggled, this, [this, mode](bool checked) { slotSetSortMode(mode, checked); });
 
   actionGroup->addAction(action);
+  tagCategory(action, category);
 
   return action;
+}
+
+QString CGisListWks::categoryName(category_e category) const {
+  switch (category) {
+    case eCategoryProject:
+      return tr("Workspace: Project");
+    case eCategoryItem:
+      return tr("Workspace: Item");
+    case eCategoryTrack:
+      return tr("Workspace: Track");
+    case eCategoryWaypoint:
+      return tr("Workspace: Waypoint");
+    case eCategoryRoute:
+      return tr("Workspace: Route");
+    case eCategoryArea:
+      return tr("Workspace: Area");
+  }
+  return QString();
+}
+
+void CGisListWks::tagCategory(QAction* action, category_e category) {
+  action->setProperty("shortcutCategory", categoryName(category));
+  categoryActions[category] << action;
 }
 
 QList<QAction*> CGisListWks::shortcutActions() const { return actions(); }
@@ -1180,12 +1189,23 @@ void CGisListWks::enableActionsOnly(const std::initializer_list<QAction*>& enabl
   }
 }
 
-QList<QAction*> CGisListWks::projectActions() const {
-  return {actionShowOnMap,     actionHideFrMap,     actionSortByTime,   actionSortByName,
-          actionSortByRating,  actionFilterProject, actionAutoSave,     actionUserFocusPrj,
-          actionSave,          actionSaveAs,        actionSaveAsStrict, actionSyncWksDev,
-          actionAutoSyncToDev, actionSyncDB,        actionCloseProj,    actionSyncDevWks};
+void CGisListWks::disableActionsOutside(const std::initializer_list<category_e>& categories) {
+  QSet<category_e> keep(categories);
+  keep << eCategoryProject;
+
+  for (auto it = categoryActions.constBegin(); it != categoryActions.constEnd(); ++it) {
+    if (keep.contains(it.key())) {
+      continue;
+    }
+
+    const QList<QAction*>& actionsOfCategory = it.value();
+    for (QAction* action : actionsOfCategory) {
+      action->setEnabled(false);
+    }
+  }
 }
+
+QList<QAction*> CGisListWks::projectActions() const { return categoryActions.value(eCategoryProject); }
 
 QList<IGisProject*> CGisListWks::targetProjects() const {
   QList<IGisProject*> projects;
@@ -1263,7 +1283,7 @@ CGisListWks::menu_e CGisListWks::updateProjectActions(const QList<IGisProject*>&
   actionHideFrMap->setEnabled(!allUnchecked);
 
   if (allOnDevice) {
-    actionSyncDevWks->setEnabled(true);
+    actionSyncDevWks->setEnabled(projects.count() == 1);
     return eMenuProjectDev;
   }
 
@@ -1291,7 +1311,11 @@ CGisListWks::menu_e CGisListWks::updateProjectActions(const QList<IGisProject*>&
   actionSyncWksDev->setEnabled(IDevice::count() && !autoSyncToDev);
   actionCloseProj->setEnabled(!autoSyncToDev);
 
-  actionGroupSort->setEnabled(true);
+  const QList<QAction*>& sortActions = actionGroupSort->actions();
+  for (QAction* action : sortActions) {
+    action->setEnabled(true);
+  }
+
   blockSorting = true;
   switch (firstProject->getSortingFolder()) {
     case IGisProject::eSortFolderName:
@@ -1330,7 +1354,6 @@ CGisListWks::menu_e CGisListWks::updateActionState() {
     action->setVisible(true);
     action->setEnabled(true);
   }
-  actionGroupSort->setEnabled(true);
 
   // a selection mixing projects and items has no common operation
   const selection_e selection = selectionType();
@@ -1342,15 +1365,10 @@ CGisListWks::menu_e CGisListWks::updateActionState() {
   const menu_e projectMenu = updateProjectActions(targetProjects());
 
   if (selection == eSelectionProjects) {
-    const QList<QAction*>& projectOnly = projectActions();
-    for (QAction* action : allActions) {
-      if (!projectOnly.contains(action)) {
-        action->setEnabled(false);
-      }
-    }
+    disableActionsOutside({});
 
     if (projectMenu != eMenuProjectTrash) {
-      actionEditDetails->setEnabled(true);
+      actionEditDetails->setEnabled(singleSelectedItem() != nullptr);
       actionCopyItem->setEnabled(true);
       actionDelete->setEnabled(projectMenu == eMenuProjectDev);
     }
@@ -1360,6 +1378,11 @@ CGisListWks::menu_e CGisListWks::updateActionState() {
 
   const QList<QTreeWidgetItem*>& items = selectedItems();
   if (items.count() > 1) {
+    disableActionsOutside({eCategoryItem});
+    actionEditDetails->setEnabled(false);
+    actionNogoTrk->setEnabled(false);
+    actionNogoArea->setEnabled(false);
+
     const QList<IGisItem::key_t>& keysTrk = selectedItems2Keys<CGisItemTrk>();
     const QList<IGisItem::key_t>& keysWpt = selectedItems2Keys<CGisItemWpt>();
 
@@ -1387,6 +1410,9 @@ CGisListWks::menu_e CGisListWks::updateActionState() {
           break;
         }
 
+        disableActionsOutside({eCategoryItem, eCategoryTrack});
+        actionNogoArea->setEnabled(false);
+
         if (parentProject != nullptr) {
           actionCombineTrk->setEnabled(parentProject->getItemCountByType(IGisItem::eTypeTrk) > 1);
         } else {
@@ -1409,6 +1435,10 @@ CGisListWks::menu_e CGisListWks::updateActionState() {
           break;
         }
 
+        disableActionsOutside({eCategoryItem, eCategoryWaypoint});
+        actionNogoTrk->setEnabled(false);
+        actionRteFromWpt->setEnabled(false);
+
         actionBubbleWpt->setChecked(wpt->hasBubble());
         actionBubbleWpt->setEnabled(isProjectVisible);
         actionEditRadiusWpt->setEnabled(isProjectVisible);
@@ -1427,6 +1457,10 @@ CGisListWks::menu_e CGisListWks::updateActionState() {
           break;
         }
 
+        disableActionsOutside({eCategoryItem, eCategoryRoute});
+        actionNogoArea->setEnabled(false);
+        actionEleWptTrk->setEnabled(false);
+
         actionFocusRte->setChecked(rte->hasUserFocus());
         actionFocusRte->setEnabled(isProjectVisible && rte->isCalculated());
         actionCalcRte->setEnabled(isProjectVisible);
@@ -1438,6 +1472,10 @@ CGisListWks::menu_e CGisListWks::updateActionState() {
       }
 
       case IGisItem::eTypeOvl:
+        disableActionsOutside({eCategoryItem, eCategoryArea});
+        actionNogoTrk->setEnabled(false);
+        actionEleWptTrk->setEnabled(false);
+
         actionEditArea->setEnabled(isProjectVisible && !isOnDevice);
         actionNogoArea->setEnabled(isProjectVisible);
         actionNogoArea->setChecked(gisItem->isNogo());

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -1574,7 +1574,7 @@ void CGisListWks::slotDeleteProject() {
         CCanvasCursorLock cursorLock(Qt::ArrowCursor, __func__);
         int res = QMessageBox::question(CMainWindow::getBestWidgetForParent(), tr("Delete project..."),
                                         tr("Do you really want to delete %1?").arg(project->getFilename()),
-                                        QMessageBox::Ok | QMessageBox::No, QMessageBox::Ok);
+                                        QMessageBox::Ok | QMessageBox::No, QMessageBox::No);
 
         if (res != QMessageBox::Ok) {
           continue;

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -152,17 +152,14 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
                                &CGisListWks::slotSyncDevWks);
 
   // common to all items actions
-  actionEditDetails = addAction("actionEditDetails", QIcon("://icons/EditDetails.svgt"), tr("Edit..."), this,
-                                &CGisListWks::slotEditItem);
-  connect(actionEditDetails, &QAction::triggered, this, &CGisListWks::slotEditPrj);
+  actionEditDetails =
+      addAction("actionEditDetails", QIcon("://icons/EditDetails.svgt"), tr("Edit..."), this, &CGisListWks::slotEdit);
   actionTagItem =
       addAction("actionTagItem", QIcon("://icons/Tag.svgt"), tr("Set Tags"), this, &CGisListWks::slotTagItem);
   actionCopyItem =
-      addAction("actionCopyItem", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopyItem);
-  connect(actionCopyItem, &QAction::triggered, this, &CGisListWks::slotCopyProject);
+      addAction("actionCopyItem", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopy);
   actionDelete =
-      addAction("actionDelete", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDeleteItem);
-  connect(actionDelete, &QAction::triggered, this, &CGisListWks::slotDeleteProject);
+      addAction("actionDelete", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDelete);
 
   // track related actions
   actionFocusTrk = addAction("actionFocusTrk", QIcon("://icons/TrkProfile.svgt"), tr("Track Information"), this,
@@ -1604,6 +1601,14 @@ void CGisListWks::slotEditItem() {
   }
 }
 
+void CGisListWks::slotEdit() {
+  if (dynamic_cast<IGisProject*>(currentItem()) != nullptr) {
+    slotEditPrj();
+  } else {
+    slotEditItem();
+  }
+}
+
 void CGisListWks::slotTagItem() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
   CGisWorkspace::self().tagItemsByKey(selectedItems2Keys<IGisItem>());
@@ -1612,6 +1617,14 @@ void CGisListWks::slotTagItem() {
 void CGisListWks::slotDeleteItem() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
   CGisWorkspace::self().delItemsByKey(selectedItems2Keys<IGisItem>());
+}
+
+void CGisListWks::slotDelete() {
+  if (dynamic_cast<IGisProject*>(currentItem()) != nullptr) {
+    slotDeleteProject();
+  } else {
+    slotDeleteItem();
+  }
 }
 
 void CGisListWks::slotCopyItem() {
@@ -1627,6 +1640,14 @@ void CGisListWks::slotCopyItem() {
    * again. This is always safe.
    */
   CGisWorkspace::self().copyItemsByKey(selectedItems2Keys<IGisItem>());
+}
+
+void CGisListWks::slotCopy() {
+  if (dynamic_cast<IGisProject*>(currentItem()) != nullptr) {
+    slotCopyProject();
+  } else {
+    slotCopyItem();
+  }
 }
 
 void CGisListWks::slotProjWpt() {

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -239,16 +239,16 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
               {actionShowOnMap, actionHideFrMap, actionSortByTime, actionSortByName, actionSortByRating,
                actionFilterProject, actionAutoSave, actionUserFocusPrj, actionAutoSyncToDev, actionSave, actionSaveAs,
                actionSaveAsStrict, actionSyncWksDev, actionSyncDB, actionCloseProj, actionSyncDevWks});
-  tagCategory(tr("Workspace: Item"), {actionEditDetails, actionTagItem, actionCopyItem, actionDelete});
-  tagCategory(tr("Workspace: Track"),
-              {actionFocusTrk, actionRangeTrk, actionEditTrk, actionReverseTrk, actionCombineTrk, actionEleWptTrk,
-               actionCopyTrkWithWpt, actionToRoute, actionToArea, actionNogoTrk});
+  tagCategory(tr("Workspace: Item"), {actionEditDetails, actionTagItem, actionCopyItem, actionDelete, actionNogoTrk,
+                                      actionNogoArea, actionEleWptTrk});
+  tagCategory(tr("Workspace: Track"), {actionFocusTrk, actionRangeTrk, actionEditTrk, actionReverseTrk,
+                                       actionCombineTrk, actionCopyTrkWithWpt, actionToRoute, actionToArea});
   tagCategory(tr("Workspace: Waypoint"),
               {actionBubbleWpt, actionMoveWpt, actionProjWpt, actionEditRadiusWpt, actionDelRadiusWpt,
                actionCopyCoordWpt, actionRteFromWpt, actionEditPrxWpt, actionChangeIconWpt});
   tagCategory(tr("Workspace: Route"),
               {actionFocusRte, actionCalcRte, actionResetRte, actionEditRte, actionReverseRte, actionRte2Trk});
-  tagCategory(tr("Workspace: Area"), {actionEditArea, actionNogoArea});
+  tagCategory(tr("Workspace: Area"), {actionEditArea});
 
   connect(qApp, &QApplication::aboutToQuit, this, &CGisListWks::slotSaveWorkspace);
   connect(this, &CGisListWks::customContextMenuRequested, this, &CGisListWks::slotContextMenu);

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -110,105 +110,137 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
   configDB();
 
   // workspace project related actions
-  actionEditPrj = addAction(QIcon("://icons/EditDetails.svgt"), tr("Edit.."), this, &CGisListWks::slotEditPrj);
-  actionCopyPrj = addAction(QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopyProject);
-  actionShowOnMap = addAction(QIcon("://icons/ShowAll.svgt"), tr("Show on Map"), this, &CGisListWks::slotShowOnMap);
-  actionHideFrMap = addAction(QIcon("://icons/ShowNone.svgt"), tr("Hide from Map"), this, &CGisListWks::slotHideFrMap);
+  actionEditPrj =
+      addAction("actionEditPrj", QIcon("://icons/EditDetails.svgt"), tr("Edit.."), this, &CGisListWks::slotEditPrj);
+  actionCopyPrj =
+      addAction("actionCopyPrj", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopyProject);
+  actionShowOnMap = addAction("actionShowOnMap", QIcon("://icons/ShowAll.svgt"), tr("Show on Map"), this,
+                              &CGisListWks::slotShowOnMap);
+  actionHideFrMap = addAction("actionHideFrMap", QIcon("://icons/ShowNone.svgt"), tr("Hide from Map"), this,
+                              &CGisListWks::slotHideFrMap);
   actionGroupSort = new QActionGroup(this);
   actionGroupSort->setExclusive(true);
-  actionSortByTime =
-      addSortAction(this, actionGroupSort, "://icons/Time.svgt", tr("Sort by Time"), IGisProject::eSortFolderTime);
-  actionSortByName =
-      addSortAction(this, actionGroupSort, "://icons/SortName.svgt", tr("Sort by Name"), IGisProject::eSortFolderName);
-  actionSortByRating =
-      addSortAction(this, actionGroupSort, "://icons/Tag.svgt", tr("Sort by Rating"), IGisProject::eSortFolderRating);
-  actionFilterProject =
-      addAction(QIcon("://icons/Filter.svgt"), tr("Filter Project"), this, &CGisListWks::slotAddProjectFilter);
+  actionSortByTime = addSortAction("actionSortByTime", this, actionGroupSort, "://icons/Time.svgt", tr("Sort by Time"),
+                                   IGisProject::eSortFolderTime);
+  actionSortByName = addSortAction("actionSortByName", this, actionGroupSort, "://icons/SortName.svgt",
+                                   tr("Sort by Name"), IGisProject::eSortFolderName);
+  actionSortByRating = addSortAction("actionSortByRating", this, actionGroupSort, "://icons/Tag.svgt",
+                                     tr("Sort by Rating"), IGisProject::eSortFolderRating);
+  actionFilterProject = addAction("actionFilterProject", QIcon("://icons/Filter.svgt"), tr("Filter Project"), this,
+                                  &CGisListWks::slotAddProjectFilter);
   actionFilterProject->setCheckable(true);
-  actionAutoSave =
-      addAction(QIcon("://icons/AutoSaveNoA.svgt"), tr("Autom. Save"), this, &CGisListWks::slotAutoSaveProject);
+  actionAutoSave = addAction("actionAutoSave", QIcon("://icons/AutoSaveNoA.svgt"), tr("Autom. Save"), this,
+                             &CGisListWks::slotAutoSaveProject);
   actionAutoSave->setCheckable(true);
-  actionUserFocusPrj =
-      addAction(QIcon("://icons/Focus.svgt"), tr("Active Project"), this, &CGisListWks::slotUserFocusPrj);
+  actionUserFocusPrj = addAction("actionUserFocusPrj", QIcon("://icons/Focus.svgt"), tr("Active Project"), this,
+                                 &CGisListWks::slotUserFocusPrj);
   actionUserFocusPrj->setCheckable(true);
-  actionAutoSyncToDev = addAction(QIcon("://icons/DeviceNoSync.svgt"), tr("Autom. Sync. w. Device"), this,
-                                  &CGisListWks::slotAutoSyncProject);
+  actionAutoSyncToDev = addAction("actionAutoSyncToDev", QIcon("://icons/DeviceNoSync.svgt"),
+                                  tr("Autom. Sync. w. Device"), this, &CGisListWks::slotAutoSyncProject);
   actionAutoSyncToDev->setCheckable(true);
 
-  actionSave = addAction(QIcon("://icons/SaveGIS.svgt"), tr("Save"), this, &CGisListWks::slotSaveProject);
-  actionSaveAs = addAction(QIcon("://icons/SaveGISAs.svgt"), tr("Save as..."), this, &CGisListWks::slotSaveAsProject);
-  actionSaveAsStrict = addAction(QIcon("://icons/SaveGISAsGpx11.svgt"), tr("Save as GPX 1.1 w/o ext..."), this,
-                                 &CGisListWks::slotSaveAsStrictGpx11Project);
-  actionSyncWksDev = addAction(QIcon("://icons/Device.svgt"), tr("Send to Devices"), this, &CGisListWks::slotSyncWksDev);
-  actionSyncDB =
-      addAction(QIcon("://icons/DatabaseSync.svgt"), tr("Sync. with Database"), this, &CGisListWks::slotSyncDB);
-  actionCloseProj = addAction(QIcon("://icons/Close.svgt"), tr("Close"), this, &CGisListWks::slotCloseProject);
+  actionSave = addAction("actionSave", QIcon("://icons/SaveGIS.svgt"), tr("Save"), this, &CGisListWks::slotSaveProject);
+  actionSaveAs = addAction("actionSaveAs", QIcon("://icons/SaveGISAs.svgt"), tr("Save as..."), this,
+                           &CGisListWks::slotSaveAsProject);
+  actionSaveAsStrict = addAction("actionSaveAsStrict", QIcon("://icons/SaveGISAsGpx11.svgt"),
+                                 tr("Save as GPX 1.1 w/o ext..."), this, &CGisListWks::slotSaveAsStrictGpx11Project);
+  actionSyncWksDev = addAction("actionSyncWksDev", QIcon("://icons/Device.svgt"), tr("Send to Devices"), this,
+                               &CGisListWks::slotSyncWksDev);
+  actionSyncDB = addAction("actionSyncDB", QIcon("://icons/DatabaseSync.svgt"), tr("Sync. with Database"), this,
+                           &CGisListWks::slotSyncDB);
+  actionCloseProj =
+      addAction("actionCloseProj", QIcon("://icons/Close.svgt"), tr("Close"), this, &CGisListWks::slotCloseProject);
 
   // device project related actions
-  actionSyncDevWks =
-      addAction(QIcon("://icons/Device.svgt"), tr("Update Project on Device"), this, &CGisListWks::slotSyncDevWks);
-  actionDelProj = addAction(QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDeleteProject);
+  actionSyncDevWks = addAction("actionSyncDevWks", QIcon("://icons/Device.svgt"), tr("Update Project on Device"), this,
+                               &CGisListWks::slotSyncDevWks);
+  actionDelProj =
+      addAction("actionDelProj", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDeleteProject);
 
   // common to all items actions
-  actionEditDetails = addAction(QIcon("://icons/EditDetails.svgt"), tr("Edit..."), this, &CGisListWks::slotEditItem);
-  actionTagItem = addAction(QIcon("://icons/Tag.svgt"), tr("Set Tags"), this, &CGisListWks::slotTagItem);
-  actionCopyItem = addAction(QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopyItem);
-  actionDelete = addAction(QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDeleteItem);
+  actionEditDetails = addAction("actionEditDetails", QIcon("://icons/EditDetails.svgt"), tr("Edit..."), this,
+                                &CGisListWks::slotEditItem);
+  actionTagItem =
+      addAction("actionTagItem", QIcon("://icons/Tag.svgt"), tr("Set Tags"), this, &CGisListWks::slotTagItem);
+  actionCopyItem =
+      addAction("actionCopyItem", QIcon("://icons/Copy.svgt"), tr("Copy to..."), this, &CGisListWks::slotCopyItem);
+  actionDelete =
+      addAction("actionDelete", QIcon("://icons/DeleteOne.svgt"), tr("Delete"), this, &CGisListWks::slotDeleteItem);
 
   // track related actions
-  actionFocusTrk =
-      addAction(QIcon("://icons/TrkProfile.svgt"), tr("Track Information"), this, &CGisListWks::slotFocusTrk);
+  actionFocusTrk = addAction("actionFocusTrk", QIcon("://icons/TrkProfile.svgt"), tr("Track Information"), this,
+                             &CGisListWks::slotFocusTrk);
   actionFocusTrk->setCheckable(true);
-  actionRangeTrk = addAction(QIcon("://icons/SelectRange.svgt"), tr("Select Range"), this, &CGisListWks::slotRangeTrk);
-  actionEditTrk = addAction(QIcon("://icons/LineMove.svgt"), tr("Edit Track Points"), this, &CGisListWks::slotEditTrk);
-  actionReverseTrk = addAction(QIcon("://icons/Reverse.svgt"), tr("Reverse Track"), this, &CGisListWks::slotReverseTrk);
-  actionCombineTrk = addAction(QIcon("://icons/Combine.svgt"), tr("Combine Tracks"), this, &CGisListWks::slotCombineTrk);
-  actionEleWptTrk =
-      addAction(QIcon("://icons/SetEle.svgt"), tr("Replace Elevation by DEM"), this, &CGisListWks::slotEleWptTrk);
-  actionCopyTrkWithWpt = addAction(QIcon("://icons/CopyTrkWithWpt.svgt"), tr("Copy Track with Waypoints"), this,
-                                   &CGisListWks::slotCopyTrkWithWpt);
-  actionToRoute = addAction(QIcon("://icons/Route.svgt"), tr("Convert to Route"), this, &CGisListWks::slotToRoute);
-  actionToArea = addAction(QIcon("://icons/Area.svgt"), tr("Convert to Area"), this, &CGisListWks::slotToArea);
-  actionNogoTrk = addAction(QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Line"), this, &CGisListWks::slotNogoItem);
+  actionRangeTrk = addAction("actionRangeTrk", QIcon("://icons/SelectRange.svgt"), tr("Select Range"), this,
+                             &CGisListWks::slotRangeTrk);
+  actionEditTrk = addAction("actionEditTrk", QIcon("://icons/LineMove.svgt"), tr("Edit Track Points"), this,
+                            &CGisListWks::slotEditTrk);
+  actionReverseTrk = addAction("actionReverseTrk", QIcon("://icons/Reverse.svgt"), tr("Reverse Track"), this,
+                               &CGisListWks::slotReverseTrk);
+  actionCombineTrk = addAction("actionCombineTrk", QIcon("://icons/Combine.svgt"), tr("Combine Tracks"), this,
+                               &CGisListWks::slotCombineTrk);
+  actionEleWptTrk = addAction("actionEleWptTrk", QIcon("://icons/SetEle.svgt"), tr("Replace Elevation by DEM"), this,
+                              &CGisListWks::slotEleWptTrk);
+  actionCopyTrkWithWpt = addAction("actionCopyTrkWithWpt", QIcon("://icons/CopyTrkWithWpt.svgt"),
+                                   tr("Copy Track with Waypoints"), this, &CGisListWks::slotCopyTrkWithWpt);
+  actionToRoute =
+      addAction("actionToRoute", QIcon("://icons/Route.svgt"), tr("Convert to Route"), this, &CGisListWks::slotToRoute);
+  actionToArea =
+      addAction("actionToArea", QIcon("://icons/Area.svgt"), tr("Convert to Area"), this, &CGisListWks::slotToArea);
+  actionNogoTrk =
+      addAction("actionNogoTrk", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Line"), this, &CGisListWks::slotNogoItem);
   actionNogoTrk->setCheckable(true);
 
   // waypoint related actions
-  actionBubbleWpt = addAction(QIcon("://icons/Bubble.svgt"), tr("Show Bubble"), this, &CGisListWks::slotBubbleWpt);
+  actionBubbleWpt =
+      addAction("actionBubbleWpt", QIcon("://icons/Bubble.svgt"), tr("Show Bubble"), this, &CGisListWks::slotBubbleWpt);
   actionBubbleWpt->setCheckable(true);
-  actionMoveWpt = addAction(QIcon("://icons/WptMove.svgt"), tr("Move Waypoint"), this, &CGisListWks::slotMoveWpt);
-  actionProjWpt = addAction(QIcon("://icons/WptProj.svgt"), tr("Proj. Waypoint..."), this, &CGisListWks::slotProjWpt);
-  actionEditRadiusWpt =
-      addAction(QIcon("://icons/WptEditProx.svgt"), tr("Change Radius"), this, &CGisListWks::slotEditRadiusWpt);
-  actionDelRadiusWpt =
-      addAction(QIcon("://icons/WptDelProx.svgt"), tr("Delete Radius"), this, &CGisListWks::slotDelRadiusWpt);
-  actionNogoWpt = addAction(QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Area"), this, &CGisListWks::slotNogoItem);
+  actionMoveWpt =
+      addAction("actionMoveWpt", QIcon("://icons/WptMove.svgt"), tr("Move Waypoint"), this, &CGisListWks::slotMoveWpt);
+  actionProjWpt = addAction("actionProjWpt", QIcon("://icons/WptProj.svgt"), tr("Proj. Waypoint..."), this,
+                            &CGisListWks::slotProjWpt);
+  actionEditRadiusWpt = addAction("actionEditRadiusWpt", QIcon("://icons/WptEditProx.svgt"), tr("Change Radius"), this,
+                                  &CGisListWks::slotEditRadiusWpt);
+  actionDelRadiusWpt = addAction("actionDelRadiusWpt", QIcon("://icons/WptDelProx.svgt"), tr("Delete Radius"), this,
+                                 &CGisListWks::slotDelRadiusWpt);
+  actionNogoWpt =
+      addAction("actionNogoWpt", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Area"), this, &CGisListWks::slotNogoItem);
   actionNogoWpt->setCheckable(true);
-  actionCopyCoordWpt =
-      addAction(QIcon("://icons/CopyCoord.svgt"), tr("Copy position"), this, &CGisListWks::slotCopyCoordWpt);
+  actionCopyCoordWpt = addAction("actionCopyCoordWpt", QIcon("://icons/CopyCoord.svgt"), tr("Copy position"), this,
+                                 &CGisListWks::slotCopyCoordWpt);
 
   // route related actions
-  actionFocusRte =
-      addAction(QIcon("://icons/RteInstr.svgt"), tr("Route Instructions"), this, &CGisListWks::slotFocusRte);
+  actionFocusRte = addAction("actionFocusRte", QIcon("://icons/RteInstr.svgt"), tr("Route Instructions"), this,
+                             &CGisListWks::slotFocusRte);
   actionFocusRte->setCheckable(true);
-  actionCalcRte = addAction(QIcon("://icons/Apply.svgt"), tr("Calculate Route"), this, &CGisListWks::slotCalcRte);
-  actionResetRte = addAction(QIcon("://icons/Reset.svgt"), tr("Reset Route"), this, &CGisListWks::slotResetRte);
-  actionEditRte = addAction(QIcon("://icons/LineMove.svgt"), tr("Edit Route"), this, &CGisListWks::slotEditRte);
-  actionReverseRte = addAction(QIcon("://icons/Reverse.svgt"), tr("Reverse Route"), this, &CGisListWks::slotReverseRte);
-  actionRte2Trk = addAction(QIcon("://icons/Track.svgt"), tr("Convert to Track"), this, &CGisListWks::slotRte2Trk);
-  actionNogoRte = addAction(QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Line"), this, &CGisListWks::slotNogoItem);
+  actionCalcRte =
+      addAction("actionCalcRte", QIcon("://icons/Apply.svgt"), tr("Calculate Route"), this, &CGisListWks::slotCalcRte);
+  actionResetRte =
+      addAction("actionResetRte", QIcon("://icons/Reset.svgt"), tr("Reset Route"), this, &CGisListWks::slotResetRte);
+  actionEditRte =
+      addAction("actionEditRte", QIcon("://icons/LineMove.svgt"), tr("Edit Route"), this, &CGisListWks::slotEditRte);
+  actionReverseRte = addAction("actionReverseRte", QIcon("://icons/Reverse.svgt"), tr("Reverse Route"), this,
+                               &CGisListWks::slotReverseRte);
+  actionRte2Trk =
+      addAction("actionRte2Trk", QIcon("://icons/Track.svgt"), tr("Convert to Track"), this, &CGisListWks::slotRte2Trk);
+  actionNogoRte =
+      addAction("actionNogoRte", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Line"), this, &CGisListWks::slotNogoItem);
   actionNogoRte->setCheckable(true);
 
   // area related actions
-  actionEditArea = addAction(QIcon("://icons/AreaMove.svgt"), tr("Edit Area Points"), this, &CGisListWks::slotEditArea);
-  actionNogoArea = addAction(QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Area"), this, &CGisListWks::slotNogoItem);
+  actionEditArea = addAction("actionEditArea", QIcon("://icons/AreaMove.svgt"), tr("Edit Area Points"), this,
+                             &CGisListWks::slotEditArea);
+  actionNogoArea = addAction("actionNogoArea", QIcon("://icons/NoGo.svgt"), tr("Toggle Nogo-Area"), this,
+                             &CGisListWks::slotNogoItem);
   actionNogoArea->setCheckable(true);
 
   // several GIS items related actions
-  actionRteFromWpt = addAction(QIcon("://icons/Route.svgt"), tr("Create Route..."), this, &CGisListWks::slotRteFromWpt);
-  actionEditPrxWpt =
-      addAction(QIcon("://icons/WptEditProx.svgt"), tr("Change Proximity..."), this, &CGisListWks::slotEditPrxWpt);
-  actionChangeIconWpt =
-      addAction(QIcon("://icons/waypoints/PinBlue.svg"), tr("Change Icon..."), this, &CGisListWks::slotSymWpt);
+  actionRteFromWpt = addAction("actionRteFromWpt", QIcon("://icons/Route.svgt"), tr("Create Route..."), this,
+                               &CGisListWks::slotRteFromWpt);
+  actionEditPrxWpt = addAction("actionEditPrxWpt", QIcon("://icons/WptEditProx.svgt"), tr("Change Proximity..."), this,
+                               &CGisListWks::slotEditPrxWpt);
+  actionChangeIconWpt = addAction("actionChangeIconWpt", QIcon("://icons/waypoints/PinBlue.svg"), tr("Change Icon..."),
+                                  this, &CGisListWks::slotSymWpt);
 
   connect(qApp, &QApplication::aboutToQuit, this, &CGisListWks::slotSaveWorkspace);
   connect(this, &CGisListWks::customContextMenuRequested, this, &CGisListWks::slotContextMenu);
@@ -410,16 +442,32 @@ void CGisListWks::setExternalMenu(QMenu* project) {
           &CGisListWks::slotGeoSearch);
 }
 
-QAction* CGisListWks::addSortAction(QObject* parent, QActionGroup* actionGroup, const QString& icon,
-                                    const QString& text, IGisProject::sorting_folder_e mode) {
+QAction* CGisListWks::addSortAction(const QString& objName, QObject* parent, QActionGroup* actionGroup,
+                                    const QString& icon, const QString& text, IGisProject::sorting_folder_e mode) {
   QAction* action = new QAction(QIcon(icon), text, parent);
+  action->setObjectName(objName);
   action->setCheckable(true);
+  QWidget::addAction(action);
 
   connect(action, &QAction::toggled, this, [this, mode](bool checked) { slotSetSortMode(mode, checked); });
 
   actionGroup->addAction(action);
 
   return action;
+}
+
+QList<QAction*> CGisListWks::shortcutActions() const {
+  return {actionEditPrj,       actionCopyPrj,       actionShowOnMap,     actionHideFrMap,    actionSortByTime,
+          actionSortByName,    actionSortByRating,  actionFilterProject, actionAutoSave,     actionUserFocusPrj,
+          actionAutoSyncToDev, actionSave,          actionSaveAs,        actionSaveAsStrict, actionSyncWksDev,
+          actionSyncDB,        actionCloseProj,     actionSyncDevWks,    actionDelProj,      actionEditDetails,
+          actionTagItem,       actionCopyItem,      actionDelete,        actionFocusTrk,     actionRangeTrk,
+          actionEditTrk,       actionReverseTrk,    actionCombineTrk,    actionEleWptTrk,    actionCopyTrkWithWpt,
+          actionToRoute,       actionToArea,        actionNogoTrk,       actionBubbleWpt,    actionMoveWpt,
+          actionProjWpt,       actionEditRadiusWpt, actionDelRadiusWpt,  actionNogoWpt,      actionCopyCoordWpt,
+          actionFocusRte,      actionCalcRte,       actionResetRte,      actionEditRte,      actionReverseRte,
+          actionRte2Trk,       actionNogoRte,       actionEditArea,      actionNogoArea,     actionRteFromWpt,
+          actionEditPrxWpt,    actionChangeIconWpt};
 }
 
 void CGisListWks::dragMoveEvent(QDragMoveEvent* e) {

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -464,18 +464,7 @@ QAction* CGisListWks::addSortAction(const QString& objName, QObject* parent, QAc
   return action;
 }
 
-QList<QAction*> CGisListWks::shortcutActions() const {
-  return {actionShowOnMap,     actionHideFrMap,      actionSortByTime,   actionSortByName,    actionSortByRating,
-          actionFilterProject, actionAutoSave,       actionUserFocusPrj, actionAutoSyncToDev, actionSave,
-          actionSaveAs,        actionSaveAsStrict,   actionSyncWksDev,   actionSyncDB,        actionCloseProj,
-          actionSyncDevWks,    actionEditDetails,    actionTagItem,      actionCopyItem,      actionDelete,
-          actionFocusTrk,      actionRangeTrk,       actionEditTrk,      actionReverseTrk,    actionCombineTrk,
-          actionEleWptTrk,     actionCopyTrkWithWpt, actionToRoute,      actionToArea,        actionNogoTrk,
-          actionBubbleWpt,     actionMoveWpt,        actionProjWpt,      actionEditRadiusWpt, actionDelRadiusWpt,
-          actionCopyCoordWpt,  actionFocusRte,       actionCalcRte,      actionResetRte,      actionEditRte,
-          actionReverseRte,    actionRte2Trk,        actionEditArea,     actionNogoArea,      actionRteFromWpt,
-          actionEditPrxWpt,    actionChangeIconWpt};
-}
+QList<QAction*> CGisListWks::shortcutActions() const { return actions(); }
 
 void CGisListWks::dragMoveEvent(QDragMoveEvent* e) {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -254,6 +254,10 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
   connect(this, &CGisListWks::customContextMenuRequested, this, &CGisListWks::slotContextMenu);
   connect(this, &CGisListWks::itemDoubleClicked, this, &CGisListWks::slotItemDoubleClicked);
   connect(this, &CGisListWks::itemChanged, this, &CGisListWks::slotItemChanged);
+  connect(this, &CGisListWks::itemSelectionChanged, this, &CGisListWks::updateActionState);
+  connect(this, &CGisListWks::currentItemChanged, this, &CGisListWks::updateActionState);
+
+  updateActionState();
 
   SETTINGS;
   saveOnExit = cfg.value("Database/saveOnExit", saveOnExit).toBool();
@@ -1140,235 +1144,368 @@ void CGisListWks::showMenuItem(const QPoint& p, const QList<IGisItem::key_t>& ke
   menu.exec(p);
 }
 
-void CGisListWks::slotContextMenu(const QPoint& point) {
-  QPoint p = mapToGlobal(point);
-  if (selectedItems().isEmpty() && menuNone) {
-    menuNone->exec(p);
-    return;
+CGisListWks::selection_e CGisListWks::selectionType() const {
+  const QList<QTreeWidgetItem*>& items = selectedItems();
+  if (items.isEmpty()) {
+    return eSelectionNone;
+  }
+
+  qsizetype numProjects = 0;
+  for (QTreeWidgetItem* item : items) {
+    if (dynamic_cast<IGisProject*>(item) != nullptr) {
+      numProjects++;
+    }
+  }
+
+  if (numProjects == 0) {
+    return eSelectionItems;
+  }
+
+  return numProjects == items.count() ? eSelectionProjects : eSelectionMixed;
+}
+
+QTreeWidgetItem* CGisListWks::singleSelectedItem() const {
+  const QList<QTreeWidgetItem*>& items = selectedItems();
+  return items.count() == 1 ? items.first() : nullptr;
+}
+
+void CGisListWks::enableActionsOnly(const std::initializer_list<QAction*>& enabled) {
+  const QList<QAction*>& allActions = actions();
+  for (QAction* action : allActions) {
+    action->setEnabled(false);
+  }
+
+  for (QAction* action : enabled) {
+    action->setEnabled(true);
+  }
+}
+
+QList<QAction*> CGisListWks::projectActions() const {
+  return {actionShowOnMap,     actionHideFrMap,     actionSortByTime,   actionSortByName,
+          actionSortByRating,  actionFilterProject, actionAutoSave,     actionUserFocusPrj,
+          actionSave,          actionSaveAs,        actionSaveAsStrict, actionSyncWksDev,
+          actionAutoSyncToDev, actionSyncDB,        actionCloseProj,    actionSyncDevWks};
+}
+
+QList<IGisProject*> CGisListWks::targetProjects() const {
+  QList<IGisProject*> projects;
+
+  const QList<QTreeWidgetItem*>& items = selectedItems();
+  for (QTreeWidgetItem* item : items) {
+    IGisProject* project = dynamic_cast<IGisProject*>(item);
+    if (project == nullptr) {
+      IGisItem* gisItem = dynamic_cast<IGisItem*>(item);
+      if (gisItem != nullptr) {
+        project = gisItem->getParentProject();
+      }
+    }
+
+    if (project != nullptr && !projects.contains(project)) {
+      projects << project;
+    }
+  }
+
+  return projects;
+}
+
+IGisProject* CGisListWks::singleTargetProject() const {
+  const QList<IGisProject*>& projects = targetProjects();
+  return projects.count() == 1 ? projects.first() : nullptr;
+}
+
+CGisListWks::menu_e CGisListWks::updateProjectActions(const QList<IGisProject*>& projects) {
+  const QList<QAction*>& projectOnly = projectActions();
+  for (QAction* action : projectOnly) {
+    action->setEnabled(false);
+  }
+
+  if (projects.isEmpty()) {
+    return eMenuNone;
   }
 
   // check whether all projects are checked or unchecked...
   bool allChecked = true;
   bool allUnchecked = true;
   bool allCantSave = true;
+  bool allOnDevice = true;
+  bool anyLostFound = false;
 
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  for (QTreeWidgetItem* item : items) {
-    IGisProject* project = dynamic_cast<IGisProject*>(item);
-    if (nullptr != project) {
-      // as soon as we find an unchecked element, not all elements are checked (and vice versa)
-      if (project->isVisible() == false) {
-        allChecked = false;
-      } else {
-        allUnchecked = false;
-      }
-
-      if (project->canSave()) {
-        allCantSave = false;
-      }
+  for (IGisProject* project : projects) {
+    // as soon as we find an unchecked element, not all elements are checked (and vice versa)
+    if (project->isVisible() == false) {
+      allChecked = false;
+    } else {
+      allUnchecked = false;
     }
+
+    if (project->canSave()) {
+      allCantSave = false;
+    }
+
+    if (!project->isOnDevice()) {
+      allOnDevice = false;
+    }
+
+    if (project->getType() == IGisProject::eTypeLostFound) {
+      anyLostFound = true;
+    }
+  }
+
+  if (anyLostFound) {
+    actionSaveAs->setEnabled(true);
+    actionSaveAsStrict->setEnabled(true);
+    actionCloseProj->setEnabled(true);
+    return eMenuProjectTrash;
   }
 
   // ...and disable entries without any effect
   actionShowOnMap->setEnabled(!allChecked);
   actionHideFrMap->setEnabled(!allUnchecked);
-  actionSave->setEnabled(!allCantSave);
 
-  if (selectedItems().count() > 1) {
-    IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
-    if (nullptr != project) {
-      if (project->isOnDevice()) {
-        showMenuProjectDev(p);
-      } else {
-        actionGroupSort->setEnabled(false);
-        actionFilterProject->setEnabled(false);
-        actionAutoSyncToDev->setEnabled(hasDeviceSupport());
-        actionSyncWksDev->setEnabled(IDevice::count());
-        actionAutoSyncToDev->setVisible(false);
-        actionSyncDB->setEnabled(project->getType() == IGisProject::eTypeDb);
-        actionAutoSave->setVisible(false);
-        actionUserFocusPrj->setVisible(false);
-        showMenuProjectWks(p);
-      }
-      return;
-    }
-
-    IGisItem* gisItem = dynamic_cast<IGisItem*>(currentItem());
-    if (nullptr != gisItem) {
-      QList<IGisItem::key_t> keysTrk;
-      QList<IGisItem::key_t> keysWpt;
-
-      const QList<QTreeWidgetItem*>& items = selectedItems();
-      for (QTreeWidgetItem* item : items) {
-        CGisItemTrk* trk = dynamic_cast<CGisItemTrk*>(item);
-        if (trk != nullptr) {
-          keysTrk << trk->getKey();
-        }
-
-        CGisItemWpt* wpt = dynamic_cast<CGisItemWpt*>(item);
-        if (wpt != nullptr) {
-          keysWpt << wpt->getKey();
-        }
-      }
-
-      bool hasWpts = !keysWpt.isEmpty();
-      bool hasTrks = !keysTrk.isEmpty();
-
-      actionRteFromWpt->setEnabled(keysWpt.count() > 1);
-      actionEditPrxWpt->setEnabled(hasWpts);
-      actionChangeIconWpt->setEnabled(hasWpts);
-      actionCombineTrk->setEnabled(keysTrk.count() > 1);
-      actionEleWptTrk->setEnabled(hasWpts | hasTrks);
-      showMenuItem(p, keysTrk, keysWpt);
-      return;
-    }
-    return;
+  if (allOnDevice) {
+    actionSyncDevWks->setEnabled(true);
+    return eMenuProjectDev;
   }
 
-  if (selectedItems().count() == 1) {
-    IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
-    if (nullptr != project) {
-      if (project->getType() == IGisProject::eTypeLostFound) {
-        showMenuProjectTrash(p);
-      } else {
-        if (project->isOnDevice()) {
-          showMenuProjectDev(p);
+  IGisProject* firstProject = projects.first();
+  actionSave->setEnabled(!allCantSave);
+  actionSaveAs->setEnabled(true);
+  actionSaveAsStrict->setEnabled(true);
+  actionSyncDB->setEnabled(firstProject->getType() == IGisProject::eTypeDb);
+
+  if (projects.count() > 1) {
+    // a state toggle needs one project to read the state from
+    actionSyncWksDev->setEnabled(IDevice::count());
+    actionCloseProj->setEnabled(true);
+    actionAutoSyncToDev->setVisible(false);
+    actionAutoSave->setVisible(false);
+    actionUserFocusPrj->setVisible(false);
+    return eMenuProjectWks;
+  }
+
+  bool autoSyncToDev = firstProject->isAutoSyncToDev();
+  actionAutoSyncToDev->setEnabled(hasDeviceSupport());
+  actionAutoSyncToDev->setChecked(autoSyncToDev);
+  actionAutoSyncToDev->setIcon(autoSyncToDev ? QIcon("://icons/DeviceSync.svgt") : QIcon("://icons/DeviceNoSync.svgt"));
+
+  actionSyncWksDev->setEnabled(IDevice::count() && !autoSyncToDev);
+  actionCloseProj->setEnabled(!autoSyncToDev);
+
+  actionGroupSort->setEnabled(true);
+  blockSorting = true;
+  switch (firstProject->getSortingFolder()) {
+    case IGisProject::eSortFolderName:
+      actionSortByName->setChecked(true);
+      break;
+
+    case IGisProject::eSortFolderTime:
+      actionSortByTime->setChecked(true);
+      break;
+
+    case IGisProject::eSortFolderRating:
+      actionSortByRating->setChecked(true);
+      break;
+  }
+  blockSorting = false;
+
+  actionFilterProject->setEnabled(true);
+  actionFilterProject->setChecked(firstProject->getProjectFilterItem() != nullptr);
+
+  bool isAutoSave = firstProject->isAutoSave();
+  actionAutoSave->setEnabled(firstProject->canSave());
+  actionAutoSave->setChecked(isAutoSave);
+  actionAutoSave->setIcon(isAutoSave ? QIcon("://icons/AutoSaveA.svgt") : QIcon("://icons/AutoSaveNoA.svgt"));
+
+  bool hasUserFocus = firstProject->hasUserFocus();
+  actionUserFocusPrj->setEnabled(true);
+  actionUserFocusPrj->setChecked(hasUserFocus);
+  actionUserFocusPrj->setIcon(hasUserFocus ? QIcon("://icons/Focus.svgt") : QIcon("://icons/UnFocus.svgt"));
+
+  return eMenuProjectWks;
+}
+
+CGisListWks::menu_e CGisListWks::updateActionState() {
+  const QList<QAction*>& allActions = actions();
+  for (QAction* action : allActions) {
+    action->setVisible(true);
+    action->setEnabled(true);
+  }
+  actionGroupSort->setEnabled(true);
+
+  // a selection mixing projects and items has no common operation
+  const selection_e selection = selectionType();
+  if (selection == eSelectionNone || selection == eSelectionMixed) {
+    enableActionsOnly({});
+    return eMenuNone;
+  }
+
+  const menu_e projectMenu = updateProjectActions(targetProjects());
+
+  if (selection == eSelectionProjects) {
+    const QList<QAction*>& projectOnly = projectActions();
+    for (QAction* action : allActions) {
+      if (!projectOnly.contains(action)) {
+        action->setEnabled(false);
+      }
+    }
+
+    if (projectMenu != eMenuProjectTrash) {
+      actionEditDetails->setEnabled(true);
+      actionCopyItem->setEnabled(true);
+      actionDelete->setEnabled(projectMenu == eMenuProjectDev);
+    }
+
+    return projectMenu;
+  }
+
+  const QList<QTreeWidgetItem*>& items = selectedItems();
+  if (items.count() > 1) {
+    const QList<IGisItem::key_t>& keysTrk = selectedItems2Keys<CGisItemTrk>();
+    const QList<IGisItem::key_t>& keysWpt = selectedItems2Keys<CGisItemWpt>();
+
+    bool hasWpts = !keysWpt.isEmpty();
+    bool hasTrks = !keysTrk.isEmpty();
+
+    actionRteFromWpt->setEnabled(keysWpt.count() > 1);
+    actionEditPrxWpt->setEnabled(hasWpts);
+    actionChangeIconWpt->setEnabled(hasWpts);
+    actionCombineTrk->setEnabled(keysTrk.count() > 1);
+    actionEleWptTrk->setEnabled(hasWpts | hasTrks);
+    return eMenuItemMulti;
+  }
+
+  IGisItem* gisItem = dynamic_cast<IGisItem*>(items.first());
+  if (nullptr != gisItem) {
+    bool isOnDevice = gisItem->isOnDevice();
+    IGisProject* parentProject = gisItem->getParentProject();
+    bool isProjectVisible = parentProject == nullptr ? false : parentProject->isVisible();
+
+    switch (gisItem->type()) {
+      case IGisItem::eTypeTrk: {
+        CGisItemTrk* trk = dynamic_cast<CGisItemTrk*>(gisItem);
+        if (trk == nullptr) {
+          break;
+        }
+
+        if (parentProject != nullptr) {
+          actionCombineTrk->setEnabled(parentProject->getItemCountByType(IGisItem::eTypeTrk) > 1);
         } else {
-          actionGroupSort->setEnabled(true);
-
-          bool autoSyncToDev = project->isAutoSyncToDev();
-          actionAutoSyncToDev->setEnabled(hasDeviceSupport());
-          actionAutoSyncToDev->setChecked(autoSyncToDev);
-          actionAutoSyncToDev->setIcon(autoSyncToDev ? QIcon("://icons/DeviceSync.svgt")
-                                                     : QIcon("://icons/DeviceNoSync.svgt"));
-
-          actionSyncWksDev->setEnabled(IDevice::count() && !autoSyncToDev);
-          actionSyncDB->setEnabled(project->getType() == IGisProject::eTypeDb);
-
-          blockSorting = true;
-          switch (project->getSortingFolder()) {
-            case IGisProject::eSortFolderName:
-              actionSortByName->setChecked(true);
-              break;
-
-            case IGisProject::eSortFolderTime:
-              actionSortByTime->setChecked(true);
-              break;
-
-            case IGisProject::eSortFolderRating:
-              actionSortByRating->setChecked(true);
-              break;
-          }
-
-          blockSorting = false;
-
-          actionFilterProject->setEnabled(true);
-          actionFilterProject->setChecked(project->getProjectFilterItem() != nullptr);
-
-          bool isAutoSave = project->isAutoSave();
-          actionAutoSave->setVisible(true);
-          actionAutoSave->setEnabled(project->canSave());
-          actionAutoSave->setChecked(project->isAutoSave());
-          actionAutoSave->setIcon(isAutoSave ? QIcon("://icons/AutoSaveA.svgt") : QIcon("://icons/AutoSaveNoA.svgt"));
-
-          bool hasUserFocus = project->hasUserFocus();
-          actionUserFocusPrj->setVisible(true);
-          actionUserFocusPrj->setChecked(hasUserFocus);
-          actionUserFocusPrj->setIcon(hasUserFocus ? QIcon("://icons/Focus.svgt") : QIcon("://icons/UnFocus.svgt"));
-          actionCloseProj->setEnabled(!autoSyncToDev);
-          showMenuProjectWks(p);
+          actionCombineTrk->setEnabled(false);
         }
-      }
-      return;
-    }
-
-    IGisItem* gisItem = dynamic_cast<IGisItem*>(currentItem());
-    if (nullptr != gisItem) {
-      bool isOnDevice = gisItem->isOnDevice();
-      IGisProject* project = gisItem->getParentProject();
-      bool isProjectVisible = project == nullptr ? false : project->isVisible();
-
-      switch (gisItem->type()) {
-        case IGisItem::eTypeTrk: {
-          CGisItemTrk* trk = dynamic_cast<CGisItemTrk*>(gisItem);
-          if (trk == nullptr) {
-            break;
-          }
-
-          if (project != nullptr) {
-            actionCombineTrk->setEnabled(project->getItemCountByType(IGisItem::eTypeTrk) > 1);
-          } else {
-            actionCombineTrk->setEnabled(false);
-          }
-          actionRangeTrk->setEnabled(isProjectVisible && !isOnDevice);
-          actionReverseTrk->setDisabled(isOnDevice);
-          actionEditTrk->setEnabled(isProjectVisible && !isOnDevice);
-          actionNogoTrk->setEnabled(isProjectVisible);
-          actionNogoTrk->setChecked(gisItem->isNogo());
-          actionCopyTrkWithWpt->setEnabled(trk->getNumberOfAttachedWpt() != 0);
-          actionFocusTrk->setChecked(gisItem->hasUserFocus());
-          actionFocusTrk->setEnabled(isProjectVisible);
-          showMenuItemTrk(p, trk->getKey());
-          break;
-        }
-
-        case IGisItem::eTypeWpt: {
-          CGisItemWpt* wpt = dynamic_cast<CGisItemWpt*>(gisItem);
-          if (wpt == nullptr) {
-            break;
-          }
-
-          actionBubbleWpt->setChecked(wpt->hasBubble());
-          actionBubbleWpt->setEnabled(isProjectVisible);
-          actionEditRadiusWpt->setEnabled(isProjectVisible);
-          bool radius = wpt->hasRadius();
-          actionDelRadiusWpt->setEnabled(isProjectVisible && radius);
-          actionNogoArea->setEnabled(isProjectVisible && radius);
-          actionNogoArea->setChecked(radius && wpt->isNogo());
-          actionMoveWpt->setEnabled(isProjectVisible && !isOnDevice);
-          actionProjWpt->setDisabled(isOnDevice);
-          showMenuItemWpt(p, wpt);
-          break;
-        }
-
-        case IGisItem::eTypeRte: {
-          CGisItemRte* rte = dynamic_cast<CGisItemRte*>(gisItem);
-          if (rte == nullptr) {
-            break;
-          }
-
-          actionFocusRte->setChecked(rte->hasUserFocus());
-          actionFocusRte->setEnabled(isProjectVisible && rte->isCalculated());
-          actionCalcRte->setEnabled(isProjectVisible);
-          actionEditRte->setEnabled(isProjectVisible);
-          actionNogoTrk->setEnabled(isProjectVisible);
-          actionNogoTrk->setChecked(gisItem->isNogo());
-          actionResetRte->setEnabled(isProjectVisible);
-          showMenuItemRte(p);
-          break;
-        }
-
-        case IGisItem::eTypeOvl:
-          actionEditArea->setEnabled(isProjectVisible && !isOnDevice);
-          actionNogoArea->setEnabled(isProjectVisible);
-          actionNogoArea->setChecked(gisItem->isNogo());
-          showMenuItemOvl(p);
-          break;
+        actionRangeTrk->setEnabled(isProjectVisible && !isOnDevice);
+        actionReverseTrk->setDisabled(isOnDevice);
+        actionEditTrk->setEnabled(isProjectVisible && !isOnDevice);
+        actionNogoTrk->setEnabled(isProjectVisible);
+        actionNogoTrk->setChecked(gisItem->isNogo());
+        actionCopyTrkWithWpt->setEnabled(trk->getNumberOfAttachedWpt() != 0);
+        actionFocusTrk->setChecked(gisItem->hasUserFocus());
+        actionFocusTrk->setEnabled(isProjectVisible);
+        return eMenuItemTrk;
       }
 
-      return;
+      case IGisItem::eTypeWpt: {
+        CGisItemWpt* wpt = dynamic_cast<CGisItemWpt*>(gisItem);
+        if (wpt == nullptr) {
+          break;
+        }
+
+        actionBubbleWpt->setChecked(wpt->hasBubble());
+        actionBubbleWpt->setEnabled(isProjectVisible);
+        actionEditRadiusWpt->setEnabled(isProjectVisible);
+        bool radius = wpt->hasRadius();
+        actionDelRadiusWpt->setEnabled(isProjectVisible && radius);
+        actionNogoArea->setEnabled(isProjectVisible && radius);
+        actionNogoArea->setChecked(radius && wpt->isNogo());
+        actionMoveWpt->setEnabled(isProjectVisible && !isOnDevice);
+        actionProjWpt->setDisabled(isOnDevice);
+        return eMenuItemWpt;
+      }
+
+      case IGisItem::eTypeRte: {
+        CGisItemRte* rte = dynamic_cast<CGisItemRte*>(gisItem);
+        if (rte == nullptr) {
+          break;
+        }
+
+        actionFocusRte->setChecked(rte->hasUserFocus());
+        actionFocusRte->setEnabled(isProjectVisible && rte->isCalculated());
+        actionCalcRte->setEnabled(isProjectVisible);
+        actionEditRte->setEnabled(isProjectVisible);
+        actionNogoTrk->setEnabled(isProjectVisible);
+        actionNogoTrk->setChecked(gisItem->isNogo());
+        actionResetRte->setEnabled(isProjectVisible);
+        return eMenuItemRte;
+      }
+
+      case IGisItem::eTypeOvl:
+        actionEditArea->setEnabled(isProjectVisible && !isOnDevice);
+        actionNogoArea->setEnabled(isProjectVisible);
+        actionNogoArea->setChecked(gisItem->isNogo());
+        return eMenuItemOvl;
     }
+  }
+
+  enableActionsOnly({});
+  return eMenuNone;
+}
+
+void CGisListWks::slotContextMenu(const QPoint& point) {
+  const QPoint p = mapToGlobal(point);
+
+  switch (updateActionState()) {
+    case eMenuNone:
+      if (selectedItems().isEmpty() && menuNone != nullptr) {
+        menuNone->exec(p);
+      }
+      break;
+
+    case eMenuProjectWks:
+      showMenuProjectWks(p);
+      break;
+
+    case eMenuProjectDev:
+      showMenuProjectDev(p);
+      break;
+
+    case eMenuProjectTrash:
+      showMenuProjectTrash(p);
+      break;
+
+    case eMenuItemTrk: {
+      CGisItemTrk* trk = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
+      if (trk != nullptr) {
+        showMenuItemTrk(p, trk->getKey());
+      }
+      break;
+    }
+
+    case eMenuItemWpt: {
+      CGisItemWpt* wpt = dynamic_cast<CGisItemWpt*>(singleSelectedItem());
+      if (wpt != nullptr) {
+        showMenuItemWpt(p, wpt);
+      }
+      break;
+    }
+
+    case eMenuItemRte:
+      showMenuItemRte(p);
+      break;
+
+    case eMenuItemOvl:
+      showMenuItemOvl(p);
+      break;
+
+    case eMenuItemMulti:
+      showMenuItem(p, selectedItems2Keys<CGisItemTrk>(), selectedItems2Keys<CGisItemWpt>());
+      break;
   }
 }
 
 void CGisListWks::setVisibilityOnMap(bool visible) {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  for (QTreeWidgetItem* item : items) {
-    IGisProject* project = dynamic_cast<IGisProject*>(item);
-    if (nullptr != project) {
-      project->setVisibility(visible);
-    }
+  const QList<IGisProject*>& projects = targetProjects();
+  for (IGisProject* project : projects) {
+    project->setVisibility(visible);
   }
   emit sigChanged();
 }
@@ -1377,30 +1514,27 @@ void CGisListWks::slotShowOnMap() { setVisibilityOnMap(true); }
 
 void CGisListWks::slotHideFrMap() { setVisibilityOnMap(false); }
 
-static void closeProjects(const QList<QTreeWidgetItem*>& items) {
-  for (QTreeWidgetItem* item : items) {
-    IGisProject* project = dynamic_cast<IGisProject*>(item);
-    if (nullptr != project) {
-      if (project->isAutoSyncToDev()) {
-        continue;
-      }
-
-      if (project->askBeforClose()) {
-        break;
-      }
-
-      if (IGisProject::eTypeGeoSearch == project->getType()) {
-        CMainWindow::self().findChild<QAction*>("actionGeoSearch")->setChecked(false);
-      }
-      project->destroyLater();
+static void closeProjects(const QList<IGisProject*>& projects) {
+  for (IGisProject* project : projects) {
+    if (project->isAutoSyncToDev()) {
+      continue;
     }
+
+    if (project->askBeforClose()) {
+      break;
+    }
+
+    if (IGisProject::eTypeGeoSearch == project->getType()) {
+      CMainWindow::self().findChild<QAction*>("actionGeoSearch")->setChecked(false);
+    }
+    project->destroyLater();
   }
 }
 
 void CGisListWks::slotCloseProject() {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  closeProjects(selectedItems());
+  closeProjects(targetProjects());
   emit sigChanged();
 }
 
@@ -1413,7 +1547,16 @@ void CGisListWks::slotCloseAllProjects() {
   }
 
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
-  closeProjects(findItems("*", Qt::MatchWildcard));
+
+  QList<IGisProject*> projects;
+  const QList<QTreeWidgetItem*>& items = findItems("*", Qt::MatchWildcard);
+  for (QTreeWidgetItem* item : items) {
+    IGisProject* project = dynamic_cast<IGisProject*>(item);
+    if (project != nullptr) {
+      projects << project;
+    }
+  }
+  closeProjects(projects);
 
   CGisWorkspace::self().slotWksItemSelectionReset();
 
@@ -1449,15 +1592,12 @@ void CGisListWks::slotDeleteProject() {
 void CGisListWks::slotSaveProject() {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  for (QTreeWidgetItem* item : items) {
-    IGisProject* project = dynamic_cast<IGisProject*>(item);
-    if (nullptr != project) {
-      if (project->canSave()) {
-        project->save();
-      } else {
-        project->saveAs();
-      }
+  const QList<IGisProject*>& projects = targetProjects();
+  for (IGisProject* project : projects) {
+    if (project->canSave()) {
+      project->save();
+    } else {
+      project->saveAs();
     }
   }
 }
@@ -1465,31 +1605,25 @@ void CGisListWks::slotSaveProject() {
 void CGisListWks::slotSaveAsProject() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  for (QTreeWidgetItem* item : items) {
-    IGisProject* project = dynamic_cast<IGisProject*>(item);
-    if (nullptr != project) {
-      project->saveAs();
-    }
+  const QList<IGisProject*>& projects = targetProjects();
+  for (IGisProject* project : projects) {
+    project->saveAs();
   }
 }
 
 void CGisListWks::slotSaveAsStrictGpx11Project() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  for (QTreeWidgetItem* item : items) {
-    IGisProject* project = dynamic_cast<IGisProject*>(item);
-    if (nullptr != project) {
-      project->saveAsStrictGpx11();
-    }
+  const QList<IGisProject*>& projects = targetProjects();
+  for (IGisProject* project : projects) {
+    project->saveAsStrictGpx11();
   }
 }
 
 void CGisListWks::slotAutoSaveProject(bool on) {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
+  IGisProject* project = singleTargetProject();
   if (project != nullptr) {
     project->setAutoSave(on);
   }
@@ -1499,7 +1633,7 @@ void CGisListWks::slotUserFocusPrj(bool yes) {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
   QString key;
-  IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
+  IGisProject* project = singleTargetProject();
   if (project != nullptr) {
     key = project->getKey();
   }
@@ -1528,7 +1662,7 @@ void CGisListWks::setUserFocus(const QString& key, bool yes) {
 void CGisListWks::slotAutoSyncProject(bool yes) {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
+  IGisProject* project = singleTargetProject();
   if (project != nullptr) {
     project->setAutoSyncToDev(yes);
     if (yes) {
@@ -1540,7 +1674,7 @@ void CGisListWks::slotAutoSyncProject(bool yes) {
 void CGisListWks::slotEditPrj() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
+  IGisProject* project = dynamic_cast<IGisProject*>(singleSelectedItem());
   if (project != nullptr) {
     project->edit();
   }
@@ -1562,6 +1696,10 @@ void CGisListWks::slotItemDoubleClicked(QTreeWidgetItem* item, int) {
 }
 
 void CGisListWks::slotItemChanged(QTreeWidgetItem* item, int /*column*/) {
+  if (item->isSelected()) {
+    updateActionState();
+  }
+
   // Check if the project or the item's project is flagged for no update.
   // First try to derive the pointer to the project
   IGisProject* itemPrj = dynamic_cast<IGisProject*>(item);
@@ -1584,17 +1722,24 @@ void CGisListWks::slotItemChanged(QTreeWidgetItem* item, int /*column*/) {
 void CGisListWks::slotEditItem() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  IGisItem* gisItem = dynamic_cast<IGisItem*>(currentItem());
+  IGisItem* gisItem = dynamic_cast<IGisItem*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().editItemByKey(gisItem->getKey());
   }
 }
 
 void CGisListWks::slotEdit() {
-  if (dynamic_cast<IGisProject*>(currentItem()) != nullptr) {
-    slotEditPrj();
-  } else {
-    slotEditItem();
+  switch (selectionType()) {
+    case eSelectionProjects:
+      slotEditPrj();
+      break;
+
+    case eSelectionItems:
+      slotEditItem();
+      break;
+
+    default:
+      break;
   }
 }
 
@@ -1609,10 +1754,17 @@ void CGisListWks::slotDeleteItem() {
 }
 
 void CGisListWks::slotDelete() {
-  if (dynamic_cast<IGisProject*>(currentItem()) != nullptr) {
-    slotDeleteProject();
-  } else {
-    slotDeleteItem();
+  switch (selectionType()) {
+    case eSelectionProjects:
+      slotDeleteProject();
+      break;
+
+    case eSelectionItems:
+      slotDeleteItem();
+      break;
+
+    default:
+      break;
   }
 }
 
@@ -1632,17 +1784,24 @@ void CGisListWks::slotCopyItem() {
 }
 
 void CGisListWks::slotCopy() {
-  if (dynamic_cast<IGisProject*>(currentItem()) != nullptr) {
-    slotCopyProject();
-  } else {
-    slotCopyItem();
+  switch (selectionType()) {
+    case eSelectionProjects:
+      slotCopyProject();
+      break;
+
+    case eSelectionItems:
+      slotCopyItem();
+      break;
+
+    default:
+      break;
   }
 }
 
 void CGisListWks::slotProjWpt() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(currentItem());
+  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().projWptByKey(gisItem->getKey());
   }
@@ -1651,7 +1810,7 @@ void CGisListWks::slotProjWpt() {
 void CGisListWks::slotBubbleWpt() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(currentItem());
+  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().toggleWptBubble(gisItem->getKey());
   }
@@ -1660,7 +1819,7 @@ void CGisListWks::slotBubbleWpt() {
 void CGisListWks::slotNogoItem() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  IGisItem* gisItem = dynamic_cast<IGisItem*>(currentItem());
+  IGisItem* gisItem = dynamic_cast<IGisItem*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().toggleNogoItem(gisItem->getKey());
   }
@@ -1669,7 +1828,7 @@ void CGisListWks::slotNogoItem() {
 void CGisListWks::slotDelRadiusWpt() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(currentItem());
+  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().deleteWptRadius(gisItem->getKey());
   }
@@ -1678,7 +1837,7 @@ void CGisListWks::slotDelRadiusWpt() {
 void CGisListWks::slotEditRadiusWpt() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(currentItem());
+  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().editWptRadius(gisItem->getKey());
   }
@@ -1687,7 +1846,7 @@ void CGisListWks::slotEditRadiusWpt() {
 void CGisListWks::slotMoveWpt() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(currentItem());
+  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().moveWptByKey(gisItem->getKey());
   }
@@ -1695,7 +1854,7 @@ void CGisListWks::slotMoveWpt() {
 
 void CGisListWks::slotCopyCoordWpt() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
-  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(currentItem());
+  CGisItemWpt* gisItem = dynamic_cast<CGisItemWpt*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().copyWptCoordByKey(gisItem->getKey());
   }
@@ -1704,7 +1863,7 @@ void CGisListWks::slotCopyCoordWpt() {
 void CGisListWks::slotFocusTrk(bool on) {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().focusTrkByKey(on, gisItem->getKey());
   }
@@ -1713,7 +1872,7 @@ void CGisListWks::slotFocusTrk(bool on) {
 void CGisListWks::slotEditTrk() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().editTrkByKey(gisItem->getKey());
   }
@@ -1722,7 +1881,7 @@ void CGisListWks::slotEditTrk() {
 void CGisListWks::slotReverseTrk() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().reverseTrkByKey(gisItem->getKey());
   }
@@ -1776,7 +1935,7 @@ void CGisListWks::slotColorTrk() {
 void CGisListWks::slotRangeTrk() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().rangeTrkByKey(gisItem->getKey());
   }
@@ -1785,7 +1944,7 @@ void CGisListWks::slotRangeTrk() {
 void CGisListWks::slotCopyTrkWithWpt() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().copyTrkWithWptByKey(gisItem->getKey());
   }
@@ -1794,7 +1953,7 @@ void CGisListWks::slotCopyTrkWithWpt() {
 void CGisListWks::slotFocusRte(bool on) {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(currentItem());
+  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().focusRteByKey(on, gisItem->getKey());
   }
@@ -1803,7 +1962,7 @@ void CGisListWks::slotFocusRte(bool on) {
 void CGisListWks::slotCalcRte() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(currentItem());
+  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().calcRteByKey(gisItem->getKey());
   }
@@ -1812,7 +1971,7 @@ void CGisListWks::slotCalcRte() {
 void CGisListWks::slotResetRte() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(currentItem());
+  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().resetRteByKey(gisItem->getKey());
   }
@@ -1821,7 +1980,7 @@ void CGisListWks::slotResetRte() {
 void CGisListWks::slotEditRte() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(currentItem());
+  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().editRteByKey(gisItem->getKey());
   }
@@ -1830,7 +1989,7 @@ void CGisListWks::slotEditRte() {
 void CGisListWks::slotReverseRte() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(currentItem());
+  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().reverseRteByKey(gisItem->getKey());
   }
@@ -1839,7 +1998,7 @@ void CGisListWks::slotReverseRte() {
 void CGisListWks::slotRte2Trk() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(currentItem());
+  CGisItemRte* gisItem = dynamic_cast<CGisItemRte*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().convertRouteToTrack(gisItem->getKey());
   }
@@ -1848,7 +2007,7 @@ void CGisListWks::slotRte2Trk() {
 void CGisListWks::slotEditArea() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemOvlArea* gisItem = dynamic_cast<CGisItemOvlArea*>(currentItem());
+  CGisItemOvlArea* gisItem = dynamic_cast<CGisItemOvlArea*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().editAreaByKey(gisItem->getKey());
   }
@@ -1908,7 +2067,7 @@ void CGisListWks::slotSyncWksDev() {
     return;
   }
 
-  IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
+  IGisProject* project = singleTargetProject();
   if (nullptr == project) {
     return;
   }
@@ -1930,20 +2089,16 @@ void CGisListWks::slotSyncWksDev() {
       }
     }
   }
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  for (QTreeWidgetItem* item : items) {
-    IGisProject* project = dynamic_cast<IGisProject*>(item);
-    if (project == nullptr) {
-      continue;
-    }
-    syncPrjToDevices(project, keys);
+  const QList<IGisProject*>& projects = targetProjects();
+  for (IGisProject* targetProject : projects) {
+    syncPrjToDevices(targetProject, keys);
   }
 }
 
 void CGisListWks::slotSyncDevWks() {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
+  IGisProject* project = singleTargetProject();
   if (nullptr == project) {
     return;
   }
@@ -1977,12 +2132,7 @@ void CGisListWks::slotSyncDevWks() {
 void CGisListWks::slotAddProjectFilter() {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  if (items.count() != 1) {
-    return;
-  }
-
-  IGisProject* project = dynamic_cast<IGisProject*>(items.first());
+  IGisProject* project = singleTargetProject();
   if (project != nullptr) {
     project->filterProject(actionFilterProject->isChecked());
   }
@@ -2225,14 +2375,12 @@ void CGisListWks::slotEditPrxWpt() {
 void CGisListWks::slotSyncDB() {
   CGisListWksEditLock lock(true, IGisItem::mutexItems);
 
-  const QList<QTreeWidgetItem*>& items = selectedItems();
-  for (QTreeWidgetItem* item : items) {
-    CDBProject* project = dynamic_cast<CDBProject*>(item);
-    if (project == nullptr) {
-      continue;
+  const QList<IGisProject*>& projects = targetProjects();
+  for (IGisProject* project : projects) {
+    CDBProject* dbProject = dynamic_cast<CDBProject*>(project);
+    if (dbProject != nullptr) {
+      dbProject->update();
     }
-
-    project->update();
   }
 }
 
@@ -2241,7 +2389,7 @@ void CGisListWks::slotSetSortMode(IGisProject::sorting_folder_e mode, bool check
     return;
   }
 
-  IGisProject* project = dynamic_cast<IGisProject*>(currentItem());
+  IGisProject* project = singleTargetProject();
   if (project != nullptr) {
     project->setSortingFolder(mode);
   }
@@ -2285,7 +2433,7 @@ void CGisListWks::slotEleWptTrk() { CGisWorkspace::self().addEleToWptTrkByKey(se
 void CGisListWks::slotToRoute() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().convertTrackToRoute(gisItem->getKey());
   }
@@ -2294,7 +2442,7 @@ void CGisListWks::slotToRoute() {
 void CGisListWks::slotToArea() {
   CGisListWksEditLock lock(false, IGisItem::mutexItems);
 
-  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(currentItem());
+  CGisItemTrk* gisItem = dynamic_cast<CGisItemTrk*>(singleSelectedItem());
   if (gisItem != nullptr) {
     CGisWorkspace::self().convertTrackToArea(gisItem->getKey());
   }

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -59,6 +59,9 @@ class CGisListWks : public QTreeWidget {
 
   bool hasDeviceSupport() const { return deviceWatcher != nullptr; }
 
+  /// all context-menu actions of this widget, for keyboard shortcut configuration
+  QList<QAction*> shortcutActions() const;
+
  public slots:
   void slotLoadWorkspace();
   void slotCopyProject();
@@ -140,12 +143,16 @@ class CGisListWks : public QTreeWidget {
   void migrateDB3to4();
   void migrateDB4to5();
   void setVisibilityOnMap(bool visible);
-  QAction* addSortAction(QObject* parent, QActionGroup* actionGroup, const QString& icon, const QString& text,
-                         IGisProject::sorting_folder_e mode);
+  QAction* addSortAction(const QString& objName, QObject* parent, QActionGroup* actionGroup, const QString& icon,
+                         const QString& text, IGisProject::sorting_folder_e mode);
 
   template <typename Func>
-  QAction* addAction(const QIcon& icon, const QString& name, QObject* parent, Func slot) {
+  QAction* addAction(const QString& objName, const QIcon& icon, const QString& name, QObject* parent, Func slot) {
     QAction* action = new QAction(icon, name, parent);
+    action->setObjectName(objName);
+    // register with the widget so a user-assigned shortcut can actually trigger it,
+    // independent of the transient context menu the action is also shown in
+    QWidget::addAction(action);
     connect(action, &QAction::triggered, this, slot);
     return action;
   }

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -191,8 +191,6 @@ class CGisListWks : public QTreeWidget {
   QAction* actionAutoSave;
   QAction* actionUserFocusPrj;
   QAction* actionAutoSyncToDev;
-  QAction* actionCopyPrj;
-  QAction* actionEditPrj;
   QAction* actionCloseProj;
   QAction* actionShowOnMap;
   QAction* actionHideFrMap;
@@ -202,7 +200,6 @@ class CGisListWks : public QTreeWidget {
   QAction* actionSortByName;
   QAction* actionSortByRating;
   QAction* actionFilterProject;
-  QAction* actionDelProj;
   QAction* actionSyncDevWks;
   QAction* actionEditDetails;
   QAction* actionTagItem;
@@ -210,7 +207,6 @@ class CGisListWks : public QTreeWidget {
   QAction* actionDelete;
   QAction* actionBubbleWpt;
   QAction* actionDelRadiusWpt;
-  QAction* actionNogoWpt;
   QAction* actionEditRadiusWpt;
   QAction* actionProjWpt;
   QAction* actionMoveWpt;
@@ -226,7 +222,6 @@ class CGisListWks : public QTreeWidget {
   QAction* actionCalcRte;
   QAction* actionResetRte;
   QAction* actionEditRte;
-  QAction* actionNogoRte;
   QAction* actionReverseRte;
   QAction* actionRte2Trk;
   QAction* actionEditArea;

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -23,6 +23,7 @@
 #include <QPointer>
 #include <QSqlDatabase>
 #include <QTreeWidget>
+#include <initializer_list>
 
 #include "gis/prj/IGisProject.h"
 #include "gis/trk/CTrackData.h"
@@ -138,6 +139,59 @@ class CGisListWks : public QTreeWidget {
   void slotToArea();
 
  private:
+  /** @brief The context menu matching the current selection, as decided by updateActionState() */
+  enum menu_e {
+    eMenuNone,
+    eMenuProjectWks,
+    eMenuProjectDev,
+    eMenuProjectTrash,
+    eMenuItemTrk,
+    eMenuItemWpt,
+    eMenuItemRte,
+    eMenuItemOvl,
+    eMenuItemMulti
+  };
+
+  /**
+     @brief Bring all actions in sync with the current selection
+
+     @return the context menu for the selection
+   */
+  menu_e updateActionState();
+
+  /** @brief What the selection holds, which decides what an action can apply to */
+  enum selection_e { eSelectionNone, eSelectionProjects, eSelectionItems, eSelectionMixed };
+
+  selection_e selectionType() const;
+
+  /** @brief The one selected item, or nullptr if the selection does not hold exactly one */
+  QTreeWidgetItem* singleSelectedItem() const;
+
+  /** @brief Disable every action, then enable the listed ones */
+  void enableActionsOnly(const std::initializer_list<QAction*>& enabled);
+
+  /**
+     @brief The actions for a project
+   */
+  QList<QAction*> projectActions() const;
+
+  /**
+     @brief The projects an action applies to
+
+     Either the selected projects, or the projects the selected items belong to
+   */
+  QList<IGisProject*> targetProjects() const;
+
+  /** @brief The one project an action applies to, or nullptr if the selection does not resolve to exactly one */
+  IGisProject* singleTargetProject() const;
+
+  /**
+     @brief Bring the project actions in sync with the projects they would act on
+
+     @return the project menu those projects ask for
+   */
+  menu_e updateProjectActions(const QList<IGisProject*>& projects);
+
   void configDB();
   void initDB();
   void migrateDB(int version);

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -20,6 +20,7 @@
 #ifndef CGISLISTWKS_H
 #define CGISLISTWKS_H
 
+#include <QMap>
 #include <QPointer>
 #include <QSqlDatabase>
 #include <QTreeWidget>
@@ -159,6 +160,12 @@ class CGisListWks : public QTreeWidget {
    */
   menu_e updateActionState();
 
+  /** @brief Category of an action */
+  enum category_e { eCategoryProject, eCategoryItem, eCategoryTrack, eCategoryWaypoint, eCategoryRoute, eCategoryArea };
+
+  /** @brief The translated name for a category */
+  QString categoryName(category_e category) const;
+
   /** @brief What the selection holds, which decides what an action can apply to */
   enum selection_e { eSelectionNone, eSelectionProjects, eSelectionItems, eSelectionMixed };
 
@@ -171,8 +178,11 @@ class CGisListWks : public QTreeWidget {
   void enableActionsOnly(const std::initializer_list<QAction*>& enabled);
 
   /**
-     @brief The actions for a project
+     @brief Disable every action outside the given categories
    */
+  void disableActionsOutside(const std::initializer_list<category_e>& categories);
+
+  /** @brief The actions for a project */
   QList<QAction*> projectActions() const;
 
   /**
@@ -201,18 +211,23 @@ class CGisListWks : public QTreeWidget {
   void migrateDB4to5();
   void setVisibilityOnMap(bool visible);
   QAction* addSortAction(const QString& objName, QObject* parent, QActionGroup* actionGroup, const QString& icon,
-                         const QString& text, IGisProject::sorting_folder_e mode);
+                         const QString& text, IGisProject::sorting_folder_e mode, category_e category);
 
   template <typename Func>
-  QAction* addAction(const QString& objName, const QIcon& icon, const QString& name, QObject* parent, Func slot) {
+  QAction* addAction(const QString& objName, const QIcon& icon, const QString& name, QObject* parent, Func slot,
+                     category_e category) {
     QAction* action = new QAction(icon, name, parent);
     action->setObjectName(objName);
     // register with the widget so a user-assigned shortcut can actually trigger it,
     // independent of the transient context menu the action is also shown in
     QWidget::addAction(action);
     connect(action, &QAction::triggered, this, slot);
+    tagCategory(action, category);
     return action;
   }
+
+  /** @brief Record the action's category, for the shortcut setup dialog and for categoryActions */
+  void tagCategory(QAction* action, category_e category);
 
   void showMenuProjectWks(const QPoint& p);
   void showMenuProjectDev(const QPoint& p);
@@ -240,6 +255,8 @@ class CGisListWks : public QTreeWidget {
   }
 
   QSqlDatabase db;
+
+  QMap<category_e, QList<QAction*>> categoryActions;
 
   QActionGroup* actionGroupSort;
   QAction* actionSave;

--- a/src/qmapshack/gis/CGisListWks.h
+++ b/src/qmapshack/gis/CGisListWks.h
@@ -89,8 +89,10 @@ class CGisListWks : public QTreeWidget {
   void slotItemDoubleClicked(QTreeWidgetItem* item, int);
   void slotItemChanged(QTreeWidgetItem* item, int column);
   void slotEditItem();
+  void slotEdit();
   void slotTagItem();
   void slotDeleteItem();
+  void slotDelete();
   void slotBubbleWpt();
   void slotNogoItem();
   void slotDelRadiusWpt();
@@ -117,6 +119,7 @@ class CGisListWks : public QTreeWidget {
   void slotCloseAllProjects();
   void slotGeoSearch(bool on);
   void slotCopyItem();
+  void slotCopy();
   void slotSyncWksDev();
   void slotSyncDevWks();
   void slotRteFromWpt();

--- a/src/qmapshack/helpers/CShortcutSetupDialog.cpp
+++ b/src/qmapshack/helpers/CShortcutSetupDialog.cpp
@@ -19,6 +19,7 @@
 
 #include <QAction>
 #include <QHeaderView>
+#include <QMenu>
 #include <QMessageBox>
 #include <QSignalBlocker>
 
@@ -37,11 +38,15 @@ CShortcutSetupDialog::CShortcutSetupDialog(QWidget* const& parent, CShortcutConf
     QTreeWidgetItem* item = new QTreeWidgetItem(treeActions);
     item->setIcon(eColumnAction, action->icon());
     item->setText(eColumnAction, action->iconText());
+    item->setText(eColumnCategory, actionCategory(action));
     item->setToolTip(eColumnAction, action->toolTip());
     item->setData(eColumnAction, Qt::UserRole, QVariant::fromValue(action));
     setItemShortcut(item, action->shortcut());
   }
   treeActions->sortItems(eColumnAction, Qt::AscendingOrder);
+  treeActions->sortItems(eColumnCategory, Qt::AscendingOrder);
+  treeActions->setSortingEnabled(true);
+  treeActions->header()->setSectionResizeMode(eColumnCategory, QHeaderView::ResizeToContents);
   treeActions->header()->setSectionResizeMode(eColumnAction, QHeaderView::Stretch);
   treeActions->header()->setSectionResizeMode(eColumnShortcut, QHeaderView::ResizeToContents);
   treeActions->header()->setStretchLastSection(false);
@@ -90,6 +95,7 @@ void CShortcutSetupDialog::slotFilterChanged(const QString& text) {
   for (qint32 i = 0; i < treeActions->topLevelItemCount(); i++) {
     QTreeWidgetItem* item = treeActions->topLevelItem(i);
     const bool match = item->text(eColumnAction).contains(text, Qt::CaseInsensitive) ||
+                       item->text(eColumnCategory).contains(text, Qt::CaseInsensitive) ||
                        item->text(eColumnShortcut).contains(text, Qt::CaseInsensitive);
     item->setHidden(!match);
   }
@@ -122,10 +128,17 @@ void CShortcutSetupDialog::slotApplyEditor() {
 
   QTreeWidgetItem* conflict = findConflict(shortcut, item);
   if (conflict != nullptr) {
+    const QString conflictLabel =
+        conflict->text(eColumnCategory).isEmpty()
+            ? conflict->text(eColumnAction)
+            : tr("%1 (%2)").arg(conflict->text(eColumnAction), conflict->text(eColumnCategory));
+    const QString itemLabel = item->text(eColumnCategory).isEmpty()
+                                  ? item->text(eColumnAction)
+                                  : tr("%1 (%2)").arg(item->text(eColumnAction), item->text(eColumnCategory));
     const QMessageBox::StandardButton answer = QMessageBox::question(
         this, tr("Shortcut already in use"),
         tr("The shortcut '%1' is already assigned to '%2'. Do you want to reassign it to '%3'?")
-            .arg(shortcut.toString(QKeySequence::NativeText), conflict->text(eColumnAction), item->text(eColumnAction)),
+            .arg(shortcut.toString(QKeySequence::NativeText), conflictLabel, itemLabel),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
     if (answer == QMessageBox::Yes) {
       setItemShortcut(conflict, QKeySequence());
@@ -176,4 +189,21 @@ void CShortcutSetupDialog::updateEditor(const QTreeWidgetItem* const item) {
   keySequenceEdit->setEnabled(item != nullptr);
   pushDefault->setEnabled(item != nullptr);
   keySequenceEdit->setKeySequence(item != nullptr ? itemShortcut(item) : QKeySequence());
+}
+
+QString CShortcutSetupDialog::actionCategory(const QAction* const action) const {
+  const QVariant tagged = action->property("shortcutCategory");
+  if (tagged.isValid()) {
+    return tagged.toString();
+  }
+  // fall back to the title of the QMenu the action was added to via the .ui file
+  for (QObject* const object : action->associatedObjects()) {
+    const QMenu* const menu = qobject_cast<const QMenu*>(object);
+    if (menu != nullptr) {
+      QString title = menu->title();
+      title.remove('&');
+      return title;
+    }
+  }
+  return QString();
 }

--- a/src/qmapshack/helpers/CShortcutSetupDialog.cpp
+++ b/src/qmapshack/helpers/CShortcutSetupDialog.cpp
@@ -22,6 +22,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QSignalBlocker>
+#include <utility>
 
 #include "helpers/CShortcutConfig.h"
 
@@ -43,6 +44,7 @@ CShortcutSetupDialog::CShortcutSetupDialog(QWidget* const& parent, CShortcutConf
     item->setData(eColumnAction, Qt::UserRole, QVariant::fromValue(action));
     setItemShortcut(item, action->shortcut());
   }
+  // QTreeModel sorts stably, so sorting by action first leaves it as the tiebreak within a category
   treeActions->sortItems(eColumnAction, Qt::AscendingOrder);
   treeActions->sortItems(eColumnCategory, Qt::AscendingOrder);
   treeActions->setSortingEnabled(true);
@@ -83,8 +85,12 @@ void CShortcutSetupDialog::accept() {
 
 void CShortcutSetupDialog::slotButtonClicked(QAbstractButton* button) {
   if (buttonBox->buttonRole(button) == QDialogButtonBox::ResetRole) {
+    QList<QTreeWidgetItem*> items;
     for (qint32 i = 0; i < treeActions->topLevelItemCount(); i++) {
-      QTreeWidgetItem* item = treeActions->topLevelItem(i);
+      items << treeActions->topLevelItem(i);
+    }
+
+    for (QTreeWidgetItem* const item : std::as_const(items)) {
       setItemShortcut(item, config->defaultShortcut(itemAction(item)));
     }
     updateEditor(treeActions->currentItem());
@@ -128,17 +134,10 @@ void CShortcutSetupDialog::slotApplyEditor() {
 
   QTreeWidgetItem* conflict = findConflict(shortcut, item);
   if (conflict != nullptr) {
-    const QString conflictLabel =
-        conflict->text(eColumnCategory).isEmpty()
-            ? conflict->text(eColumnAction)
-            : tr("%1 (%2)").arg(conflict->text(eColumnAction), conflict->text(eColumnCategory));
-    const QString itemLabel = item->text(eColumnCategory).isEmpty()
-                                  ? item->text(eColumnAction)
-                                  : tr("%1 (%2)").arg(item->text(eColumnAction), item->text(eColumnCategory));
     const QMessageBox::StandardButton answer = QMessageBox::question(
         this, tr("Shortcut already in use"),
         tr("The shortcut '%1' is already assigned to '%2'. Do you want to reassign it to '%3'?")
-            .arg(shortcut.toString(QKeySequence::NativeText), conflictLabel, itemLabel),
+            .arg(shortcut.toString(QKeySequence::NativeText), itemLabel(conflict), itemLabel(item)),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
     if (answer == QMessageBox::Yes) {
       setItemShortcut(conflict, QKeySequence());
@@ -155,6 +154,12 @@ void CShortcutSetupDialog::slotApplyEditor() {
 
 QAction* CShortcutSetupDialog::itemAction(const QTreeWidgetItem* const item) const {
   return item->data(eColumnAction, Qt::UserRole).value<QAction*>();
+}
+
+QString CShortcutSetupDialog::itemLabel(const QTreeWidgetItem* const item) const {
+  const QString& category = item->text(eColumnCategory);
+  const QString& action = item->text(eColumnAction);
+  return category.isEmpty() ? action : tr("%1 (%2)").arg(action, category);
 }
 
 QKeySequence CShortcutSetupDialog::itemShortcut(const QTreeWidgetItem* const item) const {

--- a/src/qmapshack/helpers/CShortcutSetupDialog.h
+++ b/src/qmapshack/helpers/CShortcutSetupDialog.h
@@ -41,13 +41,14 @@ class CShortcutSetupDialog : public QDialog, private Ui::IShortcutSetupDialog {
   void slotApplyEditor();
 
  private:
-  enum columns_e { eColumnAction = 0, eColumnShortcut = 1 };
+  enum columns_e { eColumnCategory = 0, eColumnAction = 1, eColumnShortcut = 2 };
 
   QAction* itemAction(const QTreeWidgetItem* const item) const;
   QKeySequence itemShortcut(const QTreeWidgetItem* const item) const;
   void setItemShortcut(QTreeWidgetItem* const item, const QKeySequence& shortcut);
   QTreeWidgetItem* findConflict(const QKeySequence& shortcut, const QTreeWidgetItem* const skip) const;
   void updateEditor(const QTreeWidgetItem* const item);
+  QString actionCategory(const QAction* const action) const;
 
   CShortcutConfig* config;
   /// guards against slotApplyEditor() re-entering itself

--- a/src/qmapshack/helpers/CShortcutSetupDialog.h
+++ b/src/qmapshack/helpers/CShortcutSetupDialog.h
@@ -44,6 +44,7 @@ class CShortcutSetupDialog : public QDialog, private Ui::IShortcutSetupDialog {
   enum columns_e { eColumnCategory = 0, eColumnAction = 1, eColumnShortcut = 2 };
 
   QAction* itemAction(const QTreeWidgetItem* const item) const;
+  QString itemLabel(const QTreeWidgetItem* const item) const;
   QKeySequence itemShortcut(const QTreeWidgetItem* const item) const;
   void setItemShortcut(QTreeWidgetItem* const item, const QKeySequence& shortcut);
   QTreeWidgetItem* findConflict(const QKeySequence& shortcut, const QTreeWidgetItem* const skip) const;

--- a/src/qmapshack/helpers/IShortcutSetupDialog.ui
+++ b/src/qmapshack/helpers/IShortcutSetupDialog.ui
@@ -37,6 +37,11 @@
      </property>
      <column>
       <property name="text">
+       <string>Category</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
        <string>Action</string>
       </property>
      </column>

--- a/src/qmapshack/locale/qmapshack.ts
+++ b/src/qmapshack/locale/qmapshack.ts
@@ -2864,11 +2864,6 @@ You can modify both parameters to customize the behavior of the filter. For the 
 <context>
     <name>CGisListWks</name>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
-        <source>Edit..</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../gis/CGisListWks.cpp" line="115"/>
         <source>Show on Map</source>
         <translation type="unfinished"></translation>
@@ -3122,6 +3117,36 @@ You can modify both parameters to customize the behavior of the filter. For the 
     <message>
         <location filename="../gis/CGisListWks.cpp" line="211"/>
         <source>Change Icon...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8257,6 +8282,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18339,6 +18370,11 @@ If you enter &apos;word&apos; a search with an exact match is done. If you enter
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_ca.ts
+++ b/src/qmapshack/locale/qmapshack_ca.ts
@@ -2890,9 +2890,8 @@ Podeu modificar els dos paràmetres per personalitzar el comportament del filtre
 <context>
     <name>CGisListWks</name>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Edita...</translation>
+        <translation type="vanished">Edita...</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="115"/>
@@ -3149,6 +3148,36 @@ Podeu modificar els dos paràmetres per personalitzar el comportament del filtre
         <location filename="../gis/CGisListWks.cpp" line="211"/>
         <source>Change Icon...</source>
         <translation>Canvia la Icona...</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="775"/>
@@ -8344,6 +8373,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18537,6 +18572,11 @@ Si introduïu &apos;word&apos; es fa una cerca de la paraula exacte. Si introdu�
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_cs.ts
+++ b/src/qmapshack/locale/qmapshack_cs.ts
@@ -2877,9 +2877,8 @@ You can modify both parameters to customize the behavior of the filter. For the 
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Upravit...</translation>
+        <translation type="vanished">Upravit...</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="145"/>
@@ -2981,6 +2980,36 @@ You can modify both parameters to customize the behavior of the filter. For the 
     <message>
         <location filename="../gis/CGisListWks.cpp" line="211"/>
         <source>Change Icon...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8305,6 +8334,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18437,6 +18472,11 @@ Pokud zadáte &apos;slovo&apos;, provede se hledání přesné shody. Pokud zad�
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_de.ts
+++ b/src/qmapshack/locale/qmapshack_de.ts
@@ -2912,9 +2912,8 @@ Sie könne beide Parameter ändern, um den Filter anzupassen. Für den Abstand s
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Bearbeiten..</translation>
+        <translation type="vanished">Bearbeiten..</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="120"/>
@@ -3078,6 +3077,36 @@ Sie könne beide Parameter ändern, um den Filter anzupassen. Für den Abstand s
         <location filename="../gis/CGisListWks.cpp" line="211"/>
         <source>Change Icon...</source>
         <translation>Symbol ändern...</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation>Arbeitsplatz: Projekt</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation>Arbeitsplatz: Element</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation>Arbeitsplatz: Track</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation>Arbeitsplatz: Wegpunkt</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation>Arbeitsplatz: Route</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
+        <translation>Arbeitsplatz: Gebiet</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="652"/>
@@ -8519,6 +8548,12 @@ Abgebrochen durch den Benutzer.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18786,6 +18821,11 @@ Wenn Sie das Wort &apos;wort&apos; eingeben, wird exakt nach dem Wort gesucht. W
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
         <translation>Aktionen filtern...</translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
+        <translation>Kategorie</translation>
     </message>
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>

--- a/src/qmapshack/locale/qmapshack_es.ts
+++ b/src/qmapshack/locale/qmapshack_es.ts
@@ -2898,9 +2898,8 @@ Se pueden modificar ambos parámetros para personalizar el comportamiento. Para 
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Editar..</translation>
+        <translation type="vanished">Editar..</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="145"/>
@@ -3002,6 +3001,36 @@ Se pueden modificar ambos parámetros para personalizar el comportamiento. Para 
     <message>
         <location filename="../gis/CGisListWks.cpp" line="211"/>
         <source>Change Icon...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8382,6 +8411,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18574,6 +18609,11 @@ Si se introduce la &apos;palabra&apos; entre apostrofes se busca una coincidenci
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_fr.ts
+++ b/src/qmapshack/locale/qmapshack_fr.ts
@@ -2892,9 +2892,8 @@ Il est possible de personnaliser ces deux paramètres. Il est conseillé de choi
 <context>
     <name>CGisListWks</name>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Éditer..</translation>
+        <translation type="vanished">Éditer..</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="115"/>
@@ -3149,6 +3148,36 @@ Il est possible de personnaliser ces deux paramètres. Il est conseillé de choi
         <location filename="../gis/CGisListWks.cpp" line="202"/>
         <source>Edit Area Points</source>
         <translation>Éditer les points de la surface</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="1004"/>
@@ -8329,6 +8358,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18497,6 +18532,11 @@ Si vous entrez &apos;mot&apos; alors &apos;mot&apos; uniquement sera recherché.
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_hr.ts
+++ b/src/qmapshack/locale/qmapshack_hr.ts
@@ -2891,9 +2891,8 @@ Možeš izmijeniti oba parametra kako biste prilagodili ponašanje filtera. Za u
 <context>
     <name>CGisListWks</name>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Uredi...</translation>
+        <translation type="vanished">Uredi...</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="115"/>
@@ -3150,6 +3149,36 @@ Možeš izmijeniti oba parametra kako biste prilagodili ponašanje filtera. Za u
         <location filename="../gis/CGisListWks.cpp" line="211"/>
         <source>Change Icon...</source>
         <translation>Promijeni Ikonu...</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="775"/>
@@ -8348,6 +8377,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18505,6 +18540,11 @@ Ako unesete &apos;riječ&apos;, pretraga se vrši s točnim podudaranjem. Ako un
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_it.ts
+++ b/src/qmapshack/locale/qmapshack_it.ts
@@ -2896,10 +2896,9 @@ Questo filtro è progettato per rilevare e nascondere i nodi che soddisfano ques
 <context>
     <name>CGisListWks</name>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
         <translatorcomment>L&apos;originale con .. mi sembra errato</translatorcomment>
-        <translation>Modifica...</translation>
+        <translation type="vanished">Modifica...</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="115"/>
@@ -3155,6 +3154,36 @@ Questo filtro è progettato per rilevare e nascondere i nodi che soddisfano ques
         <location filename="../gis/CGisListWks.cpp" line="202"/>
         <source>Edit Area Points</source>
         <translation>Modifica punti dell&apos;area</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="1004"/>
@@ -8343,6 +8372,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18529,6 +18564,11 @@ Una parola viene cercata come corrispondenza (come fosse &apos;*qualcosacosa*&ap
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_nl.ts
+++ b/src/qmapshack/locale/qmapshack_nl.ts
@@ -2876,9 +2876,8 @@ You can modify both parameters to customize the behavior of the filter. For the 
 <context>
     <name>CGisListWks</name>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Bewerken..</translation>
+        <translation type="vanished">Bewerken..</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="115"/>
@@ -3133,6 +3132,36 @@ You can modify both parameters to customize the behavior of the filter. For the 
         <location filename="../gis/CGisListWks.cpp" line="202"/>
         <source>Edit Area Points</source>
         <translation>Bewerk gebied punten</translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="1004"/>
@@ -8318,6 +8347,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18421,6 +18456,11 @@ If you enter &apos;word&apos; a search with an exact match is done. If you enter
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qmapshack/locale/qmapshack_ru.ts
+++ b/src/qmapshack/locale/qmapshack_ru.ts
@@ -2899,9 +2899,8 @@ You can modify both parameters to customize the behavior of the filter. For the 
 <context>
     <name>CGisListWks</name>
     <message>
-        <location filename="../gis/CGisListWks.cpp" line="113"/>
         <source>Edit..</source>
-        <translation>Изменить..</translation>
+        <translation type="vanished">Изменить..</translation>
     </message>
     <message>
         <location filename="../gis/CGisListWks.cpp" line="115"/>
@@ -3022,6 +3021,36 @@ You can modify both parameters to customize the behavior of the filter. For the 
     <message>
         <location filename="../gis/CGisListWks.cpp" line="211"/>
         <source>Change Icon...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="241"/>
+        <source>Workspace: Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="245"/>
+        <source>Workspace: Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="246"/>
+        <source>Workspace: Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="249"/>
+        <source>Workspace: Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="252"/>
+        <source>Workspace: Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gis/CGisListWks.cpp" line="254"/>
+        <source>Workspace: Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8352,6 +8381,12 @@ Canceled by user&apos;s request.
 </context>
 <context>
     <name>CShortcutSetupDialog</name>
+    <message>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="134"/>
+        <location filename="../helpers/CShortcutSetupDialog.cpp" line="137"/>
+        <source>%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../helpers/CShortcutSetupDialog.cpp" line="126"/>
         <source>Shortcut already in use</source>
@@ -18559,6 +18594,11 @@ If you enter &apos;word&apos; a search with an exact match is done. If you enter
     <message>
         <location filename="../helpers/IShortcutSetupDialog.ui" line="20"/>
         <source>Filter actions...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers/IShortcutSetupDialog.ui" line="40"/>
+        <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-1166

### What you have done:
Improve custom keyboard shortcuts:

* actions from context menus can now also be assigned keyboard shortcuts
* consolidate some actions which have the same label but are placed on different objects. This allows us to assign a single keyboard shortcut to them
  * Edit
  * Copy to
  * Delete
  * Toggle NoGo-Line
  * Toggle NoGo-Area
* group actions by category so that the user can better identify the correct action


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open QMapshack
2. Assign a custom keyboard shortcut to some actions
3. Press the keybord shortcut

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt

