### PR TITLE
[QMS-1244] Document all command line options in the man pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V1.XX.X
 [QMS-1242] Fix: Qt's strings are translated for languages QMapShack is not translated to
 [QMS-1243] Fix: Windows build breaks when clang-format sorts the Win32 includes
+[QMS-1244] Document all command line options in the man pages
 
 V1.21.1
 [QMS-1212] Update macOS build scripts

--- a/qmapshack.1
+++ b/qmapshack.1
@@ -2,22 +2,7 @@
 .SH NAME
 QMapShack \- GPS mapping (GeoTiff and vector) and GPSr management
 .SH SYNOPSIS
-\fBqmapshack\fP [\options\fP]
-[
-.B \-d
-|
-.B \-\-debug
-]
-[
-.B \-h
-|
-.B \-\-help
-]
-[
-.B \-n
-|
-.B \-\-no-splash
-]
+\fBqmapshack\fP [\fIoptions\fP]
 [
 .IR files ...
 ]
@@ -32,15 +17,42 @@ Main features:
   \- Handle data project-oriented.
 .SH OPTIONS
 .TP
-\fB\-d\fR, \fB\-\-debug\fR
-Run with debugging output.
-.TP
 \fB\-h\fR, \fB\-\-help\fR
-Displays the help message.
+Displays help on commandline options.
 .TP
-\fB\-n\fR, \fB\-\-no-splash\fR
-Start without splash screen.
+\fB\-\-help\-all\fR
+Displays help, including generic Qt options.
 .TP
+\fB\-v\fR, \fB\-\-version\fR
+Displays version information.
+.TP
+\fB\-n\fR, \fB\-\-no\-splash\fR
+Do not show splash screen.
+.TP
+\fB\-d\fR, \fB\-\-debug\fR
+Print debug output to console.
+.TP
+\fB\-f\fR, \fB\-\-logfile\fR
+Print debug output to logfile.
+.TP
+\fB\-c\fR, \fB\-\-config\fR \fIfile\fR
+File with QMapShack configuration.
+.TP
+\fB\-l\fR, \fB\-\-locale\fR \fIcode\fR
+Application locale.
+.TP
+\fB\-\-font\-family\fR \fIname\fR
+Application font family.
+.TP
+\fB\-\-font\-size\fR \fIsize\fR
+Application font size.
+.TP
+\fB\-\-style\fR \fIname\fR
+Qt style. Recommended: Fusion. \fB\-\-help\fR lists the styles this installation provides.
+.SH ARGUMENTS
+.TP
+.I files
+Files for future use.
 .SH SEE ALSO
 <https://github.com/Maproom/qmapshack/wiki/DocMain>.
 .SH AUTHOR

--- a/qmaptool.1
+++ b/qmaptool.1
@@ -4,11 +4,11 @@ QMapTool - Creating Raster Maps
 .br
 
 .SH "SYNOPSIS"
-\fBqmaptool\fR\fB [ -d \fR| \fB--debug \fR] [ \fB-h \fR| \fB--help \fR] [ \fB-n \fR| \fB--no-splash \fR]
+\fBqmaptool\fR [\fIoptions\fR]
 .br
 
 .SH "DESCRIPTION"
-A tool to process and referecne scanned paper maps
+A tool to process and reference scanned paper maps
 .br
 
 Main features:
@@ -21,21 +21,39 @@ Main features:
 .br
 
 .SH "OPTIONS"
-\fB-d\fR, \fB--debug\fR
-.br
-       Run with debugging output.
-.br
-
-\fB-h\fR, \fB--help\fR
-.br
-       Displays the help message.
-.br
-
-\fB-n, --no-splash\fR
-.br
-       Start without splash screen.
-.br
-
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Displays help on commandline options.
+.TP
+\fB\-\-help\-all\fR
+Displays help, including generic Qt options.
+.TP
+\fB\-v\fR, \fB\-\-version\fR
+Displays version information.
+.TP
+\fB\-n\fR, \fB\-\-no\-splash\fR
+Do not show splash screen.
+.TP
+\fB\-d\fR, \fB\-\-debug\fR
+Print debug output to console.
+.TP
+\fB\-f\fR, \fB\-\-logfile\fR
+Print debug output to logfile.
+.TP
+\fB\-c\fR, \fB\-\-config\fR \fIfile\fR
+File with QMapTool configuration.
+.TP
+\fB\-l\fR, \fB\-\-locale\fR \fIcode\fR
+Application locale.
+.TP
+\fB\-\-font\-family\fR \fIname\fR
+Application font family.
+.TP
+\fB\-\-font\-size\fR \fIsize\fR
+Application font size.
+.TP
+\fB\-\-style\fR \fIname\fR
+Qt style. Recommended: Fusion. \fB\-\-help\fR lists the styles this installation provides.
 .SH "SEE ALSO"
 https://github.com/Maproom/qmapshack/wiki/DocMain
 .br


### PR DESCRIPTION
<!---
Note:

- Lines starting with ### are section headers. Do not delete any of the sections.

- Lines starting with the label  [comment]: are instructions on how to fill in the section and will not be shown. Just add your answer below.

-->

### What is the linked issue for this pull request:
[comment]: # (Add the ticket number behind QMS-# )

QMS-#1244

### What you have done:
[comment]: # (Describe roughly.)

Both pages listed --debug, --help and --no-splash. They carry all eleven options now, with the descriptions QCommandLineParser prints, checked option by option against `--help` of both binaries. --help-all is the eleventh: Qt adds it next to --help and --version, which the pages did not mention either.

qmapshack.1 loses the broken \options\fP escape in the SYNOPSIS and the stray .TP before SEE ALSO. The synopsis names [options] instead of enumerating three of them, and the positional files argument moves into an ARGUMENTS section.

qmaptool.1 takes .TP for its option list, like qmapshack.1, instead of hand-indented .br lines. Its synopsis has no files argument because addPositionalArgument() is commented out in its CCommandProcessor.

The style option's available list is not copied into the pages - QStyleFactory fills it at runtime, so it belongs to the installation, and the pages point at --help for it.


### Steps to perform a simple smoke test:
[comment]: # (List the steps.)

see ticket

### Does the code comply to the coding rules and naming conventions [Coding Guideline](https://github.com/Maproom/qmapshack/blob/dev/README_CODING.md):

- [x] yes

### Is every user facing string in a tr() macro?

- [x] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [x] yes, I didn't forget to change changelog.txt
