### PR TITLE
[QMS-1229] Fix: Invalid and/or inaccurate elevation shading

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V1.XX.X
 [QMS-1223] Fix: Crash when a map view is closed right after it was opened
 [QMS-1224] Fix: --locale switches the strings but not date and number formats
 [QMS-1227] Fix: Crash after activating a map that is already active
+[QMS-1229] Fix: Invalid and/or inaccurate elevation shading
 [QMS-1230] Fix: Configured DEM and MAPS are not preserved after a restart
 
 V1.21.0

--- a/src/qmapshack/dem/IDem.cpp
+++ b/src/qmapshack/dem/IDem.cpp
@@ -384,7 +384,7 @@ quint8 IDem::slopeColorByte(qreal slope, const qreal* slopeStepTable) const {
 }
 
 qreal IDem::maxElevationInWindow(const float* win) const {
-  qreal meters = -2.0;
+  qreal meters = -12000.0; // lowest point on earth
   for (unsigned int i = 0; i < eWinsize3x3; i++) {
     if ((!hasNoData || win[i] != noData) && win[i] > meters) {
       meters = win[i];
@@ -402,11 +402,11 @@ qreal IDem::maxElevationInWindow(const float* win) const {
 quint8 IDem::elevationLimitByte(qreal elevation) const { return (elevation >= getElevationLimit()) ? 1 : 0; }
 
 quint8 IDem::elevationShadeByte(qreal elevation, int limitLow, int limitHi) const {
-  if (elevation < limitLow) {
+  if (elevation <= limitLow + 0.01) {
     return 0;
   } else if (elevation < limitHi) {
     const qreal relLimit = (elevation - limitLow) / (limitHi - limitLow);
-    return 1 + relLimit * 253;
+    return 1 + qRound(relLimit * 253);
   } else {
     return 255;
   }


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1229

### What you have done:
[comment]: # (Describe roughly.)

- File _src/qmapshack/dem/IDem.cpp_ function `IDem::maxElevationInWindow`:
Replaced `qreal meters = -2.0;` by `qreal meters = -12000.0;` 
- File _src/qmapshack/dem/IDem.cpp_ function `IDem::elevationShadeByte`:
Replaced `if (elevation < limitLow) {` by `if (elevation <= limitLow + 0.01) {`
- File _src/qmapshack/dem/IDem.cpp_ function `IDem::elevationShadeByte`:
Replaced `return 1 + relLimit * 253;` by `return 1 + qRound(relLimit * 253);`

### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

1. Try to locate Netherland's area below 1m, 2m, 3m, ... using _Elevation Shading_ with _Elevation Low_
2. See that area gets shown according to DEM's elevation data
3. Try to see coast lines, e.g. Netherland's _IJsselmeer_, isle of _Elba_, ...
4. See that coast lines get shown according to DEM's elevation data precision

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
