### PR TITLE
[QMS-1212] Update macOS build scripts

### DIFF
--- a/MacOSX/build-gdal.sh
+++ b/MacOSX/build-gdal.sh
@@ -50,11 +50,7 @@ $PACKAGES_PATH/bin/cmake .. -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
                             -DGDAL_USE_CURL=ON \
                             -DGDAL_ENABLE_DRIVER_WMS:BOOL=ON \
                             -DGDAL_ENABLE_DRIVER_WCS:BOOL=ON \
-                            -DGDAL_USE_TIFF=ON \
-                            -DGDAL_USE_GEOTIFF=ON \
                             -DGDAL_USE_GEOS=ON \
-                            -DGDAL_USE_PNG=ON \
-                            -DGDAL_USE_GIF=ON \
                             -DGDAL_USE_ODBC=ON \
                             -DGDAL_USE_PCRE2=ON \
                             -DGDAL_USE_ICONV=ON \
@@ -62,9 +58,8 @@ $PACKAGES_PATH/bin/cmake .. -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
                             -DGDAL_USE_EXPAT=ON \
                             -DGDAL_USE_HEIF=ON \
                             -DGDAL_USE_WEBP=OFF \
-                            -DGDAL_ENABLE_PYTHON=OFF \
-                            -DGDAL_USE_SWIG=OFF \
                             -DGDAL_USE_POPPLER=ON \
+                            -DGDAL_USE_ZSTD=ON \
                             -DBUILD_PYTHON_BINDINGS=OFF
 
 $PACKAGES_PATH/bin/cmake --build . -j"$(sysctl -n hw.ncpu)"

--- a/MacOSX/install-packages.sh
+++ b/MacOSX/install-packages.sh
@@ -50,12 +50,13 @@ if [ -z "$MACPORTS_BUILD" ]; then
         brew install libkml
         brew install minizip
         brew install uriparser
-        brew install unixodbc
-        brew install libtiff
-        brew install libgeotiff
-        brew install libheif
-        brew install geos
-		brew install poppler
+        brew install libtiff    # required by libproj, libpoppler
+        brew install jpeg-turbo # required by libtiff
+        brew install unixodbc   # required by libgdal
+        brew install libheif    # required by libgdal
+        brew install geos       # required by libgdal
+        brew install zstd       # required by libgdal
+        brew install poppler    # required by libgdal
     else
         brew install gdal
     fi

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V1.XX.X
+[QMS-1212] Update macOS build scripts
+
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files
 [QMS-902] Add HiDPI support


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1212

### What you have done:
[comment]: # (Describe roughly.)

Updated script _MacOSX/build-gdal.sh_:
- Added `-DGDAL_USE_ZSTD=ON` requirement for ZSTD compression support
- Removed unused `-DGDAL_USE_TIFF=ON`, `-DGDAL_USE_GEOTIFF=ON`, `-DGDAL_USE_PNG=ON`, `-DGDAL_USE_GIF=ON` external requirements, as these are superseded by GDAL internal code.
- Removed unused `-DGDAL_USE_SWIG=OFF`

Updated script _MacOSX/install-packages.sh_:
- Removed obsolete requirement for formula _libgeotiff_
- Added requirement for formulas _zstd_ and _jpeg-turbo_ instead

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Build QMS on platform _macOS_
2. See that QMS is built successfully
3. Verify that GDAL successfully reads ZSTD compressed raster data

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
