### PR TITLE
[QMS-1224] Fix: --locale switches the strings but not date and number…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V1.XX.X
 [QMS-1215] Support MBTiles maps via GDAL's VRT driver on macOS
 [QMS-1221] Fix: Crash on exit leaves the workspace empty
 [QMS-1223] Fix: Crash when a map view is closed right after it was opened
+[QMS-1224] Fix: --locale switches the strings but not date and number formats
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files

--- a/src/qmapshack/gis/search/CSearch.cpp
+++ b/src/qmapshack/gis/search/CSearch.cpp
@@ -85,11 +85,11 @@ CSearch::CSearch(QString searchstring) : searchText(searchstring) {
 
     // Try if it is a time. Do so first, since this is the most exclusive
     const static QList<QString> timeFormats = {
-        QLocale::system().timeFormat(QLocale::LongFormat), QLocale::system().timeFormat(QLocale::ShortFormat),
+        QLocale().timeFormat(QLocale::LongFormat), QLocale().timeFormat(QLocale::ShortFormat),
         QLocale::c().timeFormat(QLocale::LongFormat), QLocale::c().timeFormat(QLocale::ShortFormat)};
 
     for (const QString& tf : timeFormats) {
-      const QTime& time1a = QLocale::system().toTime(filterValueStringFirstPart, tf);
+      const QTime& time1a = QLocale().toTime(filterValueStringFirstPart, tf);
       if (time1a.isValid()) {
         filterValue.value1 = time1a.msecsSinceStartOfDay() / 1000;
         filterValue.str1 = "SsE";
@@ -102,7 +102,7 @@ CSearch::CSearch(QString searchstring) : searchText(searchstring) {
       }
 
       if (time1a.isValid() || time1b.isValid()) {
-        const QTime& time2a = QLocale::system().toTime(filterValueStringSecondPart, tf);
+        const QTime& time2a = QLocale().toTime(filterValueStringSecondPart, tf);
         if (time2a.isValid()) {
           filterValue.value2 = time2a.msecsSinceStartOfDay() / 1000;
           filterValue.str2 = "SsE";
@@ -120,13 +120,13 @@ CSearch::CSearch(QString searchstring) : searchText(searchstring) {
     if (filterValue.toString().isEmpty()) {
       // Try if it is a date
       const static QList<QString> dateFormats = {
-          QLocale::system().dateTimeFormat(QLocale::LongFormat), QLocale::system().dateTimeFormat(QLocale::ShortFormat),
-          QLocale::c().dateTimeFormat(QLocale::LongFormat),      QLocale::c().dateTimeFormat(QLocale::ShortFormat),
-          QLocale::system().dateFormat(QLocale::LongFormat),     QLocale::system().dateFormat(QLocale::ShortFormat),
-          QLocale::c().dateFormat(QLocale::LongFormat),          QLocale::c().dateFormat(QLocale::ShortFormat)};
+          QLocale().dateTimeFormat(QLocale::LongFormat),    QLocale().dateTimeFormat(QLocale::ShortFormat),
+          QLocale::c().dateTimeFormat(QLocale::LongFormat), QLocale::c().dateTimeFormat(QLocale::ShortFormat),
+          QLocale().dateFormat(QLocale::LongFormat),        QLocale().dateFormat(QLocale::ShortFormat),
+          QLocale::c().dateFormat(QLocale::LongFormat),     QLocale::c().dateFormat(QLocale::ShortFormat)};
 
       for (const QString& df : dateFormats) {
-        const QDateTime& time1a = QLocale::system().toDateTime(filterValueStringFirstPart, df);
+        const QDateTime& time1a = QLocale().toDateTime(filterValueStringFirstPart, df);
         if (time1a.isValid()) {
           filterValue.value1 = time1a.toSecsSinceEpoch();
           filterValue.str1 = "SsE";
@@ -139,7 +139,7 @@ CSearch::CSearch(QString searchstring) : searchText(searchstring) {
         }
 
         if (time1a.isValid() || time1b.isValid()) {
-          const QDateTime& time2a = QLocale::system().toDateTime(filterValueStringSecondPart, df);
+          const QDateTime& time2a = QLocale().toDateTime(filterValueStringSecondPart, df);
           if (time2a.isValid()) {
             filterValue.value2 = time2a.toSecsSinceEpoch();
             filterValue.str2 = "SsE";

--- a/src/qmapshack/gis/search/CSearchExplanationDialog.cpp
+++ b/src/qmapshack/gis/search/CSearchExplanationDialog.cpp
@@ -71,8 +71,8 @@ CSearchExplanationDialog::CSearchExplanationDialog(QWidget* parent) {
   explanation += "</ul>";
   explanation += tr("<p>You can write dates in the following formats:</p>");
   explanation += "<ul>";
-  explanation += "<li>" + QLocale::system().dateTimeFormat(QLocale::LongFormat) + "</li>";
-  explanation += "<li>" + QLocale::system().dateTimeFormat(QLocale::ShortFormat) + "</li>";
+  explanation += "<li>" + QLocale().dateTimeFormat(QLocale::LongFormat) + "</li>";
+  explanation += "<li>" + QLocale().dateTimeFormat(QLocale::ShortFormat) + "</li>";
   explanation += "<li>" + QLocale::c().dateTimeFormat(QLocale::LongFormat) + "</li>";
   explanation += "<li>" + QLocale::c().dateTimeFormat(QLocale::ShortFormat) + "</li>";
   explanation += "</ul>";

--- a/src/qmapshack/helpers/CVrtAdvisoryDialog.cpp
+++ b/src/qmapshack/helpers/CVrtAdvisoryDialog.cpp
@@ -215,7 +215,7 @@ void CVrtAdvisoryDialog::renderThemedContent() {
   }
 
   // SI (base-1000) so the figure matches `du --si`, not the 1024-based IEC default.
-  const QString sizeStr = QLocale::system().formattedDataSize(advice_.diskUsageBytes, 2, QLocale::DataSizeSIFormat);
+  const QString sizeStr = QLocale().formattedDataSize(advice_.diskUsageBytes, 2, QLocale::DataSizeSIFormat);
   const QString usage =
       advice_.diskUsageIsEstimate ? tr("Estimated disk usage: %1.").arg(sizeStr) : tr("Disk usage: %1.").arg(sizeStr);
   // With nothing to fix there are no build/replace parts, so state the usage on its own.

--- a/src/qmapshack/setup/IAppSetup.cpp
+++ b/src/qmapshack/setup/IAppSetup.cpp
@@ -18,9 +18,10 @@
 
 #include "setup/IAppSetup.h"
 
-#include <QFont>
-
 #include <gdal.h>
+
+#include <QFont>
+#include <QLocale>
 
 #if defined(Q_OS_MAC)
 #include "setup/CAppSetupMac.h"
@@ -125,4 +126,10 @@ void IAppSetup::processArguments() {
   }
   qApp->setFont(appFont);
 
+  // --locale switches the whole locale, not only the strings: numbers, dates and time zone names
+  // come from QLocale, so a run left on the system locale renders English text with German dates.
+  // Without the option nothing changes - QLocale already defaults to the system.
+  if (qlOpts->locale != nullptr) {
+    QLocale::setDefault(QLocale(qlOpts->locale));
+  }
 }

--- a/src/qmapshack/units/IUnit.cpp
+++ b/src/qmapshack/units/IUnit.cpp
@@ -679,7 +679,9 @@ QString IUnit::datetime2string(const QDateTime& time, time_format_e format, cons
   }
 
   const QDateTime& tmp = time.toTimeZone(tz);
-  const QLocale& locale = QLocale::system();
+  // QLocale(), not QLocale::system(): --locale has to reach the timestamps too. Without the option
+  // the default locale is the system one, so nothing changes for a normal run.
+  const QLocale& locale = QLocale();
 
   switch (format) {
     case eTimeFormatLong:
@@ -692,7 +694,7 @@ QString IUnit::datetime2string(const QDateTime& time, time_format_e format, cons
       return tmp.toString(Qt::ISODate);
   }
 
-  return locale.toString(tmp, QLocale::system().dateTimeFormat(QLocale::LongFormat));
+  return locale.toString(tmp, locale.dateTimeFormat(QLocale::LongFormat));
 }
 
 QByteArray IUnit::pos2timezone(const QPointF& pos) {


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1224

### What you have done:
[comment]: # (Describe roughly.)

prepareTranslator() was the option's only consumer, so --locale picked the catalogs while QLocale stayed on the machine's locale: English menus with German timestamps.

- processArguments() calls QLocale::setDefault() when the option is given. Without it the default locale is the system one, so a normal run is unchanged.
- Timestamps, the search filter parser, the format list the search explanation shows and the advisory's disk usage take QLocale() instead of QLocale::system(), which ignores the default.

The quickstart wiki language and the OSM name:<lang> tag matching keep the system locale. They are about the reader's and the data's language, not the interface's.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
