### PR TITLE
[QMS-1185] Fix: Tools docker cannot be shown again in QMapTool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,6 +574,14 @@ the SVG at size rather than wrap the old 32px PNG.
 
 ---
 
+## Dock widgets
+
+`QDockWidget::setFeatures()` disables `toggleViewAction()` unless `DockWidgetClosable` is in the set,
+so a docker missing that flag has a permanently greyed-out *Window* menu entry — and a floating one
+loses its close button too. Every docker in both apps must keep `DockWidgetClosable`.
+
+---
+
 ## GDAL
 
 ### `QImage::Format_Indexed8` + `RasterIO`/`ReadRaster` — row padding

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ V1.XX.X
 [QMS-1177] Show "style" option in QMS usage
 [QMS-1179] Modernize the CMake build
 [QMS-1182] Fix: Name of Qt style passed to QMS gets lost
+[QMS-1185] Fix: Tools docker cannot be shown again in QMapTool
 [QMS-1186] Fix: Windows executables are no longer UTF-8 aware
 
 V1.20.3

--- a/src/qmaptool/CMainWindow.cpp
+++ b/src/qmaptool/CMainWindow.cpp
@@ -125,7 +125,10 @@ QString CMainWindow::getUser() {
   return user;
 }
 
-void CMainWindow::prepareMenuForMac() { dockTools->toggleViewAction()->setMenuRole(QAction::NoRole); }
+void CMainWindow::prepareMenuForMac() {
+  dockTools->toggleViewAction()->setMenuRole(QAction::NoRole);
+  dockShell->toggleViewAction()->setMenuRole(QAction::NoRole);
+}
 
 void CMainWindow::makeShellVisible() { dockShell->show(); }
 

--- a/src/qmaptool/IMainWindow.ui
+++ b/src/qmaptool/IMainWindow.ui
@@ -62,7 +62,7 @@
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QDockWidget" name="dockTools">
    <property name="features">
-    <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetVerticalTitleBar</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetVerticalTitleBar</set>
    </property>
    <property name="windowTitle">
     <string>Tools</string>


### PR DESCRIPTION
Qt disables QDockWidget::toggleViewAction() unless DockWidgetClosable is set, so the Window menu entry was permanently greyed out. Give dockShell the mac menu role too.

<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1185

### What you have done:
[comment]: # (Describe roughly.)

Set the flag :)

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
