### PR TITLE
[QMS-1182] Fix: Name of Qt style passed to QMS gets lost

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ V1.XX.X
 [QMS-1173] Fix: QMS on macOS is not dark mode aware
 [QMS-1177] Show "style" option in QMS usage
 [QMS-1179] Modernize the CMake build
+[QMS-1182] Fix: Name of Qt style passed to QMS gets lost
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -347,7 +347,8 @@ CMainWindow::CMainWindow() : id(QRandomGenerator::global()->generate()) {
   }
 
 #if defined(Q_OS_MAC)
-  if (QString::compare(qApp->style()->name(), "macOS", Qt::CaseInsensitive) == 0) {
+  const QProxyStyle* qmsStyle = (QProxyStyle*)qApp->style();
+  if (QString::compare(qmsStyle->baseStyle()->name(), "macOS", Qt::CaseInsensitive) == 0) {
     // we must get rid of style sheet file due to dark mode awareness:
     // adjust toolbar height and icon size of default style "macOS"
     // to toolbar height and icon size of style "Fusion" instead

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -58,9 +58,11 @@ int main(int argc, char** argv) {
   // useful debug info
   {
     qDebug().nospace() << "Qt versions: " << "build=" << QT_VERSION_STR << ", runtime=" << qVersion();
+    const QProxyStyle* qmsStyle = (QProxyStyle*)qApp->style();
+    qDebug() << "Qt style:" << qmsStyle->baseStyle()->name();
     QString argList("");
     for (int i = 1; i < argCnt; i++) {
-      argList += " \"" % QString::fromLocal8Bit(argVal[i]) % "\"";
+      argList += " \"" % QString::fromUtf8(argVal[i]) % "\"";
     }
     qDebug() << "Executable path:" << QFileInfo(argVal[0]).absoluteFilePath();
     qDebug().noquote().nospace() << "Argument list:" << argList;
@@ -68,7 +70,6 @@ int main(int argc, char** argv) {
     qDebug() << "Configuration path:" << cfg.fileName();
   }
   delete[] argVal;
-  qDebug() << "Qt style:" << qApp->style()->name();
 
   env->initQMapShack();
 

--- a/src/qmaptool/main.cpp
+++ b/src/qmaptool/main.cpp
@@ -57,9 +57,11 @@ int main(int argc, char** argv) {
   // useful debug info
   {
     qDebug().nospace() << "Qt versions: " << "build=" << QT_VERSION_STR << ", runtime=" << qVersion();
+    const QProxyStyle* qmsStyle = (QProxyStyle*)qApp->style();
+    qDebug() << "Qt style:" << qmsStyle->baseStyle()->name();
     QString argList("");
     for (int i = 1; i < argCnt; i++) {
-      argList += " \"" % QString::fromLocal8Bit(argVal[i]) % "\"";
+      argList += " \"" % QString::fromUtf8(argVal[i]) % "\"";
     }
     qDebug() << "Executable path:" << QFileInfo(argVal[0]).absoluteFilePath();
     qDebug().noquote().nospace() << "Argument list:" << argList;
@@ -67,7 +69,6 @@ int main(int argc, char** argv) {
     qDebug() << "Configuration path:" << cfg.fileName();
   }
   delete[] argVal;
-  qDebug() << "Qt style:" << qApp->style()->name();
 
   env.initQMapTool();
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1182

### What you have done:
[comment]: # (Describe roughly.)

Replaced
`qApp->style()->name();`
by
```
QProxyStyle* proxyStyle = (QProxyStyle*)qApp->style();
proxyStyle->baseStyle()->name(); 
```

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Run QMS with parameters  `--debug --style fusion`
2. See debug output of kind `[debug] Qt style: "fusion"`

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
