### PR TITLE
[QMS-1234] Reduce the minimum window size of the track details page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -656,6 +656,33 @@ loses its close button too. Every docker in both apps must keep `DockWidgetClosa
 
 ---
 
+## Minimum sizes — a preference is not a requirement
+
+Qt enforces `minimumSizeHint()` on a window with a layout, so anything that inflates it decides the
+smallest the main window can be. The track details page once pinned it to 1648x717 — unusable on a
+1366x768 screen — through four separate places that read a *preferred* width as a *required* one.
+All four are easy to write again:
+
+- **A `QLabel` without `wordWrap` reports its whole unwrapped string as a minimum.** With `wordWrap`
+  it reports its widest word — 436 → 52 for one filter label. Qt 6 turns `hasHeightForWidth()` on by
+  itself there; the `setSizePolicy()` line usually recommended alongside is measured to change
+  nothing. Give any label holding a sentence `wordWrap`, especially one whose text is set at runtime
+  or translated: `labelInfo`'s minimum used to move with the interface language.
+- **`QSplitter` sizes a child through `qSmartMinSize()`**, which takes `qMax(sizeHint,
+  minimumSizeHint)` unless the child's size policy carries a `ShrinkFlag`. `MinimumExpanding` and
+  `Minimum` have none, so the child's preferred width becomes a hard floor — 222 px of the details
+  page. Use `Expanding` or `Preferred` for a splitter child that may shrink.
+- **A `QTreeWidget` row is as high as the item's size hint, which does not follow the width.** A
+  wrapped label in an item widget is clipped as the tree narrows; recompute the item size hints from
+  `heightForWidth()` on resize, as `CDetailsTrk::updateFilterRowHeights()` does.
+- **A combo box beside a field frame adds both widths.** Stacking it above cost the speed filters
+  nothing and saved 190 px.
+
+Measure before believing any of this of a given widget: walk the tree printing `minimumSizeHint()`,
+and remember that a `sizeHint()` is what the widget *wants*.
+
+---
+
 ## GDAL
 
 ### `QImage::Format_Indexed8` + `RasterIO`/`ReadRaster` — row padding
@@ -903,10 +930,13 @@ small sources.
 
 ## Open work
 
-Two analysed-but-unstarted designs live in `.notes/`, each wanting its own branch:
-`QMS-1135-overview-restore-plan.md` (transactional rollback when a *Fix overviews* job is cancelled)
-and `waypoint-icon-resolution-plan.md` (32 → 96 px waypoint icons, gated on storing `icon_t::focus`
-relative). De-freeze either by pointing at the file.
+Analysed designs live in `.notes/`, each wanting its own branch. De-freeze one by pointing at the
+file.
+
+- `QMS-1135-overview-restore-plan.md` — transactional rollback when a *Fix overviews* job is
+  cancelled.
+- `waypoint-icon-resolution-plan.md` — 32 → 96 px waypoint icons, gated on storing `icon_t::focus`
+  relative.
 
 ### CMake — remaining
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V1.XX.X
 [QMS-1227] Fix: Crash after activating a map that is already active
 [QMS-1229] Fix: Invalid and/or inaccurate elevation shading
 [QMS-1230] Fix: Configured DEM and MAPS are not preserved after a restart
+[QMS-1234] Reduce the minimum window size of the track details page
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files

--- a/src/qmapshack/gis/trk/CDetailsTrk.cpp
+++ b/src/qmapshack/gis/trk/CDetailsTrk.cpp
@@ -58,7 +58,9 @@ template <typename filter>
 static void addFilters(QTreeWidgetItem* itemGroup, CGisItemTrk& trk, qint32& minWidth) {
   QTreeWidgetItem* item = new QTreeWidgetItem(itemGroup);
   itemGroup->treeWidget()->setItemWidget(item, /* column = */ 0, new filter(trk, itemGroup->treeWidget()));
-  minWidth = qMax(minWidth, itemGroup->treeWidget()->itemWidget(item, 0)->sizeHint().width());
+  // minimumSizeHint, never sizeHint: a wrapped label prefers a wide two-line box but needs only its
+  // widest word, and a hard minimum derived from the preference is what pins the whole window.
+  minWidth = qMax(minWidth, itemGroup->treeWidget()->itemWidget(item, 0)->minimumSizeHint().width());
 }
 
 template <typename filter1, typename filter2, typename... remainingFilters>
@@ -206,7 +208,40 @@ CDetailsTrk::CDetailsTrk(CGisItemTrk& trk) : INotifyTrk(CGisItemTrk::eVisualDeta
   // limit tree widget horizontal size to the filter widget with the largest minimum size
   treeFilter->setMinimumWidth(minWidth + treeFilter->indentation());
 
+  // The rows are as high as their width makes them, so they have to be measured again whenever it
+  // changes. The viewport is what carries the width; the tree itself also counts its frame.
+  treeFilter->viewport()->installEventFilter(this);
+
   slotShowPlots();
+}
+
+void CDetailsTrk::updateFilterRowHeights() {
+  // A group per row of addFilterGroup(), a filter per row below it. Nothing else is in this tree.
+  for (int g = 0; g < treeFilter->topLevelItemCount(); g++) {
+    QTreeWidgetItem* group = treeFilter->topLevelItem(g);
+
+    for (int f = 0; f < group->childCount(); f++) {
+      QTreeWidgetItem* item = group->child(f);
+      const QWidget* filter = treeFilter->itemWidget(item, 0);
+      if (nullptr == filter) {
+        continue;
+      }
+
+      const int height =
+          filter->hasHeightForWidth() ? filter->heightForWidth(filter->width()) : filter->sizeHint().height();
+      // Only on a change: setSizeHint schedules a layout, and a layout is what got us here.
+      if (item->sizeHint(0).height() != height) {
+        item->setSizeHint(0, QSize(0, height));
+      }
+    }
+  }
+}
+
+bool CDetailsTrk::eventFilter(QObject* watched, QEvent* event) {
+  if (watched == treeFilter->viewport() && QEvent::Resize == event->type()) {
+    updateFilterRowHeights();
+  }
+  return QWidget::eventFilter(watched, event);
 }
 
 void CDetailsTrk::changeEvent(QEvent* e) {

--- a/src/qmapshack/gis/trk/CDetailsTrk.h
+++ b/src/qmapshack/gis/trk/CDetailsTrk.h
@@ -44,6 +44,17 @@ class CDetailsTrk : public QWidget, public INotifyTrk, private Ui::IDetailsTrk {
 
  protected:
   void changeEvent(QEvent* e) override;
+  bool eventFilter(QObject* watched, QEvent* event) override;
+
+ private:
+  /**
+     @brief Give every filter row the height its width needs.
+
+     A filter is an item widget, and a tree row is as high as the item's size hint says - which does
+     not follow the width. A wrapped label needs another line each time the tree gets narrower, so
+     without this the text is cut off at the bottom of its row.
+   */
+  void updateFilterRowHeights();
 
  private slots:
   void slotNameChanged(const QString& name);

--- a/src/qmapshack/gis/trk/IDetailsTrk.ui
+++ b/src/qmapshack/gis/trk/IDetailsTrk.ui
@@ -347,6 +347,9 @@
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
           </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item>
@@ -400,7 +403,7 @@
       </widget>
       <widget class="QTabWidget" name="tabWidget">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>

--- a/src/qmapshack/gis/trk/filter/IFilterDelete.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterDelete.ui
@@ -56,6 +56,9 @@
        <property name="text">
         <string>Remove all hidden track points permanently.</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/qmapshack/gis/trk/filter/IFilterDeleteExtension.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterDeleteExtension.ui
@@ -44,6 +44,9 @@
      <property name="text">
       <string>&lt;b&gt;Remove Extension from all Track Points&lt;/b&gt;</string>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">

--- a/src/qmapshack/gis/trk/filter/IFilterDouglasPeuker.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterDouglasPeuker.ui
@@ -56,6 +56,9 @@
        <property name="text">
         <string>Hide track points if the distance to a line between neighboring points is less than</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/qmapshack/gis/trk/filter/IFilterInterpolateElevation.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterInterpolateElevation.ui
@@ -62,6 +62,9 @@
        <property name="text">
         <string>Replace elevation of track points with interpolated data.</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/qmapshack/gis/trk/filter/IFilterLoopsCut.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterLoopsCut.ui
@@ -34,6 +34,9 @@
      <property name="text">
       <string>Cut track when loop length is greater than</string>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="0" rowspan="3">

--- a/src/qmapshack/gis/trk/filter/IFilterMedian.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterMedian.ui
@@ -56,6 +56,9 @@
        <property name="text">
         <string>Smooth deviation of the track points elevation with a Median filter of size </string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/qmapshack/gis/trk/filter/IFilterObscureDate.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterObscureDate.ui
@@ -67,6 +67,9 @@
        <property name="text">
         <string>with each track point. 0 sec. will remove timestamps.</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/qmapshack/gis/trk/filter/IFilterReplaceElevation.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterReplaceElevation.ui
@@ -56,6 +56,9 @@
        <property name="text">
         <string>Replace elevation of track points with the values from loaded DEM files in view</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/qmapshack/gis/trk/filter/IFilterSpeedCycle.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterSpeedCycle.ui
@@ -42,7 +42,7 @@
     <number>3</number>
    </property>
    <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QVBoxLayout" name="horizontalLayout_3">
      <property name="spacing">
       <number>6</number>
      </property>
@@ -50,19 +50,6 @@
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QComboBox" name="comboCyclingType"/>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </item>
@@ -93,7 +80,7 @@
         <property name="spacing">
          <number>3</number>
         </property>
-        <item row="6" column="3">
+        <item row="7" column="2">
          <widget class="QDoubleSpinBox" name="spinSlopeAtMaxSpeed">
           <property name="suffix">
            <string/>
@@ -112,7 +99,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="3">
+        <item row="4" column="2">
          <widget class="QDoubleSpinBox" name="spinSlopeAtMinSpeed">
           <property name="suffix">
            <string/>
@@ -128,17 +115,17 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="5" column="1" colspan="2">
          <widget class="QLabel" name="label_9">
           <property name="text">
            <string>Downhill:</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="5" column="3">
+        <item row="6" column="2">
          <widget class="QDoubleSpinBox" name="spinMaxSpeed">
           <property name="suffix">
            <string/>
@@ -160,7 +147,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="2">
+        <item row="4" column="1">
          <widget class="QLabel" name="label_5">
           <property name="text">
            <string>at positive Slope</string>
@@ -170,7 +157,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="4">
+        <item row="0" column="3">
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -183,17 +170,17 @@
           </property>
          </spacer>
         </item>
-        <item row="1" column="1">
+        <item row="0" column="1" colspan="2">
          <widget class="QLabel" name="label_11">
           <property name="text">
            <string>Plain Level:</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="1" column="3">
+        <item row="1" column="2">
          <widget class="QDoubleSpinBox" name="spinPlainSpeed">
           <property name="suffix">
            <string/>
@@ -215,7 +202,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="2" colspan="2">
+        <item row="8" column="1" colspan="2">
          <widget class="QPushButton" name="pushSetMinMaxSlope">
           <property name="toolTip">
            <string>User defined positive and negative slope values will be replaced by the minimum and maximum slope values from the track.</string>
@@ -225,7 +212,7 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="2">
+        <item row="7" column="1">
          <widget class="QLabel" name="label_7">
           <property name="text">
            <string>at negative Slope</string>
@@ -235,7 +222,7 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
+        <item row="6" column="1">
          <widget class="QLabel" name="label_6">
           <property name="text">
            <string>Max Speed</string>
@@ -245,7 +232,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="3">
+        <item row="3" column="2">
          <widget class="QDoubleSpinBox" name="spinMinSpeed">
           <property name="suffix">
            <string/>
@@ -267,7 +254,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="3" column="1">
          <widget class="QLabel" name="label_4">
           <property name="text">
            <string>Min Speed</string>
@@ -277,17 +264,17 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="2" column="1" colspan="2">
          <widget class="QLabel" name="label_8">
           <property name="text">
            <string>Uphill:</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="1" column="1">
          <widget class="QLabel" name="label_10">
           <property name="text">
            <string>Speed at zero Slope</string>
@@ -297,7 +284,7 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="3">
+        <item row="9" column="2">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/src/qmapshack/gis/trk/filter/IFilterSpeedHike.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterSpeedHike.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="horizontalLayout">
    <property name="spacing">
     <number>3</number>
    </property>
@@ -33,19 +33,6 @@
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QComboBox" name="comboHikingType"/>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>

--- a/src/qmapshack/gis/trk/filter/IFilterSplitSegment.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterSplitSegment.ui
@@ -44,6 +44,9 @@
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Split Segments into Tracks&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -55,6 +58,9 @@
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Creates a new track for every segment within this track.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/qmapshack/gis/trk/filter/IFilterSplitTrack.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterSplitTrack.ui
@@ -131,6 +131,9 @@
        <property name="text">
         <string>Split track into multiple shorter tracks</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/qmapshack/gis/trk/filter/IFilterSubPt2Pt.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterSubPt2Pt.ui
@@ -34,6 +34,9 @@
      <property name="text">
       <string>&lt;b&gt;Convert track subpoints to points&lt;/b&gt;</string>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -45,6 +48,9 @@
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Convert subpoints obtained from routing to ordinary track points </string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/qmapshack/gis/trk/filter/IFilterTerrainSlope.ui
+++ b/src/qmapshack/gis/trk/filter/IFilterTerrainSlope.ui
@@ -56,6 +56,9 @@
        <property name="text">
         <string>Calculate slope of the terrain based on loaded DEM files.</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1234

### What you have done:
[comment]: # (Describe roughly.)

Qt enforces minimumSizeHint() on a window with a layout, so the details page decided how small the main window could be: 1648x717, which does not fit a 1366x768 screen and which the user cannot resize back. It is 1062x717 now. Four places read a preferred width as a required one.

A QLabel without wordWrap reports its whole unwrapped string as a minimum. Fourteen sentence labels in gis/trk/filter/*.ui and labelInfo wrap now; labelInfo alone drops from 449 to 80, and its text is the translated track summary, so the floor no longer moves with the interface language. Titles and the fragments that sit between controls keep their single line. Qt 6 turns hasHeightForWidth() on by itself for a wrapped label, so no size policy goes with it.

addFilters() derives treeFilter's minimum width from minimumSizeHint() instead of sizeHint(), which is what its own comment always said. A wrapped label prefers a wide two-line box but needs only its widest word, and a hard minimum taken from the preference is what pinned the tab.

A filter is an item widget, and a tree row is as high as the item's size hint, which does not follow the width - so a wrapped label is cut off as the tree narrows. updateFilterRowHeights() measures the rows again whenever treeFilter's viewport is resized.

QSplitter sizes a child through qSmartMinSize(), which takes the larger of sizeHint and minimumSizeHint unless the child's size policy carries a ShrinkFlag. The inner tabWidget was MinimumExpanding, which has none, so the Info tab's preferred 866 became a floor where its need is
404. Expanding keeps the growing and adds the shrinking.

Both speed pages put their mode combo beside the frame holding the fields, so the two widths added up. The combo sits above it now, and the cycling page folds its four-column grid into two, with Plain Level:, Uphill: and Downhill: as headings over their own fields instead of a right-hand label column. No filter is an outlier any more; the widest five are within 60 px of each other.

The plots keep their 100 px minimum height: three readable plots are the point of the page, and the height was never the binding side.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

Compare minimum horizontal size of QMS when a track details tab is open.

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
