### PR TITLE
[QMS-1201] Fix: Checked-state cues vanish while the window is inactive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,12 @@ palette.
   so the running one cannot be the base. That is what preserves `-style` / `QT_STYLE_OVERRIDE`.
 - **Paint the menu tint before delegating to the base**, or it dims the text it marks; `CE_MenuItem`
   fills the row only when selected. Checked rows also go bold, so the cue is not colour alone.
+- **Resolve a cue's colour through `cueColorGroup()`, never the palette's current group.** The
+  current group turns `Inactive` while the window is not the active one, and KDE's
+  `[ColorEffects:Inactive] ChangeSelectionColor` mutes `Highlight` to near the button face there
+  (measured `#1b4155` on `#292c30`), so a cue drawn with the one-argument `color()` overload
+  disappears whenever the app loses focus. A cue marks state, not focus, so `Active` is pinned and
+  only the disabled dimming is kept.
 - **Never fill a checked button with `Highlight`** — `ink` drops to ~1.3:1 on it. A border over the
   untouched face keeps ~4.9:1.
 - **Menus resist style sheets:** Qt ignores `QMenu::item:checked`, and `QMenu::indicator` needs an

--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ V1.XX.X
 [QMS-1195] Extend .gitattributes file by additional file types
 [QMS-1197] Fix: Splash screen not floating on Sway
 [QMS-1199] Fix: Map tooltip showing up after mouse left the canvas
+[QMS-1201] Fix: Checked state of tool buttons and menu items lost while the window is inactive
 
 V1.20.3
 [QMS-1059] Fix: F1 help browser does not open external links

--- a/src/common/theme/CQmsStyle.cpp
+++ b/src/common/theme/CQmsStyle.cpp
@@ -28,6 +28,20 @@ constexpr qint32 kButtonBorderWidth = 2;
 constexpr qint32 kMenuBarWidth = 4;
 /** @brief Tint of a checked menu row. Painted under the content, so it does not dim the text. */
 constexpr qint32 kMenuTintAlpha = 90;
+
+/**
+ * @brief Palette group a checked-state cue resolves Highlight in.
+ *
+ * The palette's current group turns Inactive while the window is not the active one, where
+ * Highlight is muted to near the widget's own face and the cue disappears. A cue marks state, not
+ * focus, so Active is pinned and only the disabled dimming is kept.
+ *
+ * @param option style option being drawn
+ * @return QPalette::Active, or QPalette::Disabled for a disabled widget
+ */
+QPalette::ColorGroup cueColorGroup(const QStyleOption* option) {
+  return (option->state & QStyle::State_Enabled) ? QPalette::Active : QPalette::Disabled;
+}
 }  // namespace
 
 CQmsStyle::CQmsStyle(QStyle* base) : QProxyStyle(base) {}
@@ -46,7 +60,7 @@ void CQmsStyle::drawPrimitive(PrimitiveElement element, const QStyleOption* opti
     return;
   }
 
-  QPen pen(option->palette.color(QPalette::Highlight));
+  QPen pen(option->palette.color(cueColorGroup(option), QPalette::Highlight));
   pen.setWidth(kButtonBorderWidth);
 
   painter->save();
@@ -66,7 +80,7 @@ void CQmsStyle::drawControl(ControlElement element, const QStyleOption* option, 
     return;
   }
 
-  const QColor highlight = item->palette.color(QPalette::Highlight);
+  const QColor highlight = item->palette.color(cueColorGroup(item), QPalette::Highlight);
 
   painter->save();
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1201

### What you have done:
[comment]: # (Describe roughly.)

The one-argument QPalette::color() overload resolves through the palette's current group, which Qt switches to Inactive whenever the window is not the active one. KDE's ChangeSelectionColor mutes Highlight to near the button face there (#1b4155 on #292c30), so the tool button frame was invisible until the app regained focus. cueColorGroup() pins Active and keeps the disabled dimming.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
