### PR TITLE
[QMS-1169] Fix: Map viewport keeps the previous size after leaving fu…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,26 @@ divides the scale by `pixelRatio`.
 Test HiDPI paths on a normal screen with `QT_SCALE_FACTOR=2 build/bin/qmapshack`, adding
 `QT_SCALE_FACTOR_ROUNDING_POLICY=PassThrough` for fractional factors like 1.5.
 
+### Applying a new viewport size
+
+A draw thread holds a reference to its buffer with the mutex unlocked, so the buffers cannot be
+rebuilt while it runs and a resize has to be deferred. `CCanvas::slotUpdateDrawContextViewport()` is
+the only path that applies size and pixel ratio, and three rules keep it honest:
+
+- **Never pass a size captured earlier.** It reads `size()`/`devicePixelRatio()` at apply time. A
+  retry runs long after the event that scheduled it, and a queued resize event for an intermediate
+  geometry is delivered *after* the synchronously sent event for the final one — the Windows
+  fullscreen → maximized sequence does exactly that.
+- **All or nothing** (`canResize()` before `resize()`). A partially applied resize leaves the layers
+  with different viewports, which shows as map content no longer matching the GIS overlay.
+- **`paintEvent()` reconciles.** A context left behind would never be noticed otherwise: a canvas
+  shown again at an unchanged geometry gets no resize event, so the divergence would survive panning,
+  zooming and view switches until the user drags a splitter.
+
+Retries come from `timerViewport` and from each context's `finished`. `print()` is the one caller
+that changes the size to something other than the canvas' own, so it must `waitForDrawContexts()`
+before *and* after — its second `draw()` pass restarts the threads.
+
 ---
 
 ## Icons

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ V1.XX.X
 [QMS-1164] Support light and dark color schemes for UI icons
 [QMS-1165] Unify UI icon style and improve dark mode legibility
 [QMS-1166] Allow configuring custom keyboard shortcuts
+[QMS-1169] Fix: Map viewport keeps the previous size after leaving fullscreen
 [QMS-1171] Fix: Formatted text is rendered badly in dark theme
 [QMS-1173] Fix: QMS on macOS is not dark mode aware
 [QMS-1177] Show "style" option in QMS usage

--- a/src/qmapshack/CMainWindow.cpp
+++ b/src/qmapshack/CMainWindow.cpp
@@ -1571,7 +1571,11 @@ void CMainWindow::displayRegular() {
     menuBar()->setVisible(true);
   }
   actionFullScreen->setIcon(QIcon(":/icons/FullScreen.svgt"));
+  // Windows leaves fullscreen by un-maximizing, applying the saved normal geometry and re-maximizing,
+  // all synchronously. Suppress the repaint at that intermediate size.
+  setUpdatesEnabled(false);
   setWindowState(windowState() ^ Qt::WindowFullScreen);
+  setUpdatesEnabled(true);
 }
 
 void CMainWindow::displayFullscreen() {

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -137,6 +137,16 @@ CCanvas::CCanvas(QWidget* parent, const QString& storedKey) : QWidget(parent) {
   // map has to be first!
   allDrawContext << map << poi << dem << gis << rt;
 
+  timerViewport = new QTimer(this);
+  timerViewport->setSingleShot(true);
+  timerViewport->setInterval(50);
+  connect(timerViewport, &QTimer::timeout, this, &CCanvas::slotUpdateDrawContextViewport);
+
+  // a thread that has stopped no longer blocks its buffers, so a pending viewport update can be applied
+  for (IDrawContext* context : std::as_const(allDrawContext)) {
+    connect(context, &IDrawContext::finished, this, &CCanvas::slotUpdateDrawContextViewport);
+  }
+
   mouse = new CMouseAdapter(this);
   mouse->setDelegate(new CMouseNormal(gis, this, mouse));
 
@@ -215,9 +225,7 @@ CCanvas::~CCanvas() {
   for (IDrawContext* context : std::as_const(allDrawContext)) {
     context->quit();
   }
-  for (IDrawContext* context : std::as_const(allDrawContext)) {
-    context->wait();
-  }
+  waitForDrawContexts();
 
   /*
       Some mouse objects call methods from their canvas on destruction.
@@ -563,14 +571,8 @@ void CCanvas::changeEvent(QEvent* e) {
 }
 
 void CCanvas::resizeEvent(QResizeEvent* e) {
-  if (!setDrawContextSize(e->size())) {
-    // reschedule resize event because one of the draw context threads is still running
-    // and blocking the access to internal data.
-    QApplication::postEvent(this, new QResizeEvent(e->size(), e->oldSize()));
-    return;
-  }
+  slotUpdateDrawContextViewport();
 
-  needsRedraw = eRedrawAll;
   QWidget::resizeEvent(e);
 
   const QRect& r = rect();
@@ -601,6 +603,13 @@ void CCanvas::resizeEvent(QResizeEvent* e) {
 void CCanvas::paintEvent(QPaintEvent*) {
   if (!isVisible()) {
     return;
+  }
+
+  // A viewport update refused by a running draw thread is retried by timerViewport, but nothing else
+  // would ever notice a context left behind: a canvas that is shown again at an unchanged geometry
+  // gets no resize event.
+  if (!timerViewport->isActive() && !drawContextViewportIsCurrent()) {
+    timerViewport->start();
   }
 
   QPainter p;
@@ -1260,26 +1269,69 @@ void CCanvas::showProfile(bool yes) {
   }
 }
 
-bool CCanvas::setDrawContextSize(const QSize& s) {
-  bool done = true;
-  for (IDrawContext* context : std::as_const(allDrawContext)) {
-    done &= context->resize(s);
+void CCanvas::slotUpdateDrawContextViewport() {
+  if (drawContextViewportIsCurrent()) {
+    timerViewport->stop();
+    return;
   }
-  return done;
+
+  if (!setDrawContextPixelRatio(devicePixelRatio()) || !setDrawContextSize(size())) {
+    timerViewport->start();
+    return;
+  }
+
+  timerViewport->stop();
+  slotTriggerCompleteUpdate(eRedrawAll);
+}
+
+bool CCanvas::drawContextViewportIsCurrent() const {
+  const QSize& s = size();
+  const qreal ratio = devicePixelRatio();
+
+  for (IDrawContext* context : std::as_const(allDrawContext)) {
+    if ((context->getSize() != s) || (context->getPixelRatio() != ratio)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool CCanvas::setDrawContextSize(const QSize& s) {
+  // all or nothing: a partial resize leaves the layers with different viewports, which shows as
+  // map content that no longer matches the GIS overlay
+  for (IDrawContext* context : std::as_const(allDrawContext)) {
+    if (!context->canResize(s)) {
+      return false;
+    }
+  }
+  for (IDrawContext* context : std::as_const(allDrawContext)) {
+    context->resize(s);
+  }
+  return true;
 }
 
 bool CCanvas::setDrawContextPixelRatio(qreal ratio) {
-  bool done = true;
   for (IDrawContext* context : std::as_const(allDrawContext)) {
-    done &= context->setPixelRatio(ratio);
+    if (!context->canSetPixelRatio(ratio)) {
+      return false;
+    }
   }
-  return done;
+  for (IDrawContext* context : std::as_const(allDrawContext)) {
+    context->setPixelRatio(ratio);
+  }
+  return true;
+}
+
+void CCanvas::waitForDrawContexts() {
+  for (IDrawContext* context : std::as_const(allDrawContext)) {
+    context->wait();
+  }
 }
 
 void CCanvas::print(QPainter& p, const QRectF& area, const QPointF& focus, bool printScale) {
-  const QSize oldSize = size();
   const QSize newSize(area.size().toSize());
 
+  waitForDrawContexts();
   setDrawContextSize(newSize);
 
   // ----- start to draw thread based content -----
@@ -1292,9 +1344,7 @@ void CCanvas::print(QPainter& p, const QRectF& area, const QPointF& focus, bool 
     context->draw(p, redraw, focus);
   }
 
-  for (IDrawContext* context : std::as_const(allDrawContext)) {
-    context->wait();
-  }
+  waitForDrawContexts();
 
   for (IDrawContext* context : std::as_const(allDrawContext)) {
     context->draw(p, redraw, focus);
@@ -1313,7 +1363,10 @@ void CCanvas::print(QPainter& p, const QRectF& area, const QPointF& focus, bool 
     drawScale(p, r);
   }
 
-  setDrawContextSize(oldSize);
+  // the second draw() above restarted the threads, so the canvas' own size cannot be restored
+  // before they have stopped again
+  waitForDrawContexts();
+  slotUpdateDrawContextViewport();
 }
 
 bool CCanvas::event(QEvent* event) {
@@ -1329,13 +1382,7 @@ bool CCanvas::event(QEvent* event) {
     }
   }
   if (event->type() == QEvent::DevicePixelRatioChange) {
-    if (!setDrawContextPixelRatio(devicePixelRatio())) {
-      // reschedule resize event because one of the draw context threads is still running
-      // and blocking the access to internal data.
-      QApplication::postEvent(this, new QEvent(QEvent::DevicePixelRatioChange));
-    } else {
-      needsRedraw = eRedrawAll;
-    }
+    slotUpdateDrawContextViewport();
   }
   return QWidget::event(event);
 }

--- a/src/qmapshack/canvas/CCanvas.h
+++ b/src/qmapshack/canvas/CCanvas.h
@@ -233,6 +233,17 @@ class CCanvas : public QWidget {
  private slots:
   void slotToolTip();
 
+  /**
+     @brief Apply the canvas' current size and device pixel ratio to all draw context objects
+
+     Always reads the current geometry instead of taking it from an event: a retry runs long after
+     the event that scheduled it, and the canvas may have been resized again meanwhile.
+
+     If a draw thread blocks the request the retry timer takes over and nothing is applied, so the
+     layers cannot end up disagreeing about the viewport.
+   */
+  void slotUpdateDrawContextViewport();
+
   /// @brief Show the overview advisory dialog for a CDemVRT that hit the render timeout
   /// with overviews missing/inadequate; wires the dialog's "don't show again" result back
   /// to source.
@@ -259,17 +270,23 @@ class CCanvas : public QWidget {
   }
   void setZoom(bool in, redraw_e& needsRedraw);
   void setSizeTrackProfile();
+  /// @brief True if every draw context is built for the canvas' current size and pixel ratio
+  bool drawContextViewportIsCurrent() const;
+
   /**
-     @brief Resize all registered drwa context objects
+     @brief Resize all registered draw context objects
 
      @param s     the new size
 
-     @return Return false if one of the draw conext could not be resized
+     @return Return false if one of the draw contexts could not be resized
              because it's thread is running and blocking access to the data
    */
   bool setDrawContextSize(const QSize& s);
 
   bool setDrawContextPixelRatio(qreal ratio);
+
+  /// @brief Block until no draw thread is running and the buffers can be rebuilt
+  void waitForDrawContexts();
 
   bool isShowMinMaxSummary() const;
   bool isShowTrackSummary() const;
@@ -295,6 +312,9 @@ class CCanvas : public QWidget {
   CGrid* grid;                        //< the grid attached to this canvas
 
   QList<IDrawContext*> allDrawContext;
+
+  /// retry timer for a viewport update a running draw thread refused
+  QTimer* timerViewport;
 
   /// the current point of focus (usually the canvas center)
   QPointF posFocus{0.209439510239, 0.855211333477};

--- a/src/qmapshack/canvas/IDrawContext.cpp
+++ b/src/qmapshack/canvas/IDrawContext.cpp
@@ -80,8 +80,8 @@ bool IDrawContext::resize(const QSize& size) {
     return true;
   }
 
-  if (isRunning() && !wait(100)) {
-    // blocked by thread, reschedule
+  if (isRunning()) {
+    // blocked by thread, the canvas retries
     return false;
   }
 
@@ -99,8 +99,8 @@ bool IDrawContext::setPixelRatio(qreal ratio) {
     return true;
   }
 
-  if (isRunning() && !wait(100)) {
-    // blocked by thread, reschedule
+  if (isRunning()) {
+    // blocked by thread, the canvas retries
     return false;
   }
 

--- a/src/qmapshack/canvas/IDrawContext.h
+++ b/src/qmapshack/canvas/IDrawContext.h
@@ -65,6 +65,22 @@ class IDrawContext : public QThread {
    */
   bool setPixelRatio(qreal ratio);
 
+  /// @brief The canvas size the buffers are built for. Lags behind the canvas while a resize is pending.
+  const QSize& getSize() const { return lastSize; }
+
+  qreal getPixelRatio() const { return pixelRatio; }
+
+  /**
+     @brief Test if resize() would be able to rebuild the buffers right now
+
+     The thread draws on a buffer with the mutex unlocked, so the buffers must not be
+     reallocated while it runs.
+   */
+  bool canResize(const QSize& size) const { return lastSize == size || !isRunning(); }
+
+  /// @brief canResize() for setPixelRatio()
+  bool canSetPixelRatio(qreal ratio) const { return pixelRatio == ratio || !isRunning(); }
+
   /**
      @brief Zoom in and out of the map by the scale factors defined in CMapDB::scales.
      @param in            set true to zoom in, and false to zoom out


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1169

### What you have done:
[comment]: # (Describe roughly.)

Bug: when a draw thread blocked a resize, CCanvas reposted the resize event with the size captured at that moment. That stale event lands after the real final geometry, so the draw contexts keep an intermediate size — and the partial per-context application let map and GIS overlay diverge.

Fix: single slotUpdateDrawContextViewport() that reads the current size/pixel ratio at apply time, applies all-or-nothing, retries via a 50 ms timer and each context's finished(); paintEvent() reconciles contexts against the canvas; GUI-thread wait(100) dropped; print() now waits for the threads on both size changes.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket. 

Also test printing an area of the map.

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
