### PR TITLE
[QMS-1221] Fix: Crash on exit and empty workspace

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-1212] Update macOS build scripts
 [QMS-1215] Support MBTiles maps via GDAL's VRT driver on macOS
+[QMS-1221] Fix: Crash on exit leaves the workspace empty
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files

--- a/src/qmapshack/gis/CGisListWks.cpp
+++ b/src/qmapshack/gis/CGisListWks.cpp
@@ -139,7 +139,8 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
   actionSaveAs = addAction(QIcon("://icons/SaveGISAs.svgt"), tr("Save as..."), this, &CGisListWks::slotSaveAsProject);
   actionSaveAsStrict = addAction(QIcon("://icons/SaveGISAsGpx11.svgt"), tr("Save as GPX 1.1 w/o ext..."), this,
                                  &CGisListWks::slotSaveAsStrictGpx11Project);
-  actionSyncWksDev = addAction(QIcon("://icons/Device.svgt"), tr("Send to Devices"), this, &CGisListWks::slotSyncWksDev);
+  actionSyncWksDev =
+      addAction(QIcon("://icons/Device.svgt"), tr("Send to Devices"), this, &CGisListWks::slotSyncWksDev);
   actionSyncDB =
       addAction(QIcon("://icons/DatabaseSync.svgt"), tr("Sync. with Database"), this, &CGisListWks::slotSyncDB);
   actionCloseProj = addAction(QIcon("://icons/Close.svgt"), tr("Close"), this, &CGisListWks::slotCloseProject);
@@ -162,7 +163,8 @@ CGisListWks::CGisListWks(QWidget* parent) : QTreeWidget(parent) {
   actionRangeTrk = addAction(QIcon("://icons/SelectRange.svgt"), tr("Select Range"), this, &CGisListWks::slotRangeTrk);
   actionEditTrk = addAction(QIcon("://icons/LineMove.svgt"), tr("Edit Track Points"), this, &CGisListWks::slotEditTrk);
   actionReverseTrk = addAction(QIcon("://icons/Reverse.svgt"), tr("Reverse Track"), this, &CGisListWks::slotReverseTrk);
-  actionCombineTrk = addAction(QIcon("://icons/Combine.svgt"), tr("Combine Tracks"), this, &CGisListWks::slotCombineTrk);
+  actionCombineTrk =
+      addAction(QIcon("://icons/Combine.svgt"), tr("Combine Tracks"), this, &CGisListWks::slotCombineTrk);
   actionEleWptTrk =
       addAction(QIcon("://icons/SetEle.svgt"), tr("Replace Elevation by DEM"), this, &CGisListWks::slotEleWptTrk);
   actionCopyTrkWithWpt = addAction(QIcon("://icons/CopyTrkWithWpt.svgt"), tr("Copy Track with Waypoints"), this,
@@ -766,17 +768,19 @@ void CGisListWks::slotSaveWorkspace() {
     return;
   }
 
-  QSqlQuery query(db);
-  QUERY_RUN("DELETE FROM workspace", return)
-
   qDebug() << "slotSaveWorkspace()";
 
+  // No progress dialog and no other event loop spinning in here: this runs from
+  // QApplication::aboutToQuit, where processEvents() delivers a still queued quit event and
+  // re-enters QCoreApplication::exit().
+  db.transaction();
+
+  QSqlQuery query(db);
+  QUERY_RUN("DELETE FROM workspace", db.rollback(); return)
+
+  bool complete = true;
   const int total = topLevelItemCount();
-  PROGRESS_SETUP(tr("Saving workspace. Please wait."), 0, total, this);
-
   for (int i = 0; i < total; i++) {
-    PROGRESS(i, return);
-
     IGisProject* project = dynamic_cast<IGisProject*>(topLevelItem(i));
     if (nullptr == project) {
       continue;
@@ -801,12 +805,22 @@ void CGisListWks::slotSaveWorkspace() {
     query.bindValue(":changed", project->isChanged());
     query.bindValue(":visible", project->isVisible());
     query.bindValue(":data", data);
-    QUERY_EXEC(continue);
+    QUERY_EXEC(complete = false; continue);
   }
 
   query.prepare("UPDATE userfocus set focus=:focus");
   query.bindValue(":focus", IGisProject::getUserFocus());
   QUERY_EXEC();
+
+  // The delete and the re-insert must land together, else an abort leaves the workspace empty.
+  // A rollback keeps the previously saved workspace, which beats storing an incomplete one.
+  if (!complete) {
+    qWarning() << "Workspace incompletely written. Keeping the previously saved one.";
+    db.rollback();
+  } else if (!db.commit()) {
+    qWarning() << "Failed to commit workspace:" << db.lastError();
+    db.rollback();
+  }
 
   if (saveEvery) {
     QTimer::singleShot(saveEvery * 60000, this, &CGisListWks::slotSaveWorkspace);


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1221

### What you have done:
[comment]: # (Describe roughly.)

slotSaveWorkspace() runs from QApplication::aboutToQuit, where the progress dialog's processEvents() delivered a still queued quit event, re-entering QCoreApplication::exit() and emitting aboutToQuit from inside its own emission.

- The progress dialog is gone. The slot is reached from aboutToQuit and from the autosave timer; neither wants a modal dialog, and nothing in the slot may spin the event loop.
- The delete and the re-insert run in one transaction. A failed insert, a failed commit or a crash mid-loop keeps the previously saved workspace instead of leaving the table empty.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
