### PR TITLE
[QMS-1243] Fix: Windows build breaks when clang-format sorts the Win3…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V1.XX.X
 [QMS-1242] Fix: Qt's strings are translated for languages QMapShack is not translated to
+[QMS-1243] Fix: Windows build breaks when clang-format sorts the Win32 includes
 
 V1.21.1
 [QMS-1212] Update macOS build scripts

--- a/src/qmapshack/setup/CAppSetupWin.cpp
+++ b/src/qmapshack/setup/CAppSetupWin.cpp
@@ -19,9 +19,9 @@
 #include <QtSystemDetection>
 #if defined(Q_OS_WIN32)
 
-#include <errhandlingapi.h>
-#include <fileapi.h>
-#include <winbase.h>
+// windows.h stays the only Win32 include: clang-format sorts an include block alphabetically, and
+// MSVC needs windows.h ahead of every other Win32 header or winnt.h fails with "No Target
+// Architecture".
 #include <windows.h>
 
 #include <QAbstractNativeEventFilter>

--- a/src/qmaptool/setup/CAppSetupWin.cpp
+++ b/src/qmaptool/setup/CAppSetupWin.cpp
@@ -19,9 +19,9 @@
 #include <QtSystemDetection>
 #if defined(Q_OS_WIN32)
 
-#include <errhandlingapi.h>
-#include <fileapi.h>
-#include <winbase.h>
+// windows.h stays the only Win32 include: clang-format sorts an include block alphabetically, and
+// MSVC needs windows.h ahead of every other Win32 header or winnt.h fails with "No Target
+// Architecture".
 #include <windows.h>
 
 #include <QAbstractNativeEventFilter>


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1243

### What you have done:
[comment]: # (Describe roughly.)

windows.h has to come first or MSVC stops in winnt.h with "No Target Architecture", and a sorted block puts it last of the four. It is the only Win32 include now: winbase.h, fileapi.h and errhandlingapi.h come with it, which JFritzle confirmed on a Windows build of both applications. A single include has nothing to sort, so no clang-format guard is needed - the comment above it states the invariant for whoever adds the next Win32 header.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

no test. just dry run

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
