### PR TITLE
[QMS-1195] Extend .gitattributes file by additional file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,13 @@
 *.svg                  text eol=lf
 src/icons/svg.sha256   text eol=lf
 src/icons/svghygiene   text eol=lf
+#
+# Linux scripts should use lf
+*.sh   text eol=lf
+#
+# Windows scripts should use cllf
+*.bat  text eol=crlf
+*.cmd  text eol=crlf
+#
+# Markdown files should use lf
+*.md   text eol=lf

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ V1.XX.X
 [QMS-1186] Fix: Windows executables are no longer UTF-8 aware
 [QMS-1190] Drop the alglib dependency in favour of an own elevation smoothing spline
 [QMS-1193] Drop the QuaZip dependency in favour of GDAL's /vsizip/ filesystem
+[QMS-1195] Extend .gitattributes file by additional file types
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1195

### What you have done:
[comment]: # (Describe roughly.)

Added file types _.sh_, _.bat_, _.cmd_ and _.md_ to file _.gitattributes_.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Download files with these file types from github to different operating system platforms
2. See that line endings are converted or preserved according to rules

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
