### PR TITLE
[QMS-1215] Support MBTiles maps via GDAL's VRT driver on macOS

### DIFF
--- a/MacOSX/build-gdal.sh
+++ b/MacOSX/build-gdal.sh
@@ -60,6 +60,7 @@ $PACKAGES_PATH/bin/cmake .. -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
                             -DGDAL_USE_WEBP=OFF \
                             -DGDAL_USE_POPPLER=ON \
                             -DGDAL_USE_ZSTD=ON \
+                            -DGDAL_USE_SQLITE3=ON \
                             -DBUILD_PYTHON_BINDINGS=OFF
 
 $PACKAGES_PATH/bin/cmake --build . -j"$(sysctl -n hw.ncpu)"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-1212] Update macOS build scripts
+[QMS-1215] Support MBTiles maps via GDAL's VRT driver on macOS
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1215

### What you have done:
[comment]: # (Describe roughly.)

Updated script _MacOSX/build-gdal.sh_:
Added `-DGDAL_USE_SQLITE3=ON` requirement for MBTiles maps support

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Build QMS on _macOS_
2. Download MBTiles map, e.g. [OAM-World](https://www.openandromaps.org/en/downloads/general-maps#top)
3. Create corresponding VRT file using QMS _VRT Builder_ tool in one of QMS map paths
4. Reload Maps
5. Activate MBTiles map successfully 

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
