### PR TITLE
[QMS-1197] Fix: Splash screen not floating on Sway

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ V1.XX.X
 [QMS-1190] Drop the alglib dependency in favour of an own elevation smoothing spline
 [QMS-1193] Drop the QuaZip dependency in favour of GDAL's /vsizip/ filesystem
 [QMS-1195] Extend .gitattributes file by additional file types
+[QMS-1197] Fix: Splash screen not floating on Sway
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/main.cpp
+++ b/src/qmapshack/main.cpp
@@ -92,6 +92,7 @@ int main(int argc, char** argv) {
 
     splash = new QSplashScreen(pic);
     splash->setWindowFlags(splash->windowFlags() | Qt::WindowStaysOnTopHint);
+    splash->setFixedSize(pic.size());
 #ifdef Q_OS_MAC
     // remove the splash screen flag on OS-X as workaround for the reported bug
     // https://bugreports.qt.io/browse/QTBUG-49576


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1197

### What you have done:
[comment]: # (Describe roughly.)

Set the splash screen window to a fixed size.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Open QMS (with the splash screen enabled).
2. Check if splash screen behaves as expected.

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
