### PR TITLE
[QMS-1227] Fix: Crash after activating a map that is already active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V1.XX.X
 [QMS-1221] Fix: Crash on exit leaves the workspace empty
 [QMS-1223] Fix: Crash when a map view is closed right after it was opened
 [QMS-1224] Fix: --locale switches the strings but not date and number formats
+[QMS-1227] Fix: Crash after activating a map that is already active
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files

--- a/src/qmapshack/map/CMapItem.cpp
+++ b/src/qmapshack/map/CMapItem.cpp
@@ -201,6 +201,11 @@ void CMapItem::deactivate() {
 bool CMapItem::activate() {
   QMutexLocker lock(&mutexActiveMaps);
 
+  // Activating an already active map has to take the setup widget out of the tree first. It belongs
+  // to the map file object, and setItemWidget() registered it with the view: deleting it while the
+  // view still holds it leaves a dangling index widget, which the next layout hides. deactivate()
+  // does this; activate() has to as well, or a second activation corrupts the view.
+  showChildren(false);
   delete mapfile;
 
   // load map by suffix


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1227

### What you have done:
[comment]: # (Describe roughly.)

showChildren(true) hands the map's setup widget to the tree with setItemWidget(), which makes it an index widget the view keeps in its editor hash and hides on the next layout. The widget belongs to the map file object, and activate() opened with an unconditional delete of it, so a second activation left the view with a dangling pointer.

activate() now takes the children out first, the order deactivate() already uses. showChildren() returns immediately without a map file, so an inactive item is unaffected.



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
