### PR TITLE
[QMS-1237] Fix: Track information in the database view is empty for n…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V1.XX.X
 [QMS-1229] Fix: Invalid and/or inaccurate elevation shading
 [QMS-1230] Fix: Configured DEM and MAPS are not preserved after a restart
 [QMS-1234] Reduce the minimum window size of the track details page
+[QMS-1237] Fix: Track information in the database view is empty for newly saved tracks
 
 V1.21.0
 [QMS-585] Preserve extra XML namespaces in GPX files

--- a/src/qmapshack/canvas/CCanvas.cpp
+++ b/src/qmapshack/canvas/CCanvas.cpp
@@ -1007,7 +1007,7 @@ void CCanvas::slotUpdateTrackInfo(bool updateVisuals) {
 
     QString text;
     if (isShowTrackSummary()) {
-      text += trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity);
+      text += trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity | IGisItem::eFeatureShowIcon);
     }
 
     if (isShowMinMaxSummary()) {

--- a/src/qmapshack/gis/CWksItemDelegate.cpp
+++ b/src/qmapshack/gis/CWksItemDelegate.cpp
@@ -899,7 +899,7 @@ bool CWksItemDelegate::helpEventItem(const QPoint& pos, const QPoint& posGlobal,
   const auto& layout = getRectanglesItem(opt, item);
 
   if (layout.rectName.contains(pos)) {
-    QToolTip::showText(posGlobal, item.getInfo(IWksItem::eFeatureShowName), view);
+    QToolTip::showText(posGlobal, item.getInfo(IWksItem::eFeatureShowName | IWksItem::eFeatureShowIcon), view);
     return true;
   } else if (layout.rectStatus.contains(pos)) {
     if (itemStatusControl.trk.flags == 0 && itemStatusControl.wpt.flags == 0 && itemStatusControl.rte.flags == 0 &&
@@ -911,7 +911,7 @@ bool CWksItemDelegate::helpEventItem(const QPoint& pos, const QPoint& posGlobal,
                  "setup. See menu->Workspace->Setup Workspace")),
           view, {}, 5000);
     } else {
-      QToolTip::showText(posGlobal, item.getInfo(IWksItem::eFeatureShowName), view);
+      QToolTip::showText(posGlobal, item.getInfo(IWksItem::eFeatureShowName | IWksItem::eFeatureShowIcon), view);
     }
     return true;
   } else if (layout.rectChanged.contains(pos)) {

--- a/src/qmapshack/gis/IWksItem.h
+++ b/src/qmapshack/gis/IWksItem.h
@@ -75,7 +75,8 @@ class IWksItem : public QTreeWidgetItem {
     eFeatureShowFullText = 0x00000002,
     eFeatureShowActivity = 0x00000004,
     eFeatureShowDateTime = 0x00000008,
-    eFeatureShowLinks = 0x00000010
+    eFeatureShowLinks = 0x00000010,
+    eFeatureShowIcon = 0x00000020
   };
 
   eBaseType getBaseType() const;

--- a/src/qmapshack/gis/db/CDBItem.cpp
+++ b/src/qmapshack/gis/db/CDBItem.cpp
@@ -18,11 +18,42 @@
 
 #include "gis/db/CDBItem.h"
 
+#include <QRegularExpression>
 #include <QtSql>
 
 #include "gis/CGisWorkspace.h"
 #include "gis/db/IDBFolder.h"
 #include "gis/db/macros.h"
+
+namespace {
+/**
+   @brief Cut a stored item comment down to tool tip size
+
+   The comment is the item's info as HTML. Cutting it on character level can end inside a tag and
+   QTextDocument will swallow everything behind an unterminated one, leaving an empty tool tip and an
+   empty status line in the delegate. Embedded images are the worst case: a base64 data URI eats the
+   whole budget on its own. Drop images first - the tool tip is a text summary - then cut back to the
+   last complete tag.
+
+   @param comment  The comment as read from the database
+   @return The comment ready to be used as tool tip
+ */
+QString shortenComment(QString comment) {
+  static const QRegularExpression reImage("<img[^>]*>", QRegularExpression::CaseInsensitiveOption);
+  comment.remove(reImage);
+
+  if (comment.size() > 300) {
+    comment.truncate(297);
+    const qsizetype idxOpen = comment.lastIndexOf('<');
+    if (idxOpen > comment.lastIndexOf('>')) {
+      comment.truncate(idxOpen);
+    }
+    comment += "...";
+  }
+
+  return comment;
+}
+}  // namespace
 
 CDBItem::CDBItem(QSqlDatabase& db, quint64 id, IDBFolder* parent) : IDBItem(parent, eTypeItem), db(db), id(id) {
   QSqlQuery query(db);
@@ -37,12 +68,7 @@ CDBItem::CDBItem(QSqlDatabase& db, quint64 id, IDBFolder* parent) : IDBItem(pare
 
     date = query.value(4).toDateTime();
 
-    // limit comment to 300 characters
-    QString comment = query.value(5).toString();
-    if (comment.size() > 300) {
-      comment = comment.left(297) + "...";
-    }
-    setToolTip(comment);
+    setToolTip(shortenComment(query.value(5).toString()));
   }
 
   updateAge();

--- a/src/qmapshack/gis/db/CSelectSaveAction.cpp
+++ b/src/qmapshack/gis/db/CSelectSaveAction.cpp
@@ -26,9 +26,9 @@ CSelectSaveAction::CSelectSaveAction(const IGisItem* src, const IGisItem* tar, Q
   setupUi(this);
 
   labelIcon1->setPixmap(src->getDisplayIcon());
-  labelInfo1->setText(src->getInfo(IGisItem::eFeatureShowName));
+  labelInfo1->setText(src->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowIcon));
   labelIcon2->setPixmap(tar->getDisplayIcon());
-  labelInfo2->setText(tar->getInfo(IGisItem::eFeatureShowName));
+  labelInfo2->setText(tar->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowIcon));
 
   adjustSize();
 

--- a/src/qmapshack/gis/prj/CDetailsPrj.cpp
+++ b/src/qmapshack/gis/prj/CDetailsPrj.cpp
@@ -509,7 +509,8 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor, QList<CGisItemTrk*>& trks, QL
       if (w1 < 300) {
         table->cellAt(cnt, eInfo1)
             .firstCursorPosition()
-            .insertHtml(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
+            .insertHtml(
+                trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity | IGisItem::eFeatureShowIcon));
 
         QTextTable* table1 = table->cellAt(cnt, eInfo1).lastCursorPosition().insertTable(1, 2, fmtTableInfo);
 
@@ -524,7 +525,7 @@ void CDetailsPrj::drawByGroup(QTextCursor& cursor, QList<CGisItemTrk*>& trks, QL
         QTextTable* table1 = table->cellAt(cnt, eInfo1).firstCursorPosition().insertTable(1, 3, fmtTableInfo);
 
         table1->cellAt(0, 0).firstCursorPosition().insertHtml(
-            trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
+            trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity | IGisItem::eFeatureShowIcon));
 
         QImage profile(w1, h1, QImage::Format_ARGB32);
         getTrackProfile(trk, nullptr, profile);
@@ -783,7 +784,8 @@ void CDetailsPrj::drawByTrack(QTextCursor& cursor, QList<CGisItemTrk*>& trks, QL
     addIcon(table, eSym1, cnt, trk->getDisplayIcon(), trk->getKey().item, trk->isReadOnly(), printable);
     table->cellAt(cnt, eInfo2)
         .firstCursorPosition()
-        .insertHtml(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
+        .insertHtml(
+            trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity | IGisItem::eFeatureShowIcon));
 
     QTextTable* table1 = table->cellAt(cnt, eData2).lastCursorPosition().insertTable(1, 2, fmtTableInfo);
 
@@ -858,7 +860,8 @@ void CDetailsPrj::drawByDetails(QTextCursor& cursor, QList<CGisItemTrk*>& trks, 
     addIcon(table, eSym1, cnt, trk->getDisplayIcon(), trk->getKey().item, trk->isReadOnly(), printable);
     table->cellAt(cnt, eInfo2)
         .firstCursorPosition()
-        .insertHtml(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity));
+        .insertHtml(
+            trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity | IGisItem::eFeatureShowIcon));
 
     table->mergeCells(cnt, eData2, 1, 2);
     table->cellAt(cnt, eData2)

--- a/src/qmapshack/gis/trk/CGisItemTrk.cpp
+++ b/src/qmapshack/gis/trk/CGisItemTrk.cpp
@@ -413,7 +413,7 @@ QString CGisItemTrk::getInfo(quint32 feature) const {
   const QList<trkact_t>& acts = activities.getAllActivities().values();
 
   if (feature & eFeatureShowName) {
-    if ((actCnt == 1) && (acts.first() != CTrackData::trkpt_t::eAct20None)) {
+    if ((feature & eFeatureShowIcon) && (actCnt == 1) && (acts.first() != CTrackData::trkpt_t::eAct20None)) {
       const CActivityTrk::desc_t& desc = activities.getDescriptor(acts.first());
       str += QString("<img width=16 height=16 src='%1'/>&nbsp;").arg(CSvgtIcon::htmlImageSrc(desc.iconSvg));
     }

--- a/src/qmapshack/gis/trk/CScrOptTrk.cpp
+++ b/src/qmapshack/gis/trk/CScrOptTrk.cpp
@@ -30,8 +30,8 @@ CScrOptTrk::CScrOptTrk(CGisItemTrk* trk, const QPoint& point, IMouse* parent) : 
   setupUi(this);
   setOrigin(point);
   label->setFont(CMainWindow::self().getMapFont());
-  label->setText(
-      trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity | IGisItem::eFeatureShowLinks));
+  label->setText(trk->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowActivity |
+                              IGisItem::eFeatureShowLinks | IGisItem::eFeatureShowIcon));
   adjustSize();
 
   toolProfile->setChecked(trk->hasUserFocus());

--- a/src/qmapshack/helpers/CSelectCopyAction.cpp
+++ b/src/qmapshack/helpers/CSelectCopyAction.cpp
@@ -29,9 +29,9 @@ CSelectCopyAction::CSelectCopyAction(const IGisItem* src, const IGisItem* tar, Q
   setupUi(this);
 
   labelIcon1->setPixmap(src->getDisplayIcon());
-  labelInfo1->setText(src->getInfo(IGisItem::eFeatureShowName));
+  labelInfo1->setText(src->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowIcon));
   labelIcon2->setPixmap(tar->getDisplayIcon());
-  labelInfo2->setText(tar->getInfo(IGisItem::eFeatureShowName));
+  labelInfo2->setText(tar->getInfo(IGisItem::eFeatureShowName | IGisItem::eFeatureShowIcon));
 
   connect(pushCopy, &QPushButton::clicked, this, [this]() { slotSelectResult(eResultCopy); });
   connect(pushSkip, &QPushButton::clicked, this, [this]() { slotSelectResult(eResultSkip); });


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1237

### What you have done:
[comment]: # (Describe roughly.)

CDBProject stores getInfo(eFeatureShowName | eFeatureShowFullText) in items.comment. Since 5ee8f0687 that string starts with the activity icon as a data:image/png;base64 URI of several hundred to more than a thousand characters. CDBItem cut the comment at 297 characters, which lands inside that URI, so the <img ...> tag never closes and QTextDocument swallows the rest: no tool tip and no status line in the delegate.

- The embedded icon is opt-in now, via the new eFeatureShowIcon. The consumers that render the info as rich text pass it, the database comment and the search string do not. items.comment is the full text index (searchindex FTS4, MySQL FULLTEXT), which no longer collects a kilobyte of base64 per track.
- CDBItem drops images from the comment before shortening it and cuts back to the last complete tag. Dropping the images first is what repairs the already stored items, so no database migration is needed. The cut back covers the whole class of defect: the other item types carry no images, but a cut inside a <b> or <br/> breaks them just as badly.

Waypoints, routes and areas are unchanged otherwise. Their links are the only long tag they produce and those hang on eFeatureShowLinks, which no database path passes.



### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

See ticket

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
