### PR TITLE
[QMS-1179] Fix: Windows find modules define no imported targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,14 @@ Target-scoped CMake. Nothing is set at directory scope except the MSVC options b
   directory on Windows, where `CAppSetupWin` resolves `HELPPATH` against it. Six cache variables
   survive so a packager can override them. `HTML_INSTALL_DIR` is `share/doc/HTML`, not
   `CMAKE_INSTALL_DOCDIR` — changing it moves the installed help.
-- **`CMAKE_RUNTIME_OUTPUT_DIRECTORY` pins the four per-config variables too**, or a multi-config
-  generator appends `Release/` and the macOS and Windows packaging scripts stop finding the binaries.
+- **`CMAKE_RUNTIME_OUTPUT_DIRECTORY` is set, the four per-config variables are deliberately not.**
+  They are the only thing a multi-config generator consults for its `$<CONFIG>` suffix, so pinning
+  them collapses every configuration into one `bin`, which leaves a `.pdb` from the previous
+  configuration beside a mismatched `.exe` and makes the build report the other config's binary as
+  up to date. `msvc_64/CopyFilesGis.bat` reads `bin\Release\` and wants the suffix. Single-config
+  generators resolve the per-config variable to the same path as the plain one, so Linux and the
+  macOS release path (`build-QMS.sh` uses `Unix Makefiles`; its Xcode branch is marked BROKEN and
+  exits before bundling) are flat whatever the build type.
 - **`ConfigureChecks.cmake` probes through the C++ compiler.** The project enables no C language, so
   `check_include_file` / `check_symbol_exists` hard-fail; use the `_cxx` variants.
 - **`CMAKE_AUTOUIC` is OFF** — the `.ui` files are listed explicitly and go through `qt_wrap_ui`.
@@ -519,6 +525,16 @@ before doing anything. Only a commit carrying LF blobs fixes it.
 
 When the local branch is a strict ancestor of the incoming one and the only dirt is that CR churn,
 the merge is a fast-forward blocked by nothing real: `git reset --hard <remote>/<branch>`.
+
+The same trap runs the other way for `*.bat`/`*.cmd` (`text eol=crlf`): a blob committed with CRLF
+before the attribute existed reports permanently modified, because git normalises the working-tree
+copy to LF and compares against the CRLF blob. `git checkout` and `git stash` — including
+`rebase --autostash`, which leaves a half-built `.git/rebase-merge/` behind when it fails — cannot
+clear it. To rebase without committing anything, put `<path> -text` in `.git/info/attributes`
+(local, untracked, beats the tracked `.gitattributes`), rebase, delete it, then
+`rm <path> && git checkout -- <path>` so the file is re-materialised with the attribute's endings.
+`git ls-files --eol '*.bat'` lists the offenders: `i/crlf` is a blob still awaiting
+`git add --renormalize`. `msvc_64/build_routino.bat` is one.
 
 ### Nothing that stores an icon path may be pruned
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,11 @@ if(WIN32)
     list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/msvc_64/cmake)
 endif()
 
-# all binaries are collected in the ./bin directory
+# All binaries are collected in the ./bin directory. A multi-config generator appends the
+# configuration to it, which is what msvc_64/CopyFilesGis.bat reads and what keeps a .pdb with the
+# .exe it belongs to. Single-config generators ignore the per-config variables, so Linux and the
+# macOS release build get a flat bin whatever the build type.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
-# A multi-config generator would otherwise append a per-config subdirectory.
-foreach(config IN ITEMS DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${config} ${PROJECT_BINARY_DIR}/bin)
-endforeach()
 
 # Position independent code is needed for the static icon engine plugin.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,10 @@ include(FetchContent)
 ###############################################################################################
 # Get Blend2D and it's dependency AsmJit
 ###############################################################################################
+# Both are cloned by FetchContent. Fail here with a clear message instead of deep inside the
+# populate sub-build if git is not on the PATH. Set GIT_EXECUTABLE if it is elsewhere.
+find_package(Git REQUIRED)
+
 # asmjit does not do official releases so pinned it to what was HEAD at time of writing this
 set(ASMJIT_GIT_TAG  "0bd5787b54b575ed94bf32ac452153b34385c514" CACHE STRING "AsmJit git revision to fetch")
 # blend2d does releases but not set git tags; the commit set here referese to release v0.21.2

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,12 +34,9 @@
       }
     },
     {
-      "name": "windows-msvc",
-      "displayName": "Windows MSVC 2022 x64",
-      "description": "Edit the paths to match the local dependency tree, or override them in CMakeUserPresets.json.",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Visual Studio 17 2022",
-      "architecture": "x64",
+      "name": "windows-base",
+      "hidden": true,
+      "inherits": "base",
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
       "cacheVariables": {
         "QT_DEV_PATH": "C:/Qt/6.8.0/msvc2022_64",
@@ -48,6 +45,14 @@
         "ROUTINO_DEV_PATH": "C:/routino",
         "JPEG_DEV_PATH": "C:/JPEG"
       }
+    },
+    {
+      "name": "windows-msvc",
+      "inherits": "windows-base",
+      "displayName": "Windows MSVC 2022 x64",
+      "description": "Edit the paths to match the local dependency tree, or override them in CMakeUserPresets.json. Inherit windows-base instead of this preset to keep the paths but pick another generator - architecture is set here because Ninja rejects it.",
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64"
     },
     {
       "name": "macos",

--- a/msvc_64/cmake/FindGDAL.cmake
+++ b/msvc_64/cmake/FindGDAL.cmake
@@ -1,99 +1,53 @@
-# - Try to find GDAL
-# Once done this will define
+# Find GDAL. Windows only - this module is on CMAKE_MODULE_PATH under WIN32 alone and shadows
+# CMake's own FindGDAL, which does not know the GDAL_DEV_PATH layout.
 #
-#  GDAL_FOUND - system has GDAL
-#  GDAL_INCLUDE_DIRS - the GDAL include directory
-#  GDAL_LIBRARIES - Link these to use GDAL
-#  GDAL_DEFINITIONS - Compiler switches required for using GDAL
+#  GDAL_FOUND    - GDAL was found
+#  GDAL_VERSION  - version read from gdal_version.h
+#  GDAL::GDAL    - imported target carrying the library and its include directory
 #
 #  Copyright (c) 2006 Andreas Schneider <mail@cynapses.org>
 #
 #  Redistribution and use is allowed according to the terms of the New
 #  BSD license.
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
-#
 
-
-if (GDAL_LIBRARIES AND GDAL_INCLUDE_DIRS)
-  # in cache already
-  set(GDAL_FOUND TRUE)
-else (GDAL_LIBRARIES AND GDAL_INCLUDE_DIRS)
-  find_path(GDAL_INCLUDE_DIR
-    NAMES
-      gdal.h
-    PATHS
-if(WIN32)	
-      ${GDAL_DEV_PATH}/include
-endif(WIN32)
-        /usr/include
-        /usr/local/include
-        /opt/local/include
-        /sw/include
-        ${CMAKE_INSTALL_PREFIX}/include
-        /usr/include/gdal
-        /usr/local/include/gdal
-        /opt/local/include/gdal
-        /sw/include/gdal
-        ${CMAKE_INSTALL_PREFIX}/include/gdal
-        ${CMAKE_SOURCE_DIR}/Win32/GDAL/include
-    PATH_SUFFIXES
-        gdal
-  )
-
-  # debian uses version suffixes
-  # add suffix evey new release
-  find_library(GDAL_LIBRARY
-    NAMES
-        gdal
-        gdal1.3.2
-        gdal1.4.0
-        gdal1.5.0
-        gdal1.6.0
-        gdal1.7.0
-	gdal1.8.0
-        gdal
-        gdal_i
-    PATHS
-if(WIN32)	
-      ${GDAL_DEV_PATH}/lib
-endif(WIN32)
-      /usr/lib
-      /usr/local/lib
-      /opt/local/lib
-      /sw/lib
-      ${CMAKE_INSTALL_PREFIX}/lib
-      ${CMAKE_SOURCE_DIR}/Win32/GDAL/lib
-  )
-
-  set(GDAL_INCLUDE_DIRS
-    ${GDAL_INCLUDE_DIR}
-  )
-  set(GDAL_LIBRARIES
-    ${GDAL_LIBRARY}
+# The cache variable names match CMake's own FindGDAL, so a packager can override them the same way.
+find_path(GDAL_INCLUDE_DIR
+    NAMES gdal.h
+    HINTS ${GDAL_DEV_PATH}/include
+    PATH_SUFFIXES gdal
 )
 
-  if (GDAL_INCLUDE_DIRS AND GDAL_LIBRARIES)
-     set(GDAL_FOUND TRUE)
-     file(READ "${GDAL_INCLUDE_DIR}/gdal_version.h" GDAL_H_CONTENTS)
-     string(REGEX REPLACE "^.*GDAL_VERSION_MAJOR +([0-9]+).*$" "\\1" GDAL_VERSION_MAJOR "${GDAL_H_CONTENTS}")
-     string(REGEX REPLACE "^.*GDAL_VERSION_MINOR +([0-9]+).*$" "\\1" GDAL_VERSION_MINOR "${GDAL_H_CONTENTS}")
-     string(REGEX REPLACE "^.*GDAL_VERSION_REV +([0-9]+).*$" "\\1" GDAL_VERSION_REV "${GDAL_H_CONTENTS}")
-     unset(GDAL_H_CONTENTS)
-     set(GDAL_VERSION "${GDAL_VERSION_MAJOR}.${GDAL_VERSION_MINOR}.${GDAL_VERSION_REV}")
-  endif (GDAL_INCLUDE_DIRS AND GDAL_LIBRARIES)
+# gdal_i is the import library the GISInternals binary distribution ships.
+find_library(GDAL_LIBRARY
+    NAMES gdal gdal_i
+    HINTS ${GDAL_DEV_PATH}/lib
+)
 
-  if (GDAL_FOUND)
-    if (NOT GDAL_FIND_QUIETLY)
-      message(STATUS "Found GDAL: ${GDAL_LIBRARIES}")
-    endif (NOT GDAL_FIND_QUIETLY)
-  else (GDAL_FOUND)
-    if (GDAL_FIND_REQUIRED)
-      message(FATAL_ERROR "Could not find GDAL")
-    endif (GDAL_FIND_REQUIRED)
-  endif (GDAL_FOUND)
+if(GDAL_INCLUDE_DIR AND EXISTS "${GDAL_INCLUDE_DIR}/gdal_version.h")
+    file(READ "${GDAL_INCLUDE_DIR}/gdal_version.h" _gdal_version_h)
+    string(REGEX REPLACE "^.*GDAL_VERSION_MAJOR +([0-9]+).*$" "\\1" _gdal_version_major "${_gdal_version_h}")
+    string(REGEX REPLACE "^.*GDAL_VERSION_MINOR +([0-9]+).*$" "\\1" _gdal_version_minor "${_gdal_version_h}")
+    string(REGEX REPLACE "^.*GDAL_VERSION_REV +([0-9]+).*$" "\\1" _gdal_version_rev "${_gdal_version_h}")
+    set(GDAL_VERSION "${_gdal_version_major}.${_gdal_version_minor}.${_gdal_version_rev}")
+    unset(_gdal_version_h)
+    unset(_gdal_version_major)
+    unset(_gdal_version_minor)
+    unset(_gdal_version_rev)
+endif()
 
-  # show the GDAL_INCLUDE_DIRS and GDAL_LIBRARIES variables only in the advanced view
-  mark_as_advanced(GDAL_INCLUDE_DIRS GDAL_LIBRARIES)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GDAL
+    REQUIRED_VARS GDAL_LIBRARY GDAL_INCLUDE_DIR
+    VERSION_VAR GDAL_VERSION
+)
 
-endif (GDAL_LIBRARIES AND GDAL_INCLUDE_DIRS)
+if(GDAL_FOUND AND NOT TARGET GDAL::GDAL)
+    add_library(GDAL::GDAL UNKNOWN IMPORTED)
+    set_target_properties(GDAL::GDAL PROPERTIES
+        IMPORTED_LOCATION "${GDAL_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${GDAL_INCLUDE_DIR}"
+    )
+endif()
 
+# Deliberately not mark_as_advanced: on Windows both are routinely set by hand in ccmake.

--- a/msvc_64/cmake/FindJPEG.cmake
+++ b/msvc_64/cmake/FindJPEG.cmake
@@ -1,91 +1,37 @@
-# - Try to find LIBJPEG
-# Once done this will define
+# Find libjpeg. Windows only - this module is on CMAKE_MODULE_PATH under WIN32 alone and shadows
+# CMake's own FindJPEG, which does not know the JPEG_DEV_PATH layout.
 #
-#  JPEG_FOUND - system has LIBJPEG
-#  JPEG_INCLUDE_DIRS - the LIBJPEG include directory
-#  JPEG_LIBRARIES - Link these to use LIBJPEG
-#  JPEG_DEFINITIONS - Compiler switches required for using LIBJPEG
+#  JPEG_FOUND  - libjpeg was found
+#  JPEG::JPEG  - imported target carrying the library and its include directory
 #
 #  Copyright (c) 2009 Andreas Schneider <mail@cynapses.org>
 #
 #  Redistribution and use is allowed according to the terms of the New
 #  BSD license.
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
-#
 
-# NOTE: For Windows, please adapt the path (currently E:/qlgt/tools/libjpeg/win32)
-#   to your local installation directory
+find_path(JPEG_INCLUDE_DIR
+    NAMES jpeglib.h
+    HINTS ${JPEG_DEV_PATH}/include
+)
 
-if (JPEG_LIBRARIES AND JPEG_INCLUDE_DIRS)
-  # in cache already
-  set(JPEG_FOUND TRUE)
-else (JPEG_LIBRARIES AND JPEG_INCLUDE_DIRS)
+# LIBJPEG_LIBRARY, not JPEG_LIBRARY: the name predates this module and packagers set it by hand.
+find_library(LIBJPEG_LIBRARY
+    NAMES libjpeg jpeg
+    HINTS ${JPEG_DEV_PATH}/lib
+)
 
-  find_path(JPEG_INCLUDE_DIR
-    NAMES
-      jpeglib.h
-    PATHS
-if(WIN32)
-        ${JPEG_DEV_PATH}/include
-endif(WIN32)
-        /usr/include
-        /usr/local/include
-        /opt/local/include
-        /sw/include
-        ${CMAKE_SOURCE_DIR}/Win32/JPEG/include
-  )
-  mark_as_advanced(JPEG_INCLUDE_DIR)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(JPEG
+    REQUIRED_VARS LIBJPEG_LIBRARY JPEG_INCLUDE_DIR
+)
 
-  find_library(LIBJPEG_LIBRARY
-    NAMES
-if (WIN32)
-        libjpeg
-else (WIN32)
-        jpeg
-endif (WIN32)
-    PATHS
-if(WIN32)
-        ${JPEG_DEV_PATH}/lib
-endif(WIN32)
-        /usr/lib
-        /usr/local/lib
-        /opt/local/lib
-        /sw/lib
-        ${CMAKE_SOURCE_DIR}/Win32/JPEG/lib
-  )
-  mark_as_advanced(LIBJPEG_LIBRARY)
-
-  if (LIBJPEG_LIBRARY)
-    set(LIBJPEG_FOUND TRUE)
-  endif (LIBJPEG_LIBRARY)
-
-  set(JPEG_INCLUDE_DIRS
-    ${JPEG_INCLUDE_DIR}
-  )
-
-  if (LIBJPEG_FOUND)
-    set(JPEG_LIBRARIES
-      ${JPEG_LIBRARIES}
-      ${LIBJPEG_LIBRARY}
+if(JPEG_FOUND AND NOT TARGET JPEG::JPEG)
+    add_library(JPEG::JPEG UNKNOWN IMPORTED)
+    set_target_properties(JPEG::JPEG PROPERTIES
+        IMPORTED_LOCATION "${LIBJPEG_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${JPEG_INCLUDE_DIR}"
     )
-  endif (LIBJPEG_FOUND)
+endif()
 
-  if (JPEG_INCLUDE_DIRS AND JPEG_LIBRARIES)
-     set(JPEG_FOUND TRUE)
-  endif (JPEG_INCLUDE_DIRS AND JPEG_LIBRARIES)
-
-  if (JPEG_FOUND)
-    if (NOT JPEG_FIND_QUIETLY)
-      message(STATUS "Found LIBJPEG: ${JPEG_LIBRARIES}")
-    endif (NOT JPEG_FIND_QUIETLY)
-  else (JPEG_FOUND)
-    if (JPEG_FIND_REQUIRED)
-      message(FATAL_ERROR "Could not find LIBJPEG")
-    endif (JPEG_FIND_REQUIRED)
-  endif (JPEG_FOUND)
-
-  # show the JPEG_INCLUDE_DIRS and JPEG_LIBRARIES variables only in the advanced view
-  mark_as_advanced(JPEG_INCLUDE_DIRS JPEG_LIBRARIES)
-
-endif (JPEG_LIBRARIES AND JPEG_INCLUDE_DIRS)
-
+mark_as_advanced(JPEG_INCLUDE_DIR LIBJPEG_LIBRARY)

--- a/msvc_64/cmake/FindPROJ.cmake
+++ b/msvc_64/cmake/FindPROJ.cmake
@@ -1,100 +1,53 @@
-# - Try to find PROJ
-# Once done this will define
+# Find PROJ. Windows only - this module is on CMAKE_MODULE_PATH under WIN32 alone and shadows
+# the PROJ config package, which the binary distributions do not ship.
 #
-#  PROJ_FOUND - system has PROJ
-#  PROJ_INCLUDE_DIRS - the PROJ include directory
-#  PROJ_LIBRARIES - Link these to use PROJ
-#  PROJ_DEFINITIONS - Compiler switches required for using PROJ
+#  PROJ_FOUND    - PROJ was found
+#  PROJ_VERSION  - version read from proj.h
+#  PROJ::proj    - imported target carrying the library and its include directory
 #
 #  Copyright (c) 2009 Andreas Schneider <mail@cynapses.org>
 #
 #  Redistribution and use is allowed according to the terms of the New
 #  BSD license.
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
-#
 
+find_path(PROJ_INCLUDE_DIR
+    NAMES proj.h
+    HINTS ${PROJ_DEV_PATH}/include
+    PATH_SUFFIXES proj4
+)
 
-if (PROJ_LIBRARIES AND PROJ_INCLUDE_DIRS)
-  # in cache already
-  set(PROJ_FOUND TRUE)
-else (PROJ_LIBRARIES AND PROJ_INCLUDE_DIRS)
+# LIBPROJ_LIBRARY, not PROJ_LIBRARY: the name predates this module and packagers set it by hand.
+# The proj_6_* names cover older binary distributions that carried the version in the file name.
+find_library(LIBPROJ_LIBRARY
+    NAMES proj proj_6_0 proj_6_1 proj_6_2 proj_6_3
+    HINTS ${PROJ_DEV_PATH}/lib
+)
 
-  find_path(PROJ_INCLUDE_DIR
-    NAMES
-      proj.h
-    PATHS
-if(WIN32)
-      ${PROJ_DEV_PATH}/include
-endif(WIN32)
-        /usr/include
-        /usr/local/include
-        /opt/local/include
-        /sw/include
-        ${CMAKE_INSTALL_PREFIX}/include
-        ${CMAKE_SOURCE_DIR}/Win32/GDAL/include
-    PATH_SUFFIXES
-        proj4
+if(PROJ_INCLUDE_DIR AND EXISTS "${PROJ_INCLUDE_DIR}/proj.h")
+    file(READ "${PROJ_INCLUDE_DIR}/proj.h" _proj_h)
+    string(REGEX REPLACE "^.*PROJ_VERSION_MAJOR +([0-9]+).*$" "\\1" _proj_version_major "${_proj_h}")
+    string(REGEX REPLACE "^.*PROJ_VERSION_MINOR +([0-9]+).*$" "\\1" _proj_version_minor "${_proj_h}")
+    string(REGEX REPLACE "^.*PROJ_VERSION_PATCH +([0-9]+).*$" "\\1" _proj_version_patch "${_proj_h}")
+    set(PROJ_VERSION "${_proj_version_major}.${_proj_version_minor}.${_proj_version_patch}")
+    unset(_proj_h)
+    unset(_proj_version_major)
+    unset(_proj_version_minor)
+    unset(_proj_version_patch)
+endif()
 
-  )
-  #mark_as_advanced(PROJ_INCLUDE_DIR)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PROJ
+    REQUIRED_VARS LIBPROJ_LIBRARY PROJ_INCLUDE_DIR
+    VERSION_VAR PROJ_VERSION
+)
 
-  find_library(LIBPROJ_LIBRARY
-    NAMES
-        proj
-        proj_6_0
-        proj_6_1
-        proj_6_2
-        proj_6_3
-    PATHS
-if(WIN32)
-      ${PROJ_DEV_PATH}/lib
-endif(WIN32)
-        /usr/lib
-        /usr/local/lib
-        /opt/local/lib
-        /sw/lib
-        ${CMAKE_INSTALL_PREFIX}/lib
-        ${CMAKE_SOURCE_DIR}/Win32/GDAL/lib
-  )
-  #mark_as_advanced(LIBPROJ_LIBRARY)
-
-  if (LIBPROJ_LIBRARY)
-    set(LIBPROJ_FOUND TRUE)
-  endif (LIBPROJ_LIBRARY)
-
-  set(PROJ_INCLUDE_DIRS
-    ${PROJ_INCLUDE_DIR}
-  )
-
-  if (LIBPROJ_FOUND)
-    set(PROJ_LIBRARIES
-      ${PROJ_LIBRARIES}
-      ${LIBPROJ_LIBRARY}
+if(PROJ_FOUND AND NOT TARGET PROJ::proj)
+    add_library(PROJ::proj UNKNOWN IMPORTED)
+    set_target_properties(PROJ::proj PROPERTIES
+        IMPORTED_LOCATION "${LIBPROJ_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${PROJ_INCLUDE_DIR}"
     )
-  endif (LIBPROJ_FOUND)
+endif()
 
-  if (PROJ_INCLUDE_DIRS AND PROJ_LIBRARIES)
-     set(PROJ_FOUND TRUE)
-     file(READ "${PROJ_INCLUDE_DIR}/proj.h" PROJ_H_CONTENTS)
-     string(REGEX REPLACE "^.*PROJ_VERSION_MAJOR +([0-9]+).*$" "\\1" PROJ_VERSION_MAJOR "${PROJ_H_CONTENTS}")
-     string(REGEX REPLACE "^.*PROJ_VERSION_MINOR +([0-9]+).*$" "\\1" PROJ_VERSION_MINOR "${PROJ_H_CONTENTS}")
-     string(REGEX REPLACE "^.*PROJ_VERSION_PATCH +([0-9]+).*$" "\\1" PROJ_VERSION_PATCH "${PROJ_H_CONTENTS}")
-     unset(PROJ_H_CONTENTS)
-     set(PROJ_VERSION "${PROJ_VERSION_MAJOR}.${PROJ_VERSION_MINOR}.${PROJ_VERSION_PATCH}")
-  endif (PROJ_INCLUDE_DIRS AND PROJ_LIBRARIES)
-
-  if (PROJ_FOUND)
-    if (NOT PROJ_FIND_QUIETLY)
-      message(STATUS "Found PROJ: ${PROJ_LIBRARIES}")
-    endif (NOT PROJ_FIND_QUIETLY)
-  else (PROJ_FOUND)
-    if (PROJ_FIND_REQUIRED)
-      message(FATAL_ERROR "Could not find PROJ")
-    endif (PROJ_FIND_REQUIRED)
-  endif (PROJ_FOUND)
-
-  # show the PROJ_INCLUDE_DIRS and PROJ_LIBRARIES variables only in the advanced view
-  #mark_as_advanced(PROJ_INCLUDE_DIRS PROJ_LIBRARIES)
-
-endif (PROJ_LIBRARIES AND PROJ_INCLUDE_DIRS)
-
+# Deliberately not mark_as_advanced: on Windows both are routinely set by hand in ccmake.

--- a/src/qmapshack/CMakeLists.txt
+++ b/src/qmapshack/CMakeLists.txt
@@ -952,6 +952,12 @@ if(WIN32)
 endif()
 qt_add_executable(${APPLICATION_NAME} WIN32 ${MAININP} ${ICON})
 
+# CWptIconManager::init() is one huge initializer list. GCC's variable tracking exceeds its size
+# limit on it and notes that it retries without -fvar-tracking-assignments. Drop the pass for that
+# file; the coarser debug info costs nothing on a plain table of icon definitions.
+set_source_files_properties(helpers/CWptIconManager.cpp PROPERTIES
+    COMPILE_OPTIONS $<$<CXX_COMPILER_ID:GNU>:-fno-var-tracking-assignments>)
+
 target_include_directories(${APPLICATION_NAME} PRIVATE . ../common)
 # SYSTEM prevents warnings from non-QMS headers.
 target_include_directories(${APPLICATION_NAME} SYSTEM PRIVATE


### PR DESCRIPTION
msvc_64/cmake shadows CMake's FindGDAL/FindJPEG and the PROJ config package on WIN32. Its modules set variables only, so every Windows target failed to generate with "links to: GDAL::GDAL but the target was not found". Rewritten in the FindROUTINO style.

Cache variable names, the PROJ name list and the version regexes are unchanged. The GISInternals layout is untested here and needs a real MSVC build.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1179

also see discussion in PR #1181 

### What you have done:
[comment]: # (Describe roughly.)

Adjust cmake files for msvc64 build

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Test if it builds

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
