### PR TITLE
[QMS-1230] Fix: Configured DEM and MAPS are not preserved after a res…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-1223] Fix: Crash when a map view is closed right after it was opened
 [QMS-1224] Fix: --locale switches the strings but not date and number formats
 [QMS-1227] Fix: Crash after activating a map that is already active
+[QMS-1230] Fix: Configured DEM and MAPS are not preserved after a restart
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files

--- a/src/qmapshack/dem/CDemDraw.cpp
+++ b/src/qmapshack/dem/CDemDraw.cpp
@@ -89,8 +89,8 @@ void CDemDraw::setupDemPath() {
 void CDemDraw::setupDemPath(const QString& path) {
   qDebug() << "CDemDraw::setupDemPath(path)";
   QStringList paths(demPaths);
-  if (!demPaths.contains(path)) {
-    paths << path;
+  if (!containsPath(demPaths, path)) {
+    paths << cleanPath(path);
   }
   setupDemPath(paths);
 }
@@ -163,6 +163,14 @@ void CDemDraw::loadDemList(QSettings& cfg) {
   QMutexLocker lock(&CDemItem::mutexActiveDems);
   demList->clear();
 
+  // A DEM belongs to a registered path if both resolve to the same directory. Resolve the
+  // registered paths right here: a path that could not be resolved when it was read from the
+  // configuration must not lose its DEM once it is back.
+  QSet<QString> registeredPaths;
+  for (const QString& path : std::as_const(demPaths)) {
+    registeredPaths << resolvedPath(path);
+  }
+
   // create a temp list of all dems in the paths
   QMap<QString, CDemItem*> demsFound;
   for (const QString& path : std::as_const(demPaths)) {
@@ -205,7 +213,8 @@ void CDemDraw::loadDemList(QSettings& cfg) {
     // If neither the long nor short key matches, the content changed.
     // If the dem path is not part of the dem paths list also delete it.
     QFileInfo fi(dem->getFilename());
-    if ((key != dem->getKey() && key != dem->getShortKey()) || !demPaths.contains(fi.absolutePath())) {
+    if ((key != dem->getKey() && key != dem->getShortKey()) ||
+        !registeredPaths.contains(resolvedPath(fi.absolutePath()))) {
       delete dem;
       continue;
     }

--- a/src/qmapshack/dem/CDemPathSetup.cpp
+++ b/src/qmapshack/dem/CDemPathSetup.cpp
@@ -23,6 +23,7 @@
 #include "CMainWindow.h"
 #include "dem/CDemDraw.h"
 #include "dem/CDemList.h"
+#include "misc.h"
 #include "svgticon/CSvgtIcon.h"
 
 CDemPathSetup::CDemPathSetup(QStringList& paths) : QDialog(CMainWindow::getBestWidgetForParent()), paths(paths) {
@@ -50,14 +51,24 @@ void CDemPathSetup::slotItemSelectionChanged() {
   toolDelete->setEnabled(!items.isEmpty());
 }
 
-void CDemPathSetup::slotAddPath() {
-  QString path = QFileDialog::getExistingDirectory(this, tr("Select DEM file path..."), QDir::homePath());
-  if (!path.isEmpty()) {
-    if (!paths.contains(path)) {
-      QListWidgetItem* item = new QListWidgetItem(listWidget);
-      item->setText(path);
-    }
+QStringList CDemPathSetup::currentPaths() const {
+  QStringList paths;
+  for (int i = 0; i < listWidget->count(); i++) {
+    paths << listWidget->item(i)->text();
   }
+  return paths;
+}
+
+void CDemPathSetup::slotAddPath() {
+  // keep the path as the user picked it, only cleaned. Comparing resolves it later on.
+  const QString& path =
+      cleanPath(QFileDialog::getExistingDirectory(this, tr("Select DEM file path..."), QDir::homePath()));
+  if (path.isEmpty() || containsPath(currentPaths(), path)) {
+    return;
+  }
+
+  QListWidgetItem* item = new QListWidgetItem(listWidget);
+  item->setText(path);
 }
 
 void CDemPathSetup::slotDelPath() {
@@ -66,11 +77,7 @@ void CDemPathSetup::slotDelPath() {
 }
 
 void CDemPathSetup::accept() {
-  paths.clear();
-  for (int i = 0; i < listWidget->count(); i++) {
-    QListWidgetItem* item = listWidget->item(i);
-    paths << item->text();
-  }
+  paths = currentPaths();
 
   QDialog::accept();
 }

--- a/src/qmapshack/dem/CDemPathSetup.h
+++ b/src/qmapshack/dem/CDemPathSetup.h
@@ -38,6 +38,12 @@ class CDemPathSetup : public QDialog, private Ui::IDemPathSetup {
   void slotItemSelectionChanged();
 
  private:
+  /**
+   * @brief Get the paths currently listed in the dialog
+   * @return
+   */
+  QStringList currentPaths() const;
+
   QStringList& paths;
 };
 

--- a/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterRoutino.cpp
@@ -30,6 +30,7 @@
 #include "gis/rte/router/routino/CRouterRoutinoPathSetup.h"
 #include "helpers/CProgressDialog.h"
 #include "helpers/CSettings.h"
+#include "misc.h"
 #include "setup/IAppSetup.h"
 #include "svgticon/CSvgtIcon.h"
 
@@ -204,11 +205,11 @@ QString CRouterRoutino::getOptions() {
 }
 
 void CRouterRoutino::setupPath(const QString& path) {
-  if (dbPaths.contains(path)) {
+  if (path.isEmpty() || containsPath(dbPaths, path)) {
     return;
   }
 
-  dbPaths << path;
+  dbPaths << cleanPath(path);
   buildDatabaseList();
   updateHelpText();
 }

--- a/src/qmapshack/gis/rte/router/routino/CRouterRoutinoPathSetup.cpp
+++ b/src/qmapshack/gis/rte/router/routino/CRouterRoutinoPathSetup.cpp
@@ -21,6 +21,7 @@
 #include <QtWidgets>
 
 #include "CMainWindow.h"
+#include "misc.h"
 #include "svgticon/CSvgtIcon.h"
 
 CRouterRoutinoPathSetup::CRouterRoutinoPathSetup(QStringList& paths)
@@ -49,12 +50,24 @@ void CRouterRoutinoPathSetup::slotItemSelectionChanged() {
   toolDelete->setEnabled(!items.isEmpty());
 }
 
-void CRouterRoutinoPathSetup::slotAddPath() {
-  QString path = QFileDialog::getExistingDirectory(this, tr("Select routing data file path..."), QDir::homePath());
-  if (!path.isEmpty()) {
-    QListWidgetItem* item = new QListWidgetItem(listWidget);
-    item->setText(path);
+QStringList CRouterRoutinoPathSetup::currentPaths() const {
+  QStringList paths;
+  for (int i = 0; i < listWidget->count(); i++) {
+    paths << listWidget->item(i)->text();
   }
+  return paths;
+}
+
+void CRouterRoutinoPathSetup::slotAddPath() {
+  // keep the path as the user picked it, only cleaned. Comparing resolves it later on.
+  const QString& path =
+      cleanPath(QFileDialog::getExistingDirectory(this, tr("Select routing data file path..."), QDir::homePath()));
+  if (path.isEmpty() || containsPath(currentPaths(), path)) {
+    return;
+  }
+
+  QListWidgetItem* item = new QListWidgetItem(listWidget);
+  item->setText(path);
 }
 
 void CRouterRoutinoPathSetup::slotDelPath() {
@@ -63,11 +76,7 @@ void CRouterRoutinoPathSetup::slotDelPath() {
 }
 
 void CRouterRoutinoPathSetup::accept() {
-  paths.clear();
-  for (int i = 0; i < listWidget->count(); i++) {
-    QListWidgetItem* item = listWidget->item(i);
-    paths << item->text();
-  }
+  paths = currentPaths();
 
   QDialog::accept();
 }

--- a/src/qmapshack/gis/rte/router/routino/CRouterRoutinoPathSetup.h
+++ b/src/qmapshack/gis/rte/router/routino/CRouterRoutinoPathSetup.h
@@ -38,6 +38,12 @@ class CRouterRoutinoPathSetup : public QDialog, private Ui::IRouterRoutinoPathSe
   void slotItemSelectionChanged();
 
  private:
+  /**
+   * @brief Get the paths currently listed in the dialog
+   * @return
+   */
+  QStringList currentPaths() const;
+
   QStringList& paths;
 };
 

--- a/src/qmapshack/map/CMapDraw.cpp
+++ b/src/qmapshack/map/CMapDraw.cpp
@@ -96,8 +96,8 @@ void CMapDraw::setupMapPath() {
 void CMapDraw::setupMapPath(const QString& path) {
   qDebug() << "CMapDraw::setupMapPath(path)";
   QStringList paths(mapPaths);
-  if (!mapPaths.contains(path)) {
-    paths << path;
+  if (!containsPath(mapPaths, path)) {
+    paths << cleanPath(path);
   }
   setupMapPath(paths);
 }
@@ -277,6 +277,14 @@ void CMapDraw::loadMapList(QSettings& cfg) {
   QMutexLocker lock(&CMapItem::mutexActiveMaps);
   mapList->clear();
 
+  // A map belongs to a registered path if both resolve to the same directory. Resolve the
+  // registered paths right here: a path that could not be resolved when it was read from the
+  // configuration must not lose its maps once it is back.
+  QSet<QString> registeredPaths;
+  for (const QString& path : std::as_const(mapPaths)) {
+    registeredPaths << resolvedPath(path);
+  }
+
   // create a temp list of all maps in the paths
   QMap<QString, CMapItem*> mapsFound;
   for (const QString& path : std::as_const(mapPaths)) {
@@ -314,7 +322,7 @@ void CMapDraw::loadMapList(QSettings& cfg) {
     // If the map path is not part of the map paths list also delete
     // the file as it is no longer part of the used maps.
     QFileInfo fi(map->getFilename());
-    if (key != map->getKey() || !mapPaths.contains(fi.absolutePath())) {
+    if (key != map->getKey() || !registeredPaths.contains(resolvedPath(fi.absolutePath()))) {
       delete map;
       continue;
     }

--- a/src/qmapshack/map/CMapPathSetup.cpp
+++ b/src/qmapshack/map/CMapPathSetup.cpp
@@ -23,6 +23,7 @@
 #include "CMainWindow.h"
 #include "map/CMapDraw.h"
 #include "map/CMapList.h"
+#include "misc.h"
 #include "svgticon/CSvgtIcon.h"
 
 CMapPathSetup::CMapPathSetup(QStringList& paths, QString& pathCache)
@@ -55,14 +56,23 @@ void CMapPathSetup::slotItemSelectionChanged() {
   toolDelete->setEnabled(!items.isEmpty());
 }
 
-void CMapPathSetup::slotAddPath() {
-  QString path = QFileDialog::getExistingDirectory(this, tr("Select map path..."), QDir::homePath());
-  if (!path.isEmpty()) {
-    if (!paths.contains(path)) {
-      QListWidgetItem* item = new QListWidgetItem(listWidget);
-      item->setText(path);
-    }
+QStringList CMapPathSetup::currentPaths() const {
+  QStringList paths;
+  for (int i = 0; i < listWidget->count(); i++) {
+    paths << listWidget->item(i)->text();
   }
+  return paths;
+}
+
+void CMapPathSetup::slotAddPath() {
+  // keep the path as the user picked it, only cleaned. Comparing resolves it later on.
+  const QString& path = cleanPath(QFileDialog::getExistingDirectory(this, tr("Select map path..."), QDir::homePath()));
+  if (path.isEmpty() || containsPath(currentPaths(), path)) {
+    return;
+  }
+
+  QListWidgetItem* item = new QListWidgetItem(listWidget);
+  item->setText(path);
 }
 
 void CMapPathSetup::slotDelPath() {
@@ -85,11 +95,7 @@ void CMapPathSetup::slotMapHonk() {
 }
 
 void CMapPathSetup::accept() {
-  paths.clear();
-  for (int i = 0; i < listWidget->count(); i++) {
-    QListWidgetItem* item = listWidget->item(i);
-    paths << item->text();
-  }
+  paths = currentPaths();
 
   pathCache = QDir(labelCacheRoot->text()).absolutePath();
 

--- a/src/qmapshack/map/CMapPathSetup.h
+++ b/src/qmapshack/map/CMapPathSetup.h
@@ -40,6 +40,12 @@ class CMapPathSetup : public QDialog, private Ui::IMapPathSetup {
   void slotMapHonk();
 
  private:
+  /**
+   * @brief Get the paths currently listed in the dialog
+   * @return
+   */
+  QStringList currentPaths() const;
+
   QStringList& paths;
   QString& pathCache;
 };

--- a/src/qmapshack/misc.h
+++ b/src/qmapshack/misc.h
@@ -20,7 +20,9 @@
 #define MISC_H
 
 #include <QCollator>
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QMessageBox>
 #include <algorithm>
 #include <initializer_list>
@@ -57,5 +59,56 @@ inline void openFileCheckSuccess(QIODeviceBase::OpenMode mode, QFile& file) {
 }
 
 inline QString toRichText(const QString& text) { return QString("<div>%1</div").arg(text); }
+
+/**
+   @brief Bring a path into the form used for storage and display
+
+   Removes a trailing slash, redundant separators and "." / ".." elements. The path stays
+   the one the user picked. A symbolic link is not resolved, so a registered path remains
+   recognizable and keeps pointing through the link.
+
+   @param path  the path to clean
+   @return the cleaned path
+ */
+inline QString cleanPath(const QString& path) { return path.isEmpty() ? path : QDir::cleanPath(path); }
+
+/**
+   @brief Bring a path into the form used for comparison
+
+   A path picked with QFileDialog and the same path built from a directory listing can
+   denote one directory and still differ as strings: by a trailing slash, by a symbolic
+   link (`/var` vs. `/private/var` on macOS) or by their Unicode normalization (NFC vs. NFD
+   on macOS). Resolving both sides removes all three differences.
+
+   A path that does not exist - an unplugged drive - cannot be resolved and is only cleaned.
+   Both sides of a comparison have to be resolved at the same time therefore. Else a path
+   that became resolvable in between will no longer match.
+
+   @param path  the path to resolve
+   @return the resolved path, or the cleaned path if it does not exist (yet)
+ */
+inline QString resolvedPath(const QString& path) {
+  if (path.isEmpty()) {
+    return path;
+  }
+  const QString& resolved = QFileInfo(path).canonicalFilePath();
+  return resolved.isEmpty() ? QDir::cleanPath(path) : resolved;
+}
+
+/**
+   @brief Test if a path is registered already
+
+   Paths are compared by their resolved form. Thus a path and a symbolic link to it count
+   as the same registration and the directory's content is not listed twice.
+
+   @param paths  the registered paths
+   @param path   the path to look for
+   @return true if path denotes one of the registered paths
+ */
+inline bool containsPath(const QStringList& paths, const QString& path) {
+  const QString& resolved = resolvedPath(path);
+  return std::any_of(paths.begin(), paths.end(),
+                     [&resolved](const QString& other) { return resolvedPath(other) == resolved; });
+}
 
 #endif  // MISC_H

--- a/src/qmapshack/poi/CPoiDraw.cpp
+++ b/src/qmapshack/poi/CPoiDraw.cpp
@@ -97,8 +97,8 @@ void CPoiDraw::setupPoiPath() {
 
 void CPoiDraw::setupPoiPath(const QString& path) {
   QStringList paths(poiPaths);
-  if (!poiPaths.contains(path)) {
-    paths << path;
+  if (!containsPath(poiPaths, path)) {
+    paths << cleanPath(path);
   }
   setupPoiPath(paths);
 }

--- a/src/qmapshack/poi/CPoiPathSetup.cpp
+++ b/src/qmapshack/poi/CPoiPathSetup.cpp
@@ -21,6 +21,7 @@
 #include <QtWidgets>
 
 #include "CMainWindow.h"
+#include "misc.h"
 #include "poi/CPoiDraw.h"
 #include "svgticon/CSvgtIcon.h"
 
@@ -52,23 +53,29 @@ void CPoiPathSetup::slotItemSelectionChanged() {
 }
 
 void CPoiPathSetup::accept() {
-  paths.clear();
-  for (int i = 0; i < listWidget->count(); i++) {
-    QListWidgetItem* item = listWidget->item(i);
-    paths << item->text();
-  }
+  paths = currentPaths();
 
   QDialog::accept();
 }
 
-void CPoiPathSetup::slotAddPath() {
-  QString path = QFileDialog::getExistingDirectory(this, tr("Select POI file path..."), QDir::homePath());
-  if (!path.isEmpty()) {
-    if (!paths.contains(path)) {
-      QListWidgetItem* item = new QListWidgetItem(listWidget);
-      item->setText(path);
-    }
+QStringList CPoiPathSetup::currentPaths() const {
+  QStringList paths;
+  for (int i = 0; i < listWidget->count(); i++) {
+    paths << listWidget->item(i)->text();
   }
+  return paths;
+}
+
+void CPoiPathSetup::slotAddPath() {
+  // keep the path as the user picked it, only cleaned. Comparing resolves it later on.
+  const QString& path =
+      cleanPath(QFileDialog::getExistingDirectory(this, tr("Select POI file path..."), QDir::homePath()));
+  if (path.isEmpty() || containsPath(currentPaths(), path)) {
+    return;
+  }
+
+  QListWidgetItem* item = new QListWidgetItem(listWidget);
+  item->setText(path);
 }
 
 void CPoiPathSetup::slotDelPath() {

--- a/src/qmapshack/poi/CPoiPathSetup.h
+++ b/src/qmapshack/poi/CPoiPathSetup.h
@@ -36,6 +36,12 @@ class CPoiPathSetup : public QDialog, private Ui::IPoiPathSetup {
   void slotItemSelectionChanged();
 
  private:
+  /**
+   * @brief Get the paths currently listed in the dialog
+   * @return
+   */
+  QStringList currentPaths() const;
+
   QStringList& paths;
 };
 


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1230

### What you have done:
[comment]: # (Describe roughly.)

Map and DEM paths were stored exactly as QFileDialog returned them, while loadMapList()/loadDemList() compared them against QFileInfo::absolutePath() of the found files. On macOS the dialog returns a trailing slash, so the comparison failed and every known map/DEM was dropped on startup. It took a "Reload maps" - which rewrites the empty key list first - to get them back, without their activation state.

A registered path is stored as the user picked it, only cleaned. It is resolved for the comparison only, which besides the trailing slash also covers a symlinked prefix (/var vs. /private/var) and the NFC/NFD mismatch between the macOS file dialog and the directory listing. Both sides are resolved at the same moment, so a path that could not be resolved while the configuration was read still finds its maps once the drive is back. A path that stays away leaves its maps and DEM marked missing, as before.

POI and Routino share the helpers now. Routino had no path comparison at all, so the same folder could be added twice - once with and once without trailing slash
- which listed every database in it twice.

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
