### PR TITLE
[QMS-1199] Fix: Map tooltip showing up after mouse left the canvas

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ V1.XX.X
 [QMS-1193] Drop the QuaZip dependency in favour of GDAL's /vsizip/ filesystem
 [QMS-1195] Extend .gitattributes file by additional file types
 [QMS-1197] Fix: Splash screen not floating on Sway
+[QMS-1199] Fix: Map tooltip showing up after mouse left the canvas
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -732,6 +732,8 @@ void CCanvas::leaveEvent(QEvent*) {
     CCanvas::restoreOverrideCursor("leaveEvent");
   }
 
+  timerToolTip->stop();
+
   setMouseTracking(false);
 }
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1199

### What you have done:
[comment]: # (Describe roughly.)

Stop the timer that triggers the tooltip in the leaveEvent handler.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Have a map with tooltips (like some IMG maps) or POI database loaded and have "Map Tooltip" enabled
2. Move the mouse across the map and then to e.g. the QMS toolbar. (and wait a moment)
3. Move the mouse on the map and quickly switch to another window (by keyboard shortcut).

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
