### PR TITLE
[QMS-1186] Fix: Windows executables are no longer UTF-8 aware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if(MSVC)
     add_compile_options(/MP /utf-8)
     # Add manifest to run exe with code page UTF-8
     set(MANIFEST "${PROJECT_SOURCE_DIR}/msvc_64/codepage.UTF8.manifest")
-    add_link_options(/MANIFESTINPUT:${MANIFEST})
+    add_link_options(/MANIFEST:EMBED /MANIFESTINPUT:${MANIFEST})
 endif(MSVC)
 
 if(UNIX)

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ V1.XX.X
 [QMS-1177] Show "style" option in QMS usage
 [QMS-1179] Modernize the CMake build
 [QMS-1182] Fix: Name of Qt style passed to QMS gets lost
+[QMS-1186] Fix: Windows executables are no longer UTF-8 aware
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1186

### What you have done:
[comment]: # (Describe roughly.)

Added Windows linker directive `/MANIFEST:EMBED` to file _CMakeLists.txt_.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Build Windows executables
2. See that MANIFEST required for UTF-8 are embedded again

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
