### PR TITLE
[QMS-1223] Fix: Crash when a map view is closed right after it was op…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V1.XX.X
 [QMS-1212] Update macOS build scripts
 [QMS-1215] Support MBTiles maps via GDAL's VRT driver on macOS
 [QMS-1221] Fix: Crash on exit leaves the workspace empty
+[QMS-1223] Fix: Crash when a map view is closed right after it was opened
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -119,9 +119,15 @@ void CMapItem::loadConfig(QSettings& cfg, bool triggerActivation) {
     setStatus(IMapItem::eStatus::Inactive);
     if (triggerActivation) {
       // Evil hack: If you activate the map directly Qt will crash internally.
+      // The owner has to be watched as well as the item: CMapDraw is destroyed with its canvas,
+      // while the CMapList holding this item only gets a deleteLater(), so a canvas closed within
+      // the delay leaves the item alive with a dangling map.
       QPointer<CMapItem> self(this);
-      QTimer::singleShot(100, this, [self, active]() {
-        if (!self.isNull()) self->activate(active);
+      QPointer<CMapDraw> owner(map);
+      QTimer::singleShot(100, this, [self, owner, active]() {
+        if (!self.isNull() && !owner.isNull()) {
+          self->activate(active);
+        }
       });
     }
   }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1223

### What you have done:
[comment]: # (Describe roughly.)

CMapDraw is a child of its canvas and is destroyed with it, while the CMapList holding the CMapItems only gets a deleteLater(). A canvas destroyed within the 100 ms of loadConfig()'s deferred activation leaves every item alive with a dangling CMapDraw, and activate() hands it to the new map file object as parent.

The timer now watches the owner as well as the item. Reached by any short lived canvas, CPrintDialog's preview among them.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
